### PR TITLE
Add protocol config initialized view

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -600,6 +600,14 @@ impl CreatorKeysContract {
         env.storage().persistent().get(&DataKey::AdminAddress)
     }
 
+    /// Read-only view: returns whether protocol configuration has been initialized.
+    ///
+    /// Returns `true` once a protocol fee configuration has been stored and `false`
+    /// otherwise. Does not mutate contract state.
+    pub fn is_protocol_config_initialized(env: Env) -> bool {
+        read_protocol_fee_config(&env).is_some()
+    }
+
     /// Read-only view: returns the current protocol fee configuration.
     ///
     /// Returns a stable [`ProtocolFeeView`] regardless of whether a fee config has been set.

--- a/creator-keys/tests/protocol_config_initialized.rs
+++ b/creator-keys/tests/protocol_config_initialized.rs
@@ -1,0 +1,36 @@
+//! Tests for the is_protocol_config_initialized read-only method.
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Env};
+
+#[test]
+fn test_is_protocol_config_initialized_returns_true_after_fee_config_is_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    assert!(client.is_protocol_config_initialized());
+}
+
+#[test]
+fn test_is_protocol_config_initialized_is_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+
+    client.set_fee_config(&admin, &8000u32, &2000u32);
+
+    let first_read = client.is_protocol_config_initialized();
+    let second_read = client.is_protocol_config_initialized();
+
+    assert_eq!(first_read, second_read);
+    assert!(first_read);
+}


### PR DESCRIPTION
This pull request introduces a new read-only method to the `CreatorKeysContract` for checking whether the protocol fee configuration has been initialized, along with comprehensive tests to ensure its correctness and read-only behavior.

**New feature: Protocol configuration initialization check**

* Added a public read-only method `is_protocol_config_initialized` to `CreatorKeysContract`, which returns `true` if a protocol fee configuration has been set and `false` otherwise.

**Testing improvements**

* Added `protocol_config_initialized.rs` test file to verify that `is_protocol_config_initialized` returns `true` after setting the fee config and that the method is read-only (does not mutate state).

Closes #90 