### PR TITLE
Doc: add storage layout notes for creator metadata versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ For testnet deployment steps, required CLI setup, and the release checklist used
 
 ## Contract contribution rules
 
-- Document storage and event changes clearly.
+- Document storage and event changes clearly. See [docs/storage-evolution.md](./docs/storage-evolution.md) for metadata versioning rules.
 - Treat buy, sell, fee, and supply logic as high-sensitivity areas.
 - Prefer incremental contract changes over sweeping redesigns.
 - Add or update tests for every behavior change.

--- a/creator-keys/tests/fee_conservation.rs
+++ b/creator-keys/tests/fee_conservation.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{testutils::Address as _, Env, String};
 fn setup_test(
     env: &Env,
 ) -> (
-    CreatorKeysContractClient,
+    CreatorKeysContractClient<'_>,
     soroban_sdk::Address,
     soroban_sdk::Address,
 ) {
@@ -26,7 +26,7 @@ fn setup_test(
 #[test]
 fn test_fee_conservation_across_price_range() {
     let env = Env::default();
-    let (client, admin, creator) = setup_test(&env);
+    let (client, admin, _creator) = setup_test(&env);
 
     // Test across various price points
     let prices = [1, 7, 99, 100, 1000, 12345, 100000, 1234567];
@@ -92,7 +92,7 @@ fn test_quote_total_conservation() {
 #[test]
 fn test_low_value_trade_dust_handling() {
     let env = Env::default();
-    let (client, admin, creator) = setup_test(&env);
+    let (client, admin, _creator) = setup_test(&env);
 
     // Price of 1 is the absolute minimum positive price
     let price = 1;
@@ -119,7 +119,7 @@ fn test_low_value_trade_dust_handling() {
 #[test]
 fn test_fee_split_bps_edge_cases() {
     let env = Env::default();
-    let (client, admin, creator) = setup_test(&env);
+    let (client, admin, _creator) = setup_test(&env);
 
     let price = 1000;
     client.set_key_price(&admin, &price);

--- a/creator-keys/tests/fee_conservation.rs
+++ b/creator-keys/tests/fee_conservation.rs
@@ -4,7 +4,13 @@
 use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
 use soroban_sdk::{testutils::Address as _, Env, String};
 
-fn setup_test(env: &Env) -> (CreatorKeysContractClient, soroban_sdk::Address, soroban_sdk::Address) {
+fn setup_test(
+    env: &Env,
+) -> (
+    CreatorKeysContractClient,
+    soroban_sdk::Address,
+    soroban_sdk::Address,
+) {
     env.mock_all_auths();
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(env, &contract_id);

--- a/creator-keys/tests/fee_conservation.rs
+++ b/creator-keys/tests/fee_conservation.rs
@@ -1,0 +1,134 @@
+//! Tests specifically verifying that fee accounting conserves value
+//! across protocol and creator fee paths.
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Env, String};
+
+fn setup_test(env: &Env) -> (CreatorKeysContractClient, soroban_sdk::Address, soroban_sdk::Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(env);
+    let creator = soroban_sdk::Address::generate(env);
+    let handle = String::from_str(env, "alice");
+    client.register_creator(&creator, &handle);
+
+    (client, admin, creator)
+}
+
+#[test]
+fn test_fee_conservation_across_price_range() {
+    let env = Env::default();
+    let (client, admin, creator) = setup_test(&env);
+
+    // Test across various price points
+    let prices = [1, 7, 99, 100, 1000, 12345, 100000, 1234567];
+    // Test across various fee configurations (summing to 10000 BPS)
+    let fee_configs = [
+        (9000, 1000), // 90% creator, 10% protocol
+        (5000, 5000), // 50/50
+        (8000, 2000), // 80/20
+        (9900, 100),  // 99/1
+    ];
+
+    for price in prices {
+        for (creator_bps, protocol_bps) in fee_configs {
+            client.set_key_price(&admin, &price);
+            client.set_fee_config(&admin, &creator_bps, &protocol_bps);
+
+            let (creator_fee, protocol_fee) = client.compute_fees_for_payment(&price);
+
+            // ASSERTION: creator_fee + protocol_fee must EXACTLY equal the price
+            // because compute_fees_for_payment takes 'total' and splits it.
+            // In the contract, quotes use 'price' as the 'total' for fee calculation.
+            assert_eq!(
+                creator_fee + protocol_fee,
+                price,
+                "Value lost/created in split for price={}, bps=({}/{})",
+                price,
+                creator_bps,
+                protocol_bps
+            );
+        }
+    }
+}
+
+#[test]
+fn test_quote_total_conservation() {
+    let env = Env::default();
+    let (client, admin, creator) = setup_test(&env);
+
+    let price = 1000;
+    client.set_key_price(&admin, &price);
+    client.set_fee_config(&admin, &9000, &1000);
+
+    // Buy Quote
+    let buy_quote = client.get_buy_quote(&creator);
+    assert_eq!(
+        buy_quote.total_amount,
+        buy_quote.price + buy_quote.creator_fee + buy_quote.protocol_fee,
+        "Buy quote total amount does not conserve value"
+    );
+
+    // Sell Quote
+    let holder = soroban_sdk::Address::generate(&env);
+    client.buy_key(&creator, &holder, &2000); // 1000 price + 1000 fees
+
+    let sell_quote = client.get_sell_quote(&creator, &holder);
+    assert_eq!(
+        sell_quote.total_amount,
+        sell_quote.price - (sell_quote.creator_fee + sell_quote.protocol_fee),
+        "Sell quote total amount does not conserve value"
+    );
+}
+
+#[test]
+fn test_low_value_trade_dust_handling() {
+    let env = Env::default();
+    let (client, admin, creator) = setup_test(&env);
+
+    // Price of 1 is the absolute minimum positive price
+    let price = 1;
+    client.set_key_price(&admin, &price);
+    client.set_fee_config(&admin, &9000, &1000);
+
+    let (creator_fee, protocol_fee) = client.compute_fees_for_payment(&price);
+
+    // 1 * 1000 / 10000 = 0.1 -> 0 protocol fee
+    // Creator gets remainder: 1 - 0 = 1
+    assert_eq!(protocol_fee, 0);
+    assert_eq!(creator_fee, 1);
+    assert_eq!(creator_fee + protocol_fee, price);
+
+    // Price where protocol fee is exactly 1
+    let price = 10; // 10 * 1000 / 10000 = 1
+    client.set_key_price(&admin, &price);
+    let (creator_fee, protocol_fee) = client.compute_fees_for_payment(&price);
+    assert_eq!(protocol_fee, 1);
+    assert_eq!(creator_fee, 9);
+    assert_eq!(creator_fee + protocol_fee, price);
+}
+
+#[test]
+fn test_fee_split_bps_edge_cases() {
+    let env = Env::default();
+    let (client, admin, creator) = setup_test(&env);
+
+    let price = 1000;
+    client.set_key_price(&admin, &price);
+
+    // 100% Creator
+    client.set_fee_config(&admin, &10000, &0);
+    let (creator_fee, protocol_fee) = client.compute_fees_for_payment(&price);
+    assert_eq!(creator_fee, 1000);
+    assert_eq!(protocol_fee, 0);
+    assert_eq!(creator_fee + protocol_fee, price);
+
+    // 50% Protocol (Max allowed by contract)
+    client.set_fee_config(&admin, &5000, &5000);
+    let (creator_fee, protocol_fee) = client.compute_fees_for_payment(&price);
+    assert_eq!(creator_fee, 500);
+    assert_eq!(protocol_fee, 500);
+    assert_eq!(creator_fee + protocol_fee, price);
+}

--- a/docs/storage-evolution.md
+++ b/docs/storage-evolution.md
@@ -1,0 +1,61 @@
+# Creator Metadata Storage Evolution
+
+This document formalizes how creator metadata and contract state can evolve in Access Layer contracts without breaking existing reads, storage invariants, or downstream indexing.
+
+## Current Storage Layout
+
+The primary storage unit for creator metadata is the `CreatorProfile` struct, stored using the `DataKey::Creator(Address)` key in persistent storage.
+
+### `CreatorProfile` Struct (v1)
+```rust
+pub struct CreatorProfile {
+    pub creator: Address,      // Primary identity of the creator
+    pub handle: String,       // User-facing handle (e.g. "@alice")
+    pub supply: u32,          // Total supply of creator keys
+    pub holder_count: u32,    // Count of unique key holders
+    pub fee_recipient: Address, // Target for creator fee distributions
+}
+```
+
+## Evolution Strategy
+
+To maintain backward compatibility while allowing the metadata to grow, contributors must follow these rules:
+
+### 1. Additive Changes
+New fields must be added to the **end** of the `CreatorProfile` struct. 
+- Use `Option<T>` for new fields to ensure that existing records (which lack these fields) can still be deserialized correctly by the Soroban SDK.
+- The contract logic must handle the `None` case gracefully, typically by providing a sensible default or treating the field as "not yet set".
+
+### 2. View Stability
+Public views (structs returned by `get_` methods) are considered stable interfaces for indexers and clients.
+- **Never delete or rename fields** in view structs (e.g., `CreatorDetailsView`).
+- If a field becomes obsolete, keep it in the struct but document it as `@deprecated`.
+- Always provide a scalar default (e.g., `0`, `""`, or `false`) for new fields when reading older state to keep indexer behavior predictable.
+
+### 3. State Versioning
+The contract exposes a `PROTOCOL_STATE_VERSION` constant (currently `1`).
+- **Increment this value** whenever the semantics of the stored data change significantly, or when a breaking layout change is introduced.
+- Clients and indexers can use `get_protocol_state_version()` to detect when they need to update their internal mapping logic.
+
+## Compatibility Rules
+
+| Change Type | Compatibility | Strategy |
+|-------------|---------------|----------|
+| **Add Optional Field** | Backward | Append `Option<T>` to struct end. |
+| **Add Required Field** | Breaking | Requires state migration or incrementing `PROTOCOL_STATE_VERSION`. |
+| **Rename Field** | Breaking | Create new field; keep old field as deprecated if possible. |
+| **Change DataKey Type** | Breaking | Requires a dual-read strategy or full state migration. |
+
+## Migration Considerations
+
+When introducing changes that affect existing records:
+
+1. **Lazy Migration**: Prefer updating records only when they are next modified by a user action (e.g., during a `register_creator` update or a fee recipient change).
+2. **Schema Diffs**: PRs that change `contracttype` structs must include a clear description of the "Before" and "After" state.
+3. **Indexer Alignment**: Coordinate with the `accesslayer-server` team to ensure indexing logic is updated before the new contract version is deployed to mainnet.
+
+## Storage Keys and Invariants
+
+- **`DataKey::Creator(Address)`**: Unique per creator address. Must always map to a valid `CreatorProfile`.
+- **`DataKey::KeyBalance(Creator, Holder)`**: Stores the `u32` balance of keys. Must never be negative.
+- **`DataKey::FeeConfig`**: Global protocol setting. Affects all fee calculations contract-wide.


### PR DESCRIPTION
## Summary

This pr closes #143 

- Formalized creator metadata evolution by adding focused documentation on storage layout and versioning.
- Defined explicit compatibility rules for additive changes using `Option<T>` and the role of `PROTOCOL_STATE_VERSION`.
- Documented migration considerations and view stability expectations for contributors.
- Linked storage evolution rules in `CONTRIBUTING.md` to ensure visibility for new contributors.

## Testing

- [x] Documentation verified against current `lib.rs` storage keys and read paths.
- [x] Relative links between `CONTRIBUTING.md` and `docs/storage-evolution.md` verified.

## Checklist

- [x] Linked issue or backlog item (`contracts-registry-04`)
- [x] Contract behavior and invariants are described clearly
- [x] Docs updated if contract interfaces or workflows changed
- [x] Scope stays limited to one contract concern
