### PR TITLE
refactor: add creator existence helper for shared checks

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -72,6 +72,16 @@ pub struct CreatorProfile {
 #[contract]
 pub struct CreatorKeysContract;
 
+impl CreatorKeysContract {
+    fn require_creator(env: &Env, creator: &Address) -> CreatorProfile {
+        let key = DataKey::Creator(creator.clone());
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic!("creator not registered"))
+    }
+}
+
 #[contractimpl]
 impl CreatorKeysContract {
     pub fn register_creator(env: Env, creator: Address, handle: String) {
@@ -101,11 +111,7 @@ impl CreatorKeysContract {
         }
 
         let key = DataKey::Creator(creator.clone());
-        let mut profile: CreatorProfile = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or_else(|| panic!("creator not registered"));
+        let mut profile = Self::require_creator(&env, &creator);
 
         profile.supply += 1;
         env.storage().persistent().set(&key, &profile);


### PR DESCRIPTION
## Summary
Closes #14

- Extracted a private `require_creator(env: &Env, creator: &Address) -> CreatorProfile` helper into a dedicated `impl CreatorKeysContract` block
- `buy_key` now calls `Self::require_creator` instead of repeating the inline storage lookup + panic pattern
- Error message `"creator not registered"` is unchanged, keeping existing tests and caller behaviour intact

## Test plan
- [ ] `test_buy_key_unregistered_creator_panics` — still panics with expected message via helper
- [ ] `test_buy_key_insufficient_payment_panics` — unaffected by refactor
- [ ] `test_buy_key_sufficient_payment_succeeds` — continues to pass

All existing tests pass without modification.
