### PR TITLE
feat: add creator holder count support

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -138,6 +138,7 @@ pub struct CreatorProfile {
     pub creator: Address,
     pub handle: String,
     pub supply: u32,
+    pub holder_count: u32,
 }
 
 /// Reads a creator profile from storage, returning `None` for unregistered creators.
@@ -182,6 +183,7 @@ impl CreatorKeysContract {
             creator,
             handle,
             supply: 0,
+            holder_count: 0,
         };
 
         env.storage().persistent().set(&key, &profile);
@@ -215,6 +217,16 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile =
             read_creator_profile(&env, &creator).ok_or(ContractError::NotRegistered)?;
 
+        let balance_key = DataKey::KeyBalance(creator.clone(), buyer.clone());
+        let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+
+        if current_balance == 0 {
+            profile.holder_count = profile
+                .holder_count
+                .checked_add(1)
+                .ok_or(ContractError::Overflow)?;
+        }
+
         profile.supply = profile
             .supply
             .checked_add(1)
@@ -223,8 +235,6 @@ impl CreatorKeysContract {
         let key = DataKey::Creator(creator.clone());
         env.storage().persistent().set(&key, &profile);
 
-        let balance_key = DataKey::KeyBalance(creator.clone(), buyer.clone());
-        let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
         let new_balance = current_balance
             .checked_add(1)
             .ok_or(ContractError::Overflow)?;
@@ -310,6 +320,16 @@ impl CreatorKeysContract {
     /// invalid lookups. Delegates to the shared [`read_key_balance`] helper.
     pub fn get_total_key_supply(env: Env, creator: Address) -> u32 {
         read_key_balance(&env, &creator)
+    }
+
+    /// Read-only view: returns the number of unique holders for a creator.
+    ///
+    /// Returns `0` if the creator is not registered, avoiding panics for
+    /// invalid lookups. Uses the stored creator profile holder count.
+    pub fn get_creator_holder_count(env: Env, creator: Address) -> u32 {
+        read_creator_profile(&env, &creator)
+            .map(|profile| profile.holder_count)
+            .unwrap_or(0)
     }
 
     /// Read-only view: returns whether a creator is registered in the contract.

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -73,6 +73,35 @@ fn test_buy_key_success() {
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 1);
+    assert_eq!(profile.holder_count, 1);
+}
+
+#[test]
+fn test_get_creator_holder_count_counts_unique_holders() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_key_price(&admin, &100);
+
+    let creator = Address::generate(&env);
+    let handle = String::from_str(&env, "alice");
+    client.register_creator(&creator, &handle);
+
+    let holder_one = Address::generate(&env);
+    let holder_two = Address::generate(&env);
+
+    client.buy_key(&creator, &holder_one, &100);
+    client.buy_key(&creator, &holder_one, &100);
+    client.buy_key(&creator, &holder_two, &100);
+
+    let first_read = client.get_creator_holder_count(&creator);
+    let second_read = client.get_creator_holder_count(&creator);
+
+    assert_eq!(first_read, 2);
+    assert_eq!(second_read, 2);
 }
 
 #[test]


### PR DESCRIPTION
Closes #60 
## Summary

* Added `holder_count: u32` to creator state
* Incremented `holder_count` only on first purchase per holder (balance transition `0 → 1`)
* Added read-only method `get_creator_holder_count` to return total unique holders for a creator
* Added tests to verify correct holder count and read-only behavior

## Testing

* [x] `cargo fmt --all -- --check`
* [x] `cargo clippy --workspace --all-targets -- -D warnings`
* [x] `cargo test --workspace`

## Checklist

* [x] Linked issue or backlog item (#60)
* [x] Contract behavior and invariants are described clearly
* [ ] Docs updated if contract interfaces or workflows changed (not required)
* [x] Scope stays limited to one contract concern
