### PR TITLE
Add helper tests for creator fee config reads

### DIFF
--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -53,6 +53,42 @@ fn test_get_fee_config_returns_stored_protocol_config() {
 }
 
 #[test]
+fn test_read_protocol_fee_config_returns_stored_config() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let config = fee::FeeConfig {
+        creator_bps: 8200,
+        protocol_bps: 1800,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::FeeConfig, &config);
+        read_protocol_fee_config(&env).unwrap()
+    });
+
+    assert_eq!(stored.creator_bps, 8200);
+    assert_eq!(stored.protocol_bps, 1800);
+}
+
+#[test]
+fn test_read_required_protocol_fee_config_returns_stored_config() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let config = fee::FeeConfig {
+        creator_bps: 7600,
+        protocol_bps: 2400,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::FeeConfig, &config);
+        read_required_protocol_fee_config(&env).unwrap()
+    });
+
+    assert_eq!(stored.creator_bps, 7600);
+    assert_eq!(stored.protocol_bps, 2400);
+}
+
+#[test]
 fn test_get_fee_config_reads_protocol_fee_bps() {
     let env = Env::default();
     let contract_id = env.register(CreatorKeysContract, ());


### PR DESCRIPTION
This pull request adds additional unit tests to improve coverage for reading fee configuration from storage in the `creator-keys` contract. The new tests ensure that the `read_protocol_fee_config` and `read_required_protocol_fee_config` functions correctly return the stored configuration values.

**Test coverage improvements:**

* Added `test_read_protocol_fee_config_returns_stored_config` to verify that `read_protocol_fee_config` retrieves the correct stored fee configuration from persistent storage.
* Added `test_read_required_protocol_fee_config_returns_stored_config` to verify that `read_required_protocol_fee_config` retrieves the correct stored fee configuration from persistent storage.
Closes #89 