### PR TITLE
feat: test helpers, deploy/consumer docs, sell quote rounding tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,15 +23,13 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Or use the helper targets:
+You can also use the helper targets from the `Makefile` at the repo root (`make fmt-check`, `make clippy`, `make test`).
 
-```bash
-make fmt-check
-make clippy
-make test
-```
+## Integration test helpers
 
-For testnet deployment steps, required CLI setup, and the release checklist used for contract updates, see [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md).
+Shared setup for `creator-keys` integration tests lives in `creator-keys/tests/contract_test_env/`. Import the module with `mod contract_test_env;` and call the small helpers (env with mocked auths, register contract, set key price, set fees, register a test creator) instead of duplicating boilerplate in every file.
+
+For testnet deployment steps, required CLI setup, and the release checklist used for contract updates, see [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). For **wasm artifact** naming, retention, and metadata, see [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For how **clients and servers** should depend on contract read surfaces and events, see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md).
 
 ## Contract contribution rules
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo test --workspace
 
 ## Testnet deployment
 
-For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md).
+For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). Store and name release wasm files using [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For client and server integration expectations (read methods, events, version bumps), see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md).
 
 ## Open source workflow
 

--- a/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 10000
+                },
+                {
+                  "u32": 0
                 }
               ]
             }
@@ -59,13 +62,36 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_creator",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "string": "c5"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "buy_key",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "i128": {
@@ -80,7 +106,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -103,7 +128,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +148,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +160,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +168,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +176,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c5"
                       }
                     },
                     {
@@ -186,13 +211,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 10000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +293,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +343,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 100
                   }
                 }
               }
@@ -340,6 +421,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +490,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +505,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
@@ -20,7 +20,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 10
                   }
                 }
               ]
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 5000
+                },
+                {
+                  "u32": 5000
                 }
               ]
             }
@@ -59,18 +62,41 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "buy_key",
+              "function_name": "register_creator",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
+                  "string": "c4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "buy_key",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 10
                   }
                 }
               ]
@@ -103,7 +129,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +149,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +161,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +169,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +177,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c4"
                       }
                     },
                     {
@@ -186,13 +212,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +294,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +344,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 10
                   }
                 }
               }
@@ -340,6 +422,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +491,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +506,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
@@ -20,7 +20,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 3
                   }
                 }
               ]
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 5000
+                },
+                {
+                  "u32": 5000
                 }
               ]
             }
@@ -59,19 +62,13 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "buy_key",
+              "function_name": "register_creator",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 100
-                  }
+                  "string": "c3"
                 }
               ]
             }
@@ -81,6 +78,34 @@
       ]
     ],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "buy_key",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 3
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -103,7 +128,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +148,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +160,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +168,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +176,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c3"
                       }
                     },
                     {
@@ -186,13 +211,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +293,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +343,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 3
                   }
                 }
               }
@@ -340,6 +421,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +490,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +505,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
@@ -20,7 +20,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 1
                   }
                 }
               ]
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 9000
+                },
+                {
+                  "u32": 1000
                 }
               ]
             }
@@ -59,18 +62,41 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "buy_key",
+              "function_name": "register_creator",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
+                  "string": "c2"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "buy_key",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 1
                   }
                 }
               ]
@@ -103,7 +129,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +149,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +161,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +169,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +177,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c2"
                       }
                     },
                     {
@@ -186,13 +212,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 9000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +294,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +344,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 1
                   }
                 }
               }
@@ -340,6 +422,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +491,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +506,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
@@ -20,7 +20,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 999
                   }
                 }
               ]
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 9000
+                },
+                {
+                  "u32": 1000
                 }
               ]
             }
@@ -59,19 +62,13 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "buy_key",
+              "function_name": "register_creator",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 100
-                  }
+                  "string": "c1"
                 }
               ]
             }
@@ -81,6 +78,34 @@
       ]
     ],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "buy_key",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 999
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -103,7 +128,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +148,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +160,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +168,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +176,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c1"
                       }
                     },
                     {
@@ -186,13 +211,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 9000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +293,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +343,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 999
                   }
                 }
               }
@@ -340,6 +421,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +490,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +505,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
+++ b/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
@@ -20,7 +20,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 1
                   }
                 }
               ]
@@ -32,18 +32,21 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_creator",
+              "function_name": "set_fee_config",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "alice"
+                  "u32": 5000
+                },
+                {
+                  "u32": 5000
                 }
               ]
             }
@@ -59,18 +62,41 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "buy_key",
+              "function_name": "register_creator",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
+                  "string": "c6"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "buy_key",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 1
                   }
                 }
               ]
@@ -103,7 +129,7 @@
                   "symbol": "Creator"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -123,7 +149,7 @@
                       "symbol": "Creator"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -135,7 +161,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -143,7 +169,7 @@
                         "symbol": "fee_recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -151,7 +177,7 @@
                         "symbol": "handle"
                       },
                       "val": {
-                        "string": "alice"
+                        "string": "c6"
                       }
                     },
                     {
@@ -186,13 +212,69 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 5000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "KeyBalance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -212,10 +294,10 @@
                       "symbol": "KeyBalance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -262,7 +344,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 0
+                    "lo": 1
                   }
                 }
               }
@@ -340,6 +422,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
@@ -376,7 +491,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 4837995959683129791
               }
             },
             "durability": "temporary"
@@ -391,7 +506,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/tests/buy_key.rs
+++ b/creator-keys/tests/buy_key.rs
@@ -1,54 +1,43 @@
 //! Tests for `buy_key` creator validation and payment checks.
 
-use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
-use soroban_sdk::{testutils::Address as _, Env, String};
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address};
 
 #[test]
 fn test_buy_key_unregistered_creator_fails() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
-    let admin = soroban_sdk::Address::generate(&env);
-    let creator = soroban_sdk::Address::generate(&env);
-    let buyer = soroban_sdk::Address::generate(&env);
-
-    client.set_key_price(&admin, &100i128);
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100i128);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &100i128);
     assert_eq!(result, Err(Ok(ContractError::NotRegistered)));
 }
 
 #[test]
 fn test_buy_key_insufficient_payment_fails() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
 
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
-    let admin = soroban_sdk::Address::generate(&env);
-    let creator = soroban_sdk::Address::generate(&env);
-    let buyer = soroban_sdk::Address::generate(&env);
-
-    client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"));
     let result = client.try_buy_key(&creator, &buyer, &99i128);
     assert_eq!(result, Err(Ok(ContractError::InsufficientPayment)));
 }
 
 #[test]
 fn test_buy_key_sufficient_payment_succeeds() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
-    let admin = soroban_sdk::Address::generate(&env);
-    let creator = soroban_sdk::Address::generate(&env);
-    let buyer = soroban_sdk::Address::generate(&env);
-
-    client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
 
     let supply = client.buy_key(&creator, &buyer, &100i128);
     assert_eq!(supply, 1);

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -1,0 +1,82 @@
+//! Shared setup helpers for `creator-keys` integration tests.
+//!
+//! Compose the small functions here instead of one monolithic setup so each test
+//! can opt in only to what it needs (pricing without fees, fees, registered creators, etc.).
+//!
+//! Not every integration-test binary uses every helper; this crate is compiled once per
+//! `tests/*.rs` target, so we allow dead code at module scope.
+#![allow(dead_code)]
+
+use creator_keys::{constants, CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+/// Default [`Env`] for tests: enables mocked authorization for authed entrypoints.
+pub fn test_env_with_auths() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+/// Register [`CreatorKeysContract`] and return a client and the contract id.
+pub fn register_creator_keys<'a>(env: &'a Env) -> (CreatorKeysContractClient<'a>, Address) {
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(env, &id);
+    (client, id)
+}
+
+/// Admin sets a positive key price. Returns the admin address used.
+pub fn set_key_price_for_tests(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    key_price: i128,
+) -> Address {
+    let admin = Address::generate(env);
+    client.set_key_price(&admin, &key_price);
+    admin
+}
+
+/// Set global fee split. Returns the admin address used.
+pub fn set_protocol_fee_bps(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    creator_bps: u32,
+    protocol_bps: u32,
+) -> Address {
+    let admin = Address::generate(env);
+    client.set_fee_config(&admin, &creator_bps, &protocol_bps);
+    admin
+}
+
+/// Set key price and fee config using the same admin (typical for quote and fee tests).
+pub fn set_pricing_and_fees(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    key_price: i128,
+    creator_bps: u32,
+    protocol_bps: u32,
+) -> Address {
+    let admin = Address::generate(env);
+    client.set_key_price(&admin, &key_price);
+    client.set_fee_config(&admin, &creator_bps, &protocol_bps);
+    admin
+}
+
+/// Register a new creator with the given display handle.
+pub fn register_test_creator(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    handle: &str,
+) -> Address {
+    let creator = Address::generate(env);
+    client.register_creator(&creator, &String::from_str(env, handle));
+    creator
+}
+
+/// Write the persistent key price directly (bypassing `set_key_price`), for state edge cases.
+pub fn set_stored_key_price(env: &Env, contract_id: &Address, price: i128) {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&constants::storage::KEY_PRICE, &price);
+    });
+}

--- a/creator-keys/tests/quote_zero_amount.rs
+++ b/creator-keys/tests/quote_zero_amount.rs
@@ -1,27 +1,18 @@
 //! Tests for zero-amount quote normalization in buy and sell quote paths.
 
-use creator_keys::{constants, CreatorKeysContract, CreatorKeysContractClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+mod contract_test_env;
 
-fn store_key_price(env: &Env, contract_id: &Address, price: i128) {
-    env.as_contract(contract_id, || {
-        env.storage()
-            .persistent()
-            .set(&constants::storage::KEY_PRICE, &price);
-    });
-}
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_stored_key_price, test_env_with_auths,
+};
+use soroban_sdk::{testutils::Address as _, Address};
 
 #[test]
 fn test_get_buy_quote_zero_amount_returns_noop_quote() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"));
-    store_key_price(&env, &contract_id, 0);
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    let creator = register_test_creator(&env, &client, "alice");
+    set_stored_key_price(&env, &contract_id, 0);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 0);
@@ -32,20 +23,15 @@ fn test_get_buy_quote_zero_amount_returns_noop_quote() {
 
 #[test]
 fn test_get_sell_quote_zero_amount_returns_noop_quote() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
-
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
     let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
     let holder = Address::generate(&env);
 
     client.set_key_price(&admin, &100);
-    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    let creator = register_test_creator(&env, &client, "alice");
     client.buy_key(&creator, &holder, &100);
-    store_key_price(&env, &contract_id, 0);
+    set_stored_key_price(&env, &contract_id, 0);
 
     let quote = client.get_sell_quote(&creator, &holder);
     assert_eq!(quote.price, 0);

--- a/creator-keys/tests/sell_key.rs
+++ b/creator-keys/tests/sell_key.rs
@@ -1,27 +1,24 @@
 //! Tests for the initial `sell_key` contract flow.
 
-use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+mod contract_test_env;
 
-fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(env, &contract_id);
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::{ContractError, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
-    let admin = Address::generate(env);
-    client.set_key_price(&admin, &100_i128);
-
-    let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, "alice"));
-
-    (client, admin, creator)
+fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address) {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, 100_i128);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, creator)
 }
 
 #[test]
 fn test_sell_key_decrements_supply_and_balance() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (client, _admin, creator) = setup(&env);
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
     let seller = Address::generate(&env);
 
     client.buy_key(&creator, &seller, &100_i128);
@@ -36,10 +33,8 @@ fn test_sell_key_decrements_supply_and_balance() {
 
 #[test]
 fn test_sell_key_removes_holder_when_last_key_is_sold() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (client, _admin, creator) = setup(&env);
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
     let seller = Address::generate(&env);
 
     client.buy_key(&creator, &seller, &100_i128);
@@ -55,10 +50,8 @@ fn test_sell_key_removes_holder_when_last_key_is_sold() {
 
 #[test]
 fn test_sell_key_preserves_holder_count_when_seller_still_has_keys() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (client, _admin, creator) = setup(&env);
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
     let seller = Address::generate(&env);
 
     client.buy_key(&creator, &seller, &100_i128);
@@ -74,11 +67,8 @@ fn test_sell_key_preserves_holder_count_when_seller_still_has_keys() {
 
 #[test]
 fn test_sell_key_fails_for_unregistered_creator() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(CreatorKeysContract, ());
-    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
 
     let creator = Address::generate(&env);
     let seller = Address::generate(&env);
@@ -89,10 +79,8 @@ fn test_sell_key_fails_for_unregistered_creator() {
 
 #[test]
 fn test_sell_key_fails_when_seller_has_no_keys() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (client, _admin, creator) = setup(&env);
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
     let seller = Address::generate(&env);
 
     let result = client.try_sell_key(&creator, &seller);

--- a/creator-keys/tests/sell_quote_rounding.rs
+++ b/creator-keys/tests/sell_quote_rounding.rs
@@ -1,0 +1,134 @@
+//! Deterministic tests for [`CreatorKeysContract::get_sell_quote`] fee and payout math.
+//!
+//! Sell quotes use the same fee floor as other payment paths: protocol share is
+//! `floor(price * protocol_bps / 10_000)`; the remainder goes to the creator;
+//! `total_amount` is `price - creator_fee - protocol_fee` (seller net).
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
+use creator_keys::fee;
+use creator_keys::CreatorKeysContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn register_holder_with_one_key(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    creator: &Address,
+) -> Address {
+    let holder = Address::generate(env);
+    let price = client.get_buy_quote(creator).price;
+    client.buy_key(creator, &holder, &price);
+    holder
+}
+
+fn assert_sell_quote(
+    client: &CreatorKeysContractClient<'_>,
+    creator: &Address,
+    holder: &Address,
+    key_price: i128,
+    creator_bps: u32,
+    protocol_bps: u32,
+) {
+    let (exp_creator, exp_protocol) =
+        fee::checked_compute_fee_split(key_price, creator_bps, protocol_bps)
+            .expect("fee split in range");
+    let exp_total = key_price
+        .checked_sub(exp_creator)
+        .and_then(|x| x.checked_sub(exp_protocol))
+        .expect("payout sub");
+
+    let q = client.get_sell_quote(creator, holder);
+    assert_eq!(q.price, key_price, "price");
+    assert_eq!(q.creator_fee, exp_creator, "creator_fee");
+    assert_eq!(q.protocol_fee, exp_protocol, "protocol_fee");
+    assert_eq!(q.total_amount, exp_total, "total_amount (net to seller)");
+    assert_eq!(
+        exp_creator + exp_protocol,
+        key_price
+            .checked_sub(exp_total)
+            .expect("fees from price - payout"),
+        "fees + payout = price"
+    );
+}
+
+#[test]
+fn sell_quote_90_10_remainder_favors_creator_on_indivisible_price() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let key_price = 999_i128;
+    set_pricing_and_fees(&env, &client, key_price, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "c1");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    // 999 * 1000 / 10000 = 99 protocol; creator gets 900; net = 0
+    assert_sell_quote(&client, &creator, &holder, key_price, 9000, 1000);
+}
+
+#[test]
+fn sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let key_price = 1_i128;
+    set_pricing_and_fees(&env, &client, key_price, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "c2");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    assert_sell_quote(&client, &creator, &holder, key_price, 9000, 1000);
+    let q = client.get_sell_quote(&creator, &holder);
+    assert_eq!(q.protocol_fee, 0);
+    assert_eq!(q.creator_fee, 1);
+    assert_eq!(q.total_amount, 0);
+}
+
+#[test]
+fn sell_quote_50_50_small_price_protocol_takes_first_floor_unit() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let key_price = 3_i128;
+    set_pricing_and_fees(&env, &client, key_price, 5000, 5000);
+    let creator = register_test_creator(&env, &client, "c3");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    // floor(3 * 5000 / 10000) = 1 protocol; creator = 2; net = 0
+    assert_sell_quote(&client, &creator, &holder, key_price, 5000, 5000);
+}
+
+#[test]
+fn sell_quote_50_50_price_ten_equal_split_zero_net() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let key_price = 10_i128;
+    set_pricing_and_fees(&env, &client, key_price, 5000, 5000);
+    let creator = register_test_creator(&env, &client, "c4");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    assert_sell_quote(&client, &creator, &holder, key_price, 5000, 5000);
+    let q = client.get_sell_quote(&creator, &holder);
+    assert_eq!((q.creator_fee, q.protocol_fee, q.total_amount), (5, 5, 0));
+}
+
+#[test]
+fn sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let key_price = 100_i128;
+    set_pricing_and_fees(&env, &client, key_price, 10000, 0);
+    let creator = register_test_creator(&env, &client, "c5");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    let q = client.get_sell_quote(&creator, &holder);
+    assert_eq!((q.creator_fee, q.protocol_fee, q.total_amount), (100, 0, 0));
+}
+
+#[test]
+fn sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    // 50% / 50% is the maximum protocol share allowed (`PROTOCOL_BPS_MAX` = 5000).
+    let key_price = 1_i128;
+    set_pricing_and_fees(&env, &client, key_price, 5000, 5000);
+    let creator = register_test_creator(&env, &client, "c6");
+    let holder = register_holder_with_one_key(&env, &client, &creator);
+    // floor(1 * 5000 / 10000) = 0 protocol; creator 1; net 0
+    assert_sell_quote(&client, &creator, &holder, key_price, 5000, 5000);
+    let q = client.get_sell_quote(&creator, &holder);
+    assert_eq!((q.creator_fee, q.protocol_fee, q.total_amount), (1, 0, 0));
+}

--- a/docs/contract-consumer-boundaries.md
+++ b/docs/contract-consumer-boundaries.md
@@ -1,0 +1,40 @@
+# Contract outputs: client, server, and compatibility
+
+Access Layer’s **Soroban** contracts are the on-chain source of truth for registration, key supply, pricing, and fee configuration. The **client** (wallet, web app) and **server** (API, indexers) consume specific **read surfaces** and **event payloads** from those contracts. This page lists the main dependencies and the compatibility expectations when those outputs change.
+
+For fee math and rounding, see [fee-assumptions.md](./fee-assumptions.md). For testnet build and deploy steps, see [stellar-testnet-deployment.md](./stellar-testnet-deployment.md). For static names of read-only entrypoints (useful to indexers and version checks), see the `constants::creator_reads` submodule in `creator-keys` source.
+
+## What clients and servers depend on
+
+### Versioning and schema detection
+
+- **`get_protocol_state_version`**: Intentionally bumps when *externally visible* protocol semantics or stable read shapes change. Clients and indexers can gate UI or parsing on this value.
+- **Wasm hash (deploy artifact)**: Off-chain systems that pin “which build is live” should track the **deployed wasm hash** and/or **contract id** in config (see [deploy-artifacts.md](./deploy-artifacts.md)).
+
+### Read-only state and “views”
+
+Stable structs returned by read-only methods are part of the integration contract:
+
+- **`ProtocolFeeView` / `get_protocol_fee_view`**: Non-optional fee configuration snapshot (`is_configured` plus bps). Used when you must not branch on `Option` at the type level.
+- **`CreatorDetailsView`**, **`CreatorFeeView`**, **`HolderKeyCountView`**: Registration and per-creator state without panicking on bad addresses.
+- **Quotes** — `get_buy_quote` / `get_sell_quote` → `QuoteResponse` (`price`, `creator_fee`, `protocol_fee`, `total_amount`). **Buy** uses `total_amount = price + fees`; **sell** uses `total_amount = price - fees` (seller payout after fees, under current logic).
+- **Constants exposed as entrypoints** — e.g. `get_key_decimals` — must stay aligned with any off-chain display or formatting.
+
+### Events
+
+State-changing entrypoints that emit events (for example `register_creator`, `buy_key`) are consumption boundaries for **indexers and analytics**: payload shape and event names are stable API for the server. Any change to event name, field order, or field meaning should be treated as a **breaking** change for indexers unless versioned (e.g. a new event name) or coordinated with consumers.
+
+## Compatibility expectations
+
+| Change | Expectation |
+|--------|-------------|
+| **Bugfix** that does not change storage layout, event schema, or read return shapes | New wasm deploy; `PROTOCOL_STATE_VERSION` may stay the same; consumers already compatible. |
+| **New optional read method** or **new field with defaulting behavior** in a versioned read path | Coordinate clients/indexers; prefer bumping `get_protocol_state_version` when the new surface is the recommended path. |
+| **Fee basis-point rules or `QuoteResponse` meaning** (e.g. what `total_amount` includes) | Treat as **breaking** for UIs and pricing previews: bump `PROTOCOL_STATE_VERSION`, document in [fee-assumptions.md](./fee-assumptions.md), and release in lockstep with client/server updates. |
+| **Storage or event format change** | Breaking for indexers and any client that decodes old events: explicit migration or backfill plan; never silent change. |
+
+## Out of scope for this repository
+
+**Application features** (email, social graphs, off-chain key custody UX) and **indexer business logic** live in their respective codebases. This repo documents only what the chain exposes. When in doubt, treat **contract method names, event names, and serialized struct fields** as the public API to other layers.
+
+Contributors can validate read surfaces against current tests with `cargo test -p creator-keys` and the workspace checks in [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/deploy-artifacts.md
+++ b/docs/deploy-artifacts.md
@@ -1,0 +1,46 @@
+# Deploy artifacts: storage, naming, and metadata
+
+This note complements [stellar-testnet-deployment.md](./stellar-testnet-deployment.md). The wasm produced by `stellar contract build` is the source of truth for what gets deployed, but the default build output under `target/` is **local, ephemeral, and not suitable as a long-term record** on its own.
+
+## Where to store release artifacts
+
+- **Do not** rely on a developer’s `target/` tree as the canonical copy: it is easy to rebuild from a different commit or toolchain and get a different hash.
+- **Do** copy the built wasm (and a small sidecar file with the metadata below) to a team-controlled, access-managed location appropriate to your org, for example:
+  - release assets on a VCS host (tagged release attachments)
+  - an object store with access policies (e.g. S3 with restricted IAM)
+  - a secured internal artifact registry
+- **Never** put signing keys, funded seed phrases, or unredacted private RPC URLs next to the wasm; keep secrets in a proper secret store.
+
+## Naming
+
+Use a predictable pattern so humans and scripts can find the right binary without opening it. Recommended components (include at least **network** and **git commit**; add **version** or **date** when releasing):
+
+- `creator_keys_<network>_<git_short_sha>.wasm` — ad-hoc or CI builds
+- `creator_keys_<semver>_<network>_<build_date_utc>.wasm` — tagged releases
+
+`network` examples: `testnet`, `mainnet-future` (or a Stellar network passphrase short id if you standardize one internally).
+
+## Minimum metadata to record
+
+Store alongside each wasm (JSON or a short `README` next to the file):
+
+| Field | Why it matters |
+|--------|----------------|
+| **Git commit** (full or short SHA) | Reproducible code review and diff |
+| **Repository** (URL or `org/repo` name) | Distinguish forks and mirrors |
+| **Soroban / SDK version** (from this repo’s [Cargo workspace](../Cargo.toml)) | Toolchain compatibility for auditors and re-builds |
+| **Rustc version** (from the build that produced the wasm) | Bit-identical rebuild attempts |
+| **`stellar contract build` invocation** (or `Makefile` target) | Proves which package and profile were used |
+| **Target triple** (e.g. `wasm32v1-none`) | Soroban standard |
+| **SHA-256 of the wasm file** | Integrity check; compare before deploy |
+| **Network** (e.g. testnet / future mainnet) | Prevents wrong-env deploys |
+| **Contract id** (after deploy) | Bind off-chain config and indexers to an on-chain instance |
+
+If you re-deploy the same built wasm, keep the same wasm hash and add a new row or note for the new contract id if the previous deployment is superseded.
+
+## Retention
+
+- **Testnet / review builds**: keep enough history for debugging (e.g. last N builds or last 30–90 days), then prune according to your org policy.
+- **Tagged or production releases**: retain at least the wasm and metadata for the life of that deployment; longer if required for compliance or user support.
+
+Contributors can validate a local build still matches the documented process using [stellar-testnet-deployment.md](./stellar-testnet-deployment.md) and `cargo test --workspace` in this repository.

--- a/docs/stellar-testnet-deployment.md
+++ b/docs/stellar-testnet-deployment.md
@@ -64,6 +64,8 @@ Expected artifact:
 target/wasm32v1-none/release/creator_keys.wasm
 ```
 
+This path is a **local build output** only. After you build, copy the wasm to team-controlled storage with a clear name and recorded metadata; see [deploy-artifacts.md](./deploy-artifacts.md).
+
 ## Deploy to Stellar testnet
 
 Deploy the built wasm and save a local alias for follow-up calls:


### PR DESCRIPTION
Closes #147 Closes #152 Closes #153 Closes #156
## Summary

- **#147** — Reusable `creator-keys` integration test setup in `tests/contract_test_env/`; refactors `buy_key`, `sell_key`, and `quote_zero_amount` to use shared helpers; documents usage in [CONTRIBUTING.md](CONTRIBUTING.md).
- **#152** — Deploy artifact naming, safe storage, metadata, and retention: [docs/deploy-artifacts.md](docs/deploy-artifacts.md); cross-links from [docs/stellar-testnet-deployment.md](docs/stellar-testnet-deployment.md), [README](README.md), and CONTRIBUTING.
- **#153** — Client/server expectations for contract reads, events, and `PROTOCOL_STATE_VERSION`: [docs/contract-consumer-boundaries.md](docs/contract-consumer-boundaries.md); linked from README/CONTRIBUTING.
- **#156** — Deterministic [sell quote rounding](creator-keys/tests/sell_quote_rounding.rs) tests (fee floor, small prices, 50/50, 100% creator, max protocol bps) with snapshots as applicable.

## How to verify

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace