### PR TITLE
feat: add get_protocol_fee_bps read-only method

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -763,6 +763,16 @@ impl CreatorKeysContract {
         }
     }
 
+    /// Read-only view: returns the protocol fee basis points value.
+    ///
+    /// Returns the stored `protocol_bps` from the fee configuration.
+    /// Returns `0` if no fee config has been set. Does not mutate contract state.
+    pub fn get_protocol_fee_bps(env: Env) -> u32 {
+        read_protocol_fee_config(&env)
+            .map(|c| c.protocol_bps)
+            .unwrap_or(0)
+    }
+
     pub fn compute_fees_for_payment(env: Env, total: i128) -> Result<(i128, i128), ContractError> {
         let config = read_required_protocol_fee_config(&env)?;
         fee::checked_compute_fee_split(total, config.creator_bps, config.protocol_bps)

--- a/creator-keys/tests/protocol_fee_bps.rs
+++ b/creator-keys/tests/protocol_fee_bps.rs
@@ -1,0 +1,44 @@
+//! Tests for the `get_protocol_fee_bps` read-only method (#79).
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_get_protocol_fee_bps_returns_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    assert_eq!(client.get_protocol_fee_bps(), 1000);
+}
+
+#[test]
+fn test_get_protocol_fee_bps_returns_zero_when_unconfigured() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_protocol_fee_bps(), 0);
+}
+
+#[test]
+fn test_get_protocol_fee_bps_is_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.set_fee_config(&admin, &8000u32, &2000u32);
+
+    let first = client.get_protocol_fee_bps();
+    let second = client.get_protocol_fee_bps();
+
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary

Add a dedicated read-only method `get_protocol_fee_bps` that returns the stored protocol fee basis points value as a `u32`.

Closes #79

## Changes

- `creator-keys/src/lib.rs`: add `get_protocol_fee_bps` after `get_protocol_fee_view`; returns `protocol_bps` from stored fee config or `0` when unconfigured
- `creator-keys/tests/protocol_fee_bps.rs`: three tests covering configured value, unconfigured default (returns 0), and read-only invariant

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item
- [x] Contract behavior and invariants are described clearly
- [ ] Docs updated if contract interfaces or workflows changed
- [x] Scope stays limited to one contract concern