### PR TITLE
feat(creator-keys): emit richer registration events

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -4,10 +4,27 @@
 //! the contract, reducing string duplication and ensuring consistency across
 //! event emission paths.
 
-use soroban_sdk::{symbol_short, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, String, Symbol};
 
 /// Event name for creator registration.
 pub const REGISTER_EVENT_NAME: Symbol = symbol_short!("register");
 
 /// Event name for key purchase.
 pub const BUY_EVENT_NAME: Symbol = symbol_short!("buy");
+
+/// Stable registration event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(REGISTER_EVENT_NAME, creator)`
+/// - data: `CreatorRegisteredEvent`
+///
+/// This keeps the creator address indexed in event topics while preserving
+/// a predictable payload for off-chain consumers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CreatorRegisteredEvent {
+    pub creator: Address,
+    pub handle: String,
+    pub supply: u32,
+    pub holder_count: u32,
+}

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -223,7 +223,15 @@ impl CreatorKeysContract {
         };
 
         env.storage().persistent().set(&key, &profile);
-        env.events().publish((events::REGISTER_EVENT_NAME,), key);
+        env.events().publish(
+            (events::REGISTER_EVENT_NAME, profile.creator.clone()),
+            events::CreatorRegisteredEvent {
+                creator: profile.creator.clone(),
+                handle: profile.handle.clone(),
+                supply: profile.supply,
+                holder_count: profile.holder_count,
+            },
+        );
 
         Ok(())
     }

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -1,4 +1,4 @@
-//! Tests for registration and buy event payloads (#22).
+//! Tests for registration and buy event payloads.
 
 use creator_keys::{events, CreatorKeysContract, CreatorKeysContractClient};
 use soroban_sdk::{
@@ -33,9 +33,32 @@ fn test_register_creator_emits_event() {
     let last = events.last().unwrap();
     let (_, topics, _data) = last;
 
-    // First topic should be the "register" symbol
     let topic: soroban_sdk::Symbol = topics.get(0).unwrap().into_val(&env);
     assert_eq!(topic, events::REGISTER_EVENT_NAME);
+
+    let event_creator: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(event_creator, creator);
+}
+
+#[test]
+fn test_register_creator_event_data_is_indexer_friendly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let handle = String::from_str(&env, "alice");
+
+    client.register_creator(&creator, &handle);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let payload: events::CreatorRegisteredEvent = last.2.into_val(&env);
+
+    assert_eq!(payload.creator, creator);
+    assert_eq!(payload.handle, handle);
+    assert_eq!(payload.supply, 0);
+    assert_eq!(payload.holder_count, 0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #2

## Changes
- expand the creator registration event into a stable typed payload for downstream indexing
- include the creator address as an indexed event topic
- expose `creator`, `handle`, `supply`, and `holder_count` in the registration event data
- document the registration event structure in code comments
- update event tests to verify the richer payload and indexed creator topic

## Testing
- cargo fmt --all -- --check
- CI will run:
  - cargo clippy --workspace --all-targets -- -D warnings
  - cargo test --workspace

## Notes
- this PR focuses only on improving registration event structure for indexers
- buy and sell event enrichment can continue in follow-up issues
