### PR TITLE
Add focused unit tests for protocol fee recipient read method

### DIFF
--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -89,6 +89,34 @@ fn test_read_required_protocol_fee_config_returns_stored_config() {
 }
 
 #[test]
+fn test_get_protocol_fee_recipient_returns_none_when_unset() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+
+    let recipient = env.as_contract(&contract_id, || {
+        CreatorKeysContract::get_protocol_fee_recipient(env.clone())
+    });
+
+    assert_eq!(recipient, None);
+}
+
+#[test]
+fn test_get_protocol_fee_recipient_returns_stored_address() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let expected = Address::generate(&env);
+
+    let recipient = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&constants::storage::PROTOCOL_FEE_RECIPIENT, &expected);
+        CreatorKeysContract::get_protocol_fee_recipient(env.clone())
+    });
+
+    assert_eq!(recipient, Some(expected));
+}
+
+#[test]
 fn test_get_fee_config_reads_protocol_fee_bps() {
     let env = Env::default();
     let contract_id = env.register(CreatorKeysContract, ());


### PR DESCRIPTION
closes #105
## Summary

- 

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Contract behavior and invariants are described clearly
- [ ] Docs updated if contract interfaces or workflows changed
- [ ] Scope stays limited to one contract concern
