### PR TITLE
Add creator config read accessors and shared constants

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -82,6 +82,29 @@ pub mod fee {
     }
 }
 
+pub mod constants {
+    use super::DataKey;
+
+    pub mod storage {
+        use super::DataKey;
+
+        pub const FEE_CONFIG: DataKey = DataKey::FeeConfig;
+        pub const KEY_PRICE: DataKey = DataKey::KeyPrice;
+        pub const TREASURY_ADDRESS: DataKey = DataKey::TreasuryAddress;
+    }
+
+    pub mod creator_reads {
+        pub const DETAILS: &str = "get_creator_details";
+        pub const FEE_BPS: &str = "get_creator_fee_bps";
+        pub const FEE_CONFIG: &str = "get_creator_fee_config";
+        pub const FEE_RECIPIENT: &str = "get_creator_fee_recipient";
+        pub const HOLDER_KEY_COUNT: &str = "get_holder_key_count";
+        pub const PROFILE: &str = "get_creator";
+        pub const SUPPLY: &str = "get_creator_supply";
+        pub const TREASURY_SHARE: &str = "get_creator_treasury_share";
+    }
+}
+
 /// Stable, non-optional view of the protocol fee configuration.
 ///
 /// Returned by [`CreatorKeysContract::get_protocol_fee_view`] for indexer-friendly consumption.
@@ -206,6 +229,16 @@ pub fn read_key_balance(env: &Env, creator: &Address) -> u32 {
         .unwrap_or(0)
 }
 
+fn read_protocol_fee_config(env: &Env) -> Option<fee::FeeConfig> {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::FEE_CONFIG)
+}
+
+fn read_required_protocol_fee_config(env: &Env) -> Result<fee::FeeConfig, ContractError> {
+    read_protocol_fee_config(env).ok_or(ContractError::FeeConfigNotSet)
+}
+
 /// Formats a quote response with overflow-safe total amount calculation.
 ///
 /// Returns `Err(ContractError::Overflow)` if any addition or subtraction would overflow.
@@ -287,7 +320,7 @@ impl CreatorKeysContract {
         let price: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey::KeyPrice)
+            .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         if payment < price {
@@ -469,6 +502,25 @@ impl CreatorKeysContract {
         Ok(profile.fee_recipient)
     }
 
+    /// Read-only view: returns the configured creator fee rate in basis points.
+    ///
+    /// The returned value is the creator-facing share stored in the current protocol
+    /// fee configuration, scoped to a registered creator lookup.
+    pub fn get_creator_fee_bps(env: Env, creator: Address) -> Result<u32, ContractError> {
+        let _profile = read_registered_creator_profile(&env, &creator)?;
+        let config = read_required_protocol_fee_config(&env)?;
+        Ok(config.creator_bps)
+    }
+
+    /// Read-only view: returns the creator treasury share for a registered creator.
+    ///
+    /// Access Layer currently stores creator treasury share as the creator-facing
+    /// basis-point share in protocol fee configuration. This method provides a
+    /// creator-scoped accessor without mutating state.
+    pub fn get_creator_treasury_share(env: Env, creator: Address) -> Result<u32, ContractError> {
+        Self::get_creator_fee_bps(env, creator)
+    }
+
     pub fn set_fee_config(
         env: Env,
         admin: Address,
@@ -484,7 +536,9 @@ impl CreatorKeysContract {
             creator_bps,
             protocol_bps,
         };
-        env.storage().persistent().set(&DataKey::FeeConfig, &config);
+        env.storage()
+            .persistent()
+            .set(&constants::storage::FEE_CONFIG, &config);
         Ok(())
     }
 
@@ -493,12 +547,14 @@ impl CreatorKeysContract {
         if price <= 0 {
             return Err(ContractError::NotPositiveAmount);
         }
-        env.storage().persistent().set(&DataKey::KeyPrice, &price);
+        env.storage()
+            .persistent()
+            .set(&constants::storage::KEY_PRICE, &price);
         Ok(())
     }
 
     pub fn get_fee_config(env: Env) -> Option<fee::FeeConfig> {
-        env.storage().persistent().get(&DataKey::FeeConfig)
+        read_protocol_fee_config(&env)
     }
 
     /// Sets the protocol treasury address.
@@ -509,7 +565,7 @@ impl CreatorKeysContract {
         admin.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::TreasuryAddress, &treasury);
+            .set(&constants::storage::TREASURY_ADDRESS, &treasury);
     }
 
     /// Read-only view: returns the current protocol treasury address.
@@ -518,7 +574,9 @@ impl CreatorKeysContract {
     /// Use this method for indexers and read-only callers that need the current
     /// treasury routing target.
     pub fn get_treasury_address(env: Env) -> Option<Address> {
-        env.storage().persistent().get(&DataKey::TreasuryAddress)
+        env.storage()
+            .persistent()
+            .get(&constants::storage::TREASURY_ADDRESS)
     }
 
     /// Read-only view: returns the current protocol fee configuration.
@@ -530,7 +588,7 @@ impl CreatorKeysContract {
         match env
             .storage()
             .persistent()
-            .get::<DataKey, fee::FeeConfig>(&DataKey::FeeConfig)
+            .get::<DataKey, fee::FeeConfig>(&constants::storage::FEE_CONFIG)
         {
             Some(config) => ProtocolFeeView {
                 creator_bps: config.creator_bps,
@@ -546,11 +604,7 @@ impl CreatorKeysContract {
     }
 
     pub fn compute_fees_for_payment(env: Env, total: i128) -> Result<(i128, i128), ContractError> {
-        let config: fee::FeeConfig = env
-            .storage()
-            .persistent()
-            .get(&DataKey::FeeConfig)
-            .ok_or(ContractError::FeeConfigNotSet)?;
+        let config = read_required_protocol_fee_config(&env)?;
         fee::checked_compute_fee_split(total, config.creator_bps, config.protocol_bps)
             .ok_or(ContractError::Overflow)
     }
@@ -577,7 +631,7 @@ impl CreatorKeysContract {
         match env
             .storage()
             .persistent()
-            .get::<DataKey, fee::FeeConfig>(&DataKey::FeeConfig)
+            .get::<DataKey, fee::FeeConfig>(&constants::storage::FEE_CONFIG)
         {
             Some(config) => CreatorFeeView {
                 creator_bps: config.creator_bps,
@@ -602,7 +656,7 @@ impl CreatorKeysContract {
         let price: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey::KeyPrice)
+            .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         if read_creator_profile(&env, &creator).is_none() {
@@ -627,7 +681,7 @@ impl CreatorKeysContract {
         let price: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey::KeyPrice)
+            .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         if read_creator_profile(&env, &creator).is_none() {

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -1,0 +1,39 @@
+//! Tests for the `get_creator_fee_bps` read-only method.
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_get_creator_fee_bps_returns_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    assert_eq!(client.get_creator_fee_bps(&creator), 9000);
+}
+
+#[test]
+fn test_get_creator_fee_bps_is_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    client.set_fee_config(&admin, &7500u32, &2500u32);
+
+    let first = client.get_creator_fee_bps(&creator);
+    let second = client.get_creator_fee_bps(&creator);
+
+    assert_eq!(first, second);
+}

--- a/creator-keys/tests/creator_read_method_names.rs
+++ b/creator-keys/tests/creator_read_method_names.rs
@@ -1,0 +1,15 @@
+//! Behavior-neutral tests for shared creator read method names.
+
+use creator_keys::constants::creator_reads;
+
+#[test]
+fn test_creator_read_method_names_are_stable() {
+    assert_eq!(creator_reads::PROFILE, "get_creator");
+    assert_eq!(creator_reads::DETAILS, "get_creator_details");
+    assert_eq!(creator_reads::SUPPLY, "get_creator_supply");
+    assert_eq!(creator_reads::FEE_RECIPIENT, "get_creator_fee_recipient");
+    assert_eq!(creator_reads::FEE_CONFIG, "get_creator_fee_config");
+    assert_eq!(creator_reads::FEE_BPS, "get_creator_fee_bps");
+    assert_eq!(creator_reads::TREASURY_SHARE, "get_creator_treasury_share");
+    assert_eq!(creator_reads::HOLDER_KEY_COUNT, "get_holder_key_count");
+}

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -1,0 +1,39 @@
+//! Tests for the `get_creator_treasury_share` read-only method.
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_get_creator_treasury_share_returns_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    assert_eq!(client.get_creator_treasury_share(&creator), 9000);
+}
+
+#[test]
+fn test_get_creator_treasury_share_is_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    client.set_fee_config(&admin, &8000u32, &2000u32);
+
+    let first = client.get_creator_treasury_share(&creator);
+    let second = client.get_creator_treasury_share(&creator);
+
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
This PR resolves four related contract maintenance issues around creator configuration reads and internal consistency.

The main contract change is the addition of two new read-only creator-scoped accessors:
- get_creator_fee_bps, which returns the configured creator fee rate in basis points for a registered creator
- get_creator_treasury_share, which returns the creator treasury share for a registered creator

In the current contract design, creator-facing share data comes from the stored protocol fee configuration rather than a separate creator-specific treasury-share field. To stay behavior-neutral and avoid introducing a storage migration, both new methods read from the existing stored fee configuration after validating that the creator is registered. This keeps the contract aligned with the current data model while satisfying the new read-only access requirements.

This PR also extracts protocol configuration storage keys into a dedicated shared constants location. Reads and writes for:
- fee configuration
- key price
- treasury address
now reuse those constants directly instead of repeating raw DataKey variants inline. The goal here is consistency and lower maintenance cost without changing runtime behavior.

For creator read method naming consistency, this PR introduces a small shared constant set for creator read method names. The constants are intentionally narrow in scope and document the canonical names used by the contract surface for creator-facing read endpoints. This is a behavior-neutral cleanup intended to reduce naming drift in future changes.

## What Changed
- added constants::storage for shared protocol config storage keys
- added constants::creator_reads for shared creator read method names
- added ead_protocol_fee_config and ead_required_protocol_fee_config helpers to centralize protocol fee-config reads
- added get_creator_fee_bps(env, creator)
- added get_creator_treasury_share(env, creator)
- updated existing storage reads/writes to reuse shared storage key constants where appropriate
- added focused integration tests for the new read-only methods
- added a behavior-neutral test to lock the shared creator read method names

## Behavior Notes
- no existing buy, sell, fee, treasury, or creator registration behavior was changed
- no storage layout changes were introduced
- no new authorization requirements were added
- the new methods are read-only and do not mutate contract state
- get_creator_treasury_share currently returns the same creator-facing basis-point value as get_creator_fee_bps, because that is the stored creator share available in the current contract model

## Testing
Ran:
- cargo test --workspace

Coverage added in this PR includes:
- successful read path for get_creator_fee_bps
- read-only stability for get_creator_fee_bps
- successful read path for get_creator_treasury_share
- read-only stability for get_creator_treasury_share
- stability test for shared creator read method naming constants

## Issues
- Closes #69
- Closes #74
- Closes #76
- Closes #82