### PR TITLE
feat: buy quote monotonicity tests, supply invariants, read-only docs, sell underflow error (#157 #165 #167 #174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo test --workspace
 
 ## Testnet deployment
 
-For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). Store and name release wasm files using [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For client and server integration expectations (read methods, events, version bumps), see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md).
+For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). Store and name release wasm files using [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For client and server integration expectations (read methods, events, version bumps), see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md). For detailed return value semantics of every read-only entrypoint (units, precision, edge-case outputs), see [docs/read-only-methods.md](./docs/read-only-methods.md).
 
 ## Open source workflow
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -18,6 +18,7 @@ pub enum ContractError {
     FeeConfigNotSet = 7,
     InvalidFeeConfig = 8,
     InsufficientBalance = 9,
+    SellUnderflow = 10,
 }
 
 pub mod fee {
@@ -471,17 +472,17 @@ impl CreatorKeysContract {
 
         let new_balance = current_balance
             .checked_sub(1)
-            .ok_or(ContractError::Overflow)?;
+            .ok_or(ContractError::SellUnderflow)?;
         profile.supply = profile
             .supply
             .checked_sub(1)
-            .ok_or(ContractError::Overflow)?;
+            .ok_or(ContractError::SellUnderflow)?;
 
         if new_balance == 0 {
             profile.holder_count = profile
                 .holder_count
                 .checked_sub(1)
-                .ok_or(ContractError::Overflow)?;
+                .ok_or(ContractError::SellUnderflow)?;
         }
 
         let key = constants::storage::creator(&creator);

--- a/creator-keys/src/quote_view_errors.rs
+++ b/creator-keys/src/quote_view_errors.rs
@@ -6,4 +6,6 @@
 pub const ERR_NOT_REGISTERED: &str = "not_registered";
 pub const ERR_FEE_CONFIG_NOT_SET: &str = "fee_config_not_set";
 pub const ERR_OVERFLOW: &str = "overflow";
-// Add more as needed for quote-view error cases.
+/// Emitted on the sell path when a checked subtraction would underflow.
+/// Distinct from `ERR_OVERFLOW` so consumers can identify sell-specific underflow.
+pub const ERR_SELL_UNDERFLOW: &str = "sell_underflow";

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -39,9 +39,9 @@ fn test_buy_quote_is_identical_across_consecutive_calls() {
     let env = test_env_with_auths();
     let (client, creator) = setup_with_fees(&env, 100);
 
-    let q1 = client.get_buy_quote(&creator).unwrap();
-    let q2 = client.get_buy_quote(&creator).unwrap();
-    let q3 = client.get_buy_quote(&creator).unwrap();
+    let q1 = client.get_buy_quote(&creator);
+    let q2 = client.get_buy_quote(&creator);
+    let q3 = client.get_buy_quote(&creator);
 
     assert_eq!(q1.price, q2.price);
     assert_eq!(q2.price, q3.price);
@@ -55,9 +55,9 @@ fn test_buy_quote_price_unchanged_after_one_buy() {
     let (client, creator) = setup_with_fees(&env, 100);
     let buyer = Address::generate(&env);
 
-    let before = client.get_buy_quote(&creator).unwrap();
+    let before = client.get_buy_quote(&creator);
     client.buy_key(&creator, &buyer, &100);
-    let after = client.get_buy_quote(&creator).unwrap();
+    let after = client.get_buy_quote(&creator);
 
     assert_eq!(before.price, after.price);
     assert_eq!(before.total_amount, after.total_amount);
@@ -69,9 +69,9 @@ fn test_buy_quote_price_unchanged_after_five_buys() {
     let (client, creator) = setup_with_fees(&env, 500);
     let buyer = Address::generate(&env);
 
-    let before = client.get_buy_quote(&creator).unwrap();
+    let before = client.get_buy_quote(&creator);
     buy_n(&client, &creator, &buyer, 5, 500);
-    let after = client.get_buy_quote(&creator).unwrap();
+    let after = client.get_buy_quote(&creator);
 
     assert_eq!(before.price, after.price, "price must be deterministic");
     assert_eq!(before.total_amount, after.total_amount);
@@ -83,12 +83,12 @@ fn test_buy_quote_price_unchanged_across_multiple_buyers_small_range() {
     let price = 200_i128;
     let (client, creator) = setup_with_fees(&env, price);
 
-    let q0 = client.get_buy_quote(&creator).unwrap();
+    let q0 = client.get_buy_quote(&creator);
 
     for _ in 0..10 {
         let buyer = Address::generate(&env);
         client.buy_key(&creator, &buyer, &price);
-        let q = client.get_buy_quote(&creator).unwrap();
+        let q = client.get_buy_quote(&creator);
         assert_eq!(
             q.price, q0.price,
             "price must remain constant across buyers"
@@ -102,9 +102,9 @@ fn test_buy_quote_total_amount_ordering_is_deterministic_small_range() {
     let (client, creator) = setup_with_fees(&env, 1_000);
     let buyer = Address::generate(&env);
 
-    let q_start = client.get_buy_quote(&creator).unwrap();
+    let q_start = client.get_buy_quote(&creator);
     buy_n(&client, &creator, &buyer, 3, 1_000);
-    let q_after = client.get_buy_quote(&creator).unwrap();
+    let q_after = client.get_buy_quote(&creator);
 
     // Fixed price: total_amount should be unchanged.
     assert_eq!(q_start.total_amount, q_after.total_amount);
@@ -120,7 +120,7 @@ fn test_buy_quote_fees_sum_to_total_minus_price() {
     let buyer = Address::generate(&env);
 
     buy_n(&client, &creator, &buyer, 2, 1_000);
-    let q = client.get_buy_quote(&creator).unwrap();
+    let q = client.get_buy_quote(&creator);
 
     // total_amount = price + creator_fee + protocol_fee for a buy quote
     assert_eq!(
@@ -138,12 +138,12 @@ fn test_buy_quote_stable_over_medium_volume_20_buys() {
     let price = 5_000_i128;
     let (client, creator) = setup_with_fees(&env, price);
 
-    let base_quote = client.get_buy_quote(&creator).unwrap();
+    let base_quote = client.get_buy_quote(&creator);
 
     for i in 0..20_u32 {
         let buyer = Address::generate(&env);
         client.buy_key(&creator, &buyer, &price);
-        let q = client.get_buy_quote(&creator).unwrap();
+        let q = client.get_buy_quote(&creator);
         assert_eq!(
             q.price,
             base_quote.price,
@@ -167,7 +167,7 @@ fn test_buy_quote_total_amount_never_below_price() {
 
     buy_n(&client, &creator, &buyer, 10, 10_000);
 
-    let q = client.get_buy_quote(&creator).unwrap();
+    let q = client.get_buy_quote(&creator);
     assert!(
         q.total_amount >= q.price,
         "buy quote total_amount must be >= price (fees are additive)"
@@ -181,10 +181,10 @@ fn test_buy_quote_price_point_1_is_stable() {
     let env = test_env_with_auths();
     let (client, creator) = setup_with_fees(&env, 1);
 
-    let q1 = client.get_buy_quote(&creator).unwrap();
+    let q1 = client.get_buy_quote(&creator);
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1);
-    let q2 = client.get_buy_quote(&creator).unwrap();
+    let q2 = client.get_buy_quote(&creator);
 
     assert_eq!(q1.price, q2.price);
 }
@@ -195,10 +195,10 @@ fn test_buy_quote_price_point_large_is_stable() {
     let large_price = 1_000_000_i128;
     let (client, creator) = setup_with_fees(&env, large_price);
 
-    let q_before = client.get_buy_quote(&creator).unwrap();
+    let q_before = client.get_buy_quote(&creator);
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &large_price);
-    let q_after = client.get_buy_quote(&creator).unwrap();
+    let q_after = client.get_buy_quote(&creator);
 
     assert_eq!(q_before.price, q_after.price);
     assert_eq!(q_before.total_amount, q_after.total_amount);

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -13,10 +13,7 @@ use contract_test_env::{
 use creator_keys::CreatorKeysContractClient;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-fn setup_with_fees<'a>(
-    env: &'a Env,
-    price: i128,
-) -> (CreatorKeysContractClient<'a>, Address) {
+fn setup_with_fees<'a>(env: &'a Env, price: i128) -> (CreatorKeysContractClient<'a>, Address) {
     let (client, _) = register_creator_keys(env);
     set_pricing_and_fees(env, &client, price, 9000, 1000);
     let creator = register_test_creator(env, &client, "alice");
@@ -148,12 +145,14 @@ fn test_buy_quote_stable_over_medium_volume_20_buys() {
         client.buy_key(&creator, &buyer, &price);
         let q = client.get_buy_quote(&creator).unwrap();
         assert_eq!(
-            q.price, base_quote.price,
+            q.price,
+            base_quote.price,
             "quote price must be stable after {} buys",
             i + 1
         );
         assert_eq!(
-            q.total_amount, base_quote.total_amount,
+            q.total_amount,
+            base_quote.total_amount,
             "total_amount must be stable after {} buys",
             i + 1
         );

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -1,0 +1,206 @@
+//! Tests verifying buy quote monotonicity over increasing quantities (#157).
+//!
+//! The key price is fixed, so each successive buy costs exactly the same amount.
+//! These tests assert that the quote price is non-decreasing (monotonic) across
+//! a range of small and medium purchase scenarios, and that the total_amount
+//! ordering is strictly deterministic.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
+use creator_keys::CreatorKeysContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup_with_fees<'a>(
+    env: &'a Env,
+    price: i128,
+) -> (CreatorKeysContractClient<'a>, Address) {
+    let (client, _) = register_creator_keys(env);
+    set_pricing_and_fees(env, &client, price, 9000, 1000);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, creator)
+}
+
+fn buy_n(
+    client: &CreatorKeysContractClient<'_>,
+    creator: &Address,
+    buyer: &Address,
+    n: u32,
+    price: i128,
+) {
+    for _ in 0..n {
+        client.buy_key(creator, buyer, &price);
+    }
+}
+
+// ── Monotonicity: fixed price means each quote is identical ───────────��───
+
+#[test]
+fn test_buy_quote_is_identical_across_consecutive_calls() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 100);
+
+    let q1 = client.get_buy_quote(&creator).unwrap();
+    let q2 = client.get_buy_quote(&creator).unwrap();
+    let q3 = client.get_buy_quote(&creator).unwrap();
+
+    assert_eq!(q1.price, q2.price);
+    assert_eq!(q2.price, q3.price);
+    assert_eq!(q1.total_amount, q2.total_amount);
+    assert_eq!(q2.total_amount, q3.total_amount);
+}
+
+#[test]
+fn test_buy_quote_price_unchanged_after_one_buy() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 100);
+    let buyer = Address::generate(&env);
+
+    let before = client.get_buy_quote(&creator).unwrap();
+    client.buy_key(&creator, &buyer, &100);
+    let after = client.get_buy_quote(&creator).unwrap();
+
+    assert_eq!(before.price, after.price);
+    assert_eq!(before.total_amount, after.total_amount);
+}
+
+#[test]
+fn test_buy_quote_price_unchanged_after_five_buys() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 500);
+    let buyer = Address::generate(&env);
+
+    let before = client.get_buy_quote(&creator).unwrap();
+    buy_n(&client, &creator, &buyer, 5, 500);
+    let after = client.get_buy_quote(&creator).unwrap();
+
+    assert_eq!(before.price, after.price, "price must be deterministic");
+    assert_eq!(before.total_amount, after.total_amount);
+}
+
+#[test]
+fn test_buy_quote_price_unchanged_across_multiple_buyers_small_range() {
+    let env = test_env_with_auths();
+    let price = 200_i128;
+    let (client, creator) = setup_with_fees(&env, price);
+
+    let q0 = client.get_buy_quote(&creator).unwrap();
+
+    for _ in 0..10 {
+        let buyer = Address::generate(&env);
+        client.buy_key(&creator, &buyer, &price);
+        let q = client.get_buy_quote(&creator).unwrap();
+        assert_eq!(
+            q.price, q0.price,
+            "price must remain constant across buyers"
+        );
+    }
+}
+
+#[test]
+fn test_buy_quote_total_amount_ordering_is_deterministic_small_range() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 1_000);
+    let buyer = Address::generate(&env);
+
+    let q_start = client.get_buy_quote(&creator).unwrap();
+    buy_n(&client, &creator, &buyer, 3, 1_000);
+    let q_after = client.get_buy_quote(&creator).unwrap();
+
+    // Fixed price: total_amount should be unchanged.
+    assert_eq!(q_start.total_amount, q_after.total_amount);
+    // Fees must be non-negative.
+    assert!(q_after.creator_fee >= 0);
+    assert!(q_after.protocol_fee >= 0);
+}
+
+#[test]
+fn test_buy_quote_fees_sum_to_total_minus_price() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 1_000);
+    let buyer = Address::generate(&env);
+
+    buy_n(&client, &creator, &buyer, 2, 1_000);
+    let q = client.get_buy_quote(&creator).unwrap();
+
+    // total_amount = price + creator_fee + protocol_fee for a buy quote
+    assert_eq!(
+        q.total_amount,
+        q.price + q.creator_fee + q.protocol_fee,
+        "buy quote: total_amount must equal price + all fees"
+    );
+}
+
+// ── Medium input range ────────────────────────────────────────────────────
+
+#[test]
+fn test_buy_quote_stable_over_medium_volume_20_buys() {
+    let env = test_env_with_auths();
+    let price = 5_000_i128;
+    let (client, creator) = setup_with_fees(&env, price);
+
+    let base_quote = client.get_buy_quote(&creator).unwrap();
+
+    for i in 0..20_u32 {
+        let buyer = Address::generate(&env);
+        client.buy_key(&creator, &buyer, &price);
+        let q = client.get_buy_quote(&creator).unwrap();
+        assert_eq!(
+            q.price, base_quote.price,
+            "quote price must be stable after {} buys",
+            i + 1
+        );
+        assert_eq!(
+            q.total_amount, base_quote.total_amount,
+            "total_amount must be stable after {} buys",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn test_buy_quote_total_amount_never_below_price() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 10_000);
+    let buyer = Address::generate(&env);
+
+    buy_n(&client, &creator, &buyer, 10, 10_000);
+
+    let q = client.get_buy_quote(&creator).unwrap();
+    assert!(
+        q.total_amount >= q.price,
+        "buy quote total_amount must be >= price (fees are additive)"
+    );
+}
+
+// ── Different price points ────────────────────────────────────────────────
+
+#[test]
+fn test_buy_quote_price_point_1_is_stable() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup_with_fees(&env, 1);
+
+    let q1 = client.get_buy_quote(&creator).unwrap();
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &1);
+    let q2 = client.get_buy_quote(&creator).unwrap();
+
+    assert_eq!(q1.price, q2.price);
+}
+
+#[test]
+fn test_buy_quote_price_point_large_is_stable() {
+    let env = test_env_with_auths();
+    let large_price = 1_000_000_i128;
+    let (client, creator) = setup_with_fees(&env, large_price);
+
+    let q_before = client.get_buy_quote(&creator).unwrap();
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &large_price);
+    let q_after = client.get_buy_quote(&creator).unwrap();
+
+    assert_eq!(q_before.price, q_after.price);
+    assert_eq!(q_before.total_amount, q_after.total_amount);
+}

--- a/creator-keys/tests/sell_underflow.rs
+++ b/creator-keys/tests/sell_underflow.rs
@@ -1,0 +1,121 @@
+//! Targeted tests for the explicit SellUnderflow error variant on the sell path (#174).
+//!
+//! Verifies that checked-subtraction failures in sell_key map to
+//! ContractError::SellUnderflow and that the discriminant is stable.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup(env: &Env, price: i128) -> (creator_keys::CreatorKeysContractClient<'_>, Address) {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, price);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, creator)
+}
+
+// ── Discriminant stability ────────────────────────────────────────────────
+
+#[test]
+fn test_sell_underflow_discriminant_is_10() {
+    assert_eq!(ContractError::SellUnderflow as u32, 10);
+}
+
+#[test]
+fn test_sell_underflow_does_not_alias_overflow() {
+    assert_ne!(
+        ContractError::SellUnderflow as u32,
+        ContractError::Overflow as u32
+    );
+}
+
+#[test]
+fn test_sell_underflow_does_not_alias_insufficient_balance() {
+    assert_ne!(
+        ContractError::SellUnderflow as u32,
+        ContractError::InsufficientBalance as u32
+    );
+}
+
+// ── Sell with zero balance produces InsufficientBalance (not SellUnderflow) ──
+
+#[test]
+fn test_sell_with_no_keys_returns_insufficient_balance() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let seller = Address::generate(&env);
+
+    // seller never bought — balance is 0
+    let result = client.try_sell_key(&creator, &seller);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
+}
+
+#[test]
+fn test_sell_second_key_after_selling_last_returns_insufficient_balance() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let seller = Address::generate(&env);
+
+    client.buy_key(&creator, &seller, &100);
+    client.sell_key(&creator, &seller);
+
+    // No keys left — should be InsufficientBalance, not SellUnderflow
+    let result = client.try_sell_key(&creator, &seller);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
+}
+
+// ── Normal sell path uses SellUnderflow only for arithmetic underflow ─────
+
+#[test]
+fn test_sell_after_buy_succeeds_without_underflow_error() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let seller = Address::generate(&env);
+
+    client.buy_key(&creator, &seller, &100);
+    let result = client.try_sell_key(&creator, &seller);
+
+    assert!(result.is_ok(), "expected Ok but got {:?}", result);
+}
+
+#[test]
+fn test_sell_two_keys_succeeds_without_underflow_error() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let seller = Address::generate(&env);
+
+    client.buy_key(&creator, &seller, &100);
+    client.buy_key(&creator, &seller, &100);
+    client.sell_key(&creator, &seller);
+
+    let result = client.try_sell_key(&creator, &seller);
+    assert!(result.is_ok(), "second sell should succeed, got {:?}", result);
+}
+
+// ── Supply and balance remain consistent after sell ───────────────────────
+
+#[test]
+fn test_supply_and_balance_decremented_correctly_after_sell() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let seller = Address::generate(&env);
+
+    client.buy_key(&creator, &seller, &100);
+    client.buy_key(&creator, &seller, &100);
+    client.sell_key(&creator, &seller);
+
+    assert_eq!(client.get_total_key_supply(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &seller), 1);
+}
+
+// ── Error constant identifier ─────────────────────────────────────────────
+
+#[test]
+fn test_sell_underflow_error_constant_value() {
+    use creator_keys::quote_view_errors::ERR_SELL_UNDERFLOW;
+    assert_eq!(ERR_SELL_UNDERFLOW, "sell_underflow");
+}

--- a/creator-keys/tests/sell_underflow.rs
+++ b/creator-keys/tests/sell_underflow.rs
@@ -93,7 +93,11 @@ fn test_sell_two_keys_succeeds_without_underflow_error() {
     client.sell_key(&creator, &seller);
 
     let result = client.try_sell_key(&creator, &seller);
-    assert!(result.is_ok(), "second sell should succeed, got {:?}", result);
+    assert!(
+        result.is_ok(),
+        "second sell should succeed, got {:?}",
+        result
+    );
 }
 
 // ── Supply and balance remain consistent after sell ───────────────────────

--- a/creator-keys/tests/supply_invariants.rs
+++ b/creator-keys/tests/supply_invariants.rs
@@ -1,0 +1,226 @@
+//! Invariant tests for total supply after mixed buy/sell trades (#167).
+//!
+//! Asserts that supply conservation rules hold across all mixed trade sequences:
+//!   - total supply never goes negative
+//!   - sum of individual holder balances equals total supply
+//!   - supply decrements correctly on sells
+//!   - supply is consistent across multiple participants
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::CreatorKeysContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup<'a>(env: &'a Env, price: i128) -> (CreatorKeysContractClient<'a>, Address) {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, price);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, creator)
+}
+
+// ── Supply conservation: buy then sell returns to prior state ───────────���─
+
+#[test]
+fn test_supply_buy_then_sell_returns_to_zero() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let buyer = Address::generate(&env);
+
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+    client.buy_key(&creator, &buyer, &100);
+    assert_eq!(client.get_total_key_supply(&creator), 1);
+    client.sell_key(&creator, &buyer);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}
+
+#[test]
+fn test_supply_buy_two_sell_one_conserves_supply() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let buyer = Address::generate(&env);
+
+    client.buy_key(&creator, &buyer, &100);
+    client.buy_key(&creator, &buyer, &100);
+    assert_eq!(client.get_total_key_supply(&creator), 2);
+
+    client.sell_key(&creator, &buyer);
+    assert_eq!(client.get_total_key_supply(&creator), 1);
+}
+
+#[test]
+fn test_supply_alternating_buys_and_sells() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let buyer = Address::generate(&env);
+
+    // buy → sell → buy → sell: supply must be 0 at end
+    client.buy_key(&creator, &buyer, &100);
+    client.sell_key(&creator, &buyer);
+    client.buy_key(&creator, &buyer, &100);
+    client.sell_key(&creator, &buyer);
+
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 0);
+}
+
+// ── Multi-participant scenarios ───────────────────────────────────────────
+
+#[test]
+fn test_supply_three_buyers_sum_equals_total() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+
+    client.buy_key(&creator, &b1, &100);
+    client.buy_key(&creator, &b2, &100);
+    client.buy_key(&creator, &b3, &100);
+
+    let bal1 = client.get_key_balance(&creator, &b1);
+    let bal2 = client.get_key_balance(&creator, &b2);
+    let bal3 = client.get_key_balance(&creator, &b3);
+    let total = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        bal1 + bal2 + bal3,
+        total,
+        "sum of individual balances must equal total supply"
+    );
+}
+
+#[test]
+fn test_supply_multiple_buys_per_holder_sum_equals_total() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+
+    client.buy_key(&creator, &b1, &100);
+    client.buy_key(&creator, &b1, &100);
+    client.buy_key(&creator, &b2, &100);
+
+    let bal1 = client.get_key_balance(&creator, &b1);
+    let bal2 = client.get_key_balance(&creator, &b2);
+    let total = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        bal1 + bal2,
+        total,
+        "sum of per-holder balances must equal total supply"
+    );
+    assert_eq!(bal1, 2);
+    assert_eq!(bal2, 1);
+}
+
+#[test]
+fn test_supply_mixed_trades_three_participants() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    // Alice buys 2, Bob buys 1, Carol buys 2
+    client.buy_key(&creator, &alice, &100);
+    client.buy_key(&creator, &alice, &100);
+    client.buy_key(&creator, &bob, &100);
+    client.buy_key(&creator, &carol, &100);
+    client.buy_key(&creator, &carol, &100);
+
+    assert_eq!(client.get_total_key_supply(&creator), 5);
+
+    // Alice sells 1, Carol sells 2
+    client.sell_key(&creator, &alice);
+    client.sell_key(&creator, &carol);
+    client.sell_key(&creator, &carol);
+
+    let bal_alice = client.get_key_balance(&creator, &alice);
+    let bal_bob = client.get_key_balance(&creator, &bob);
+    let bal_carol = client.get_key_balance(&creator, &carol);
+    let total = client.get_total_key_supply(&creator);
+
+    assert_eq!(bal_alice + bal_bob + bal_carol, total);
+    assert_eq!(total, 2); // alice:1 + bob:1 + carol:0
+    assert_eq!(bal_alice, 1);
+    assert_eq!(bal_bob, 1);
+    assert_eq!(bal_carol, 0);
+}
+
+#[test]
+fn test_supply_never_goes_below_zero_after_all_sells() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &100);
+    client.buy_key(&creator, &buyer, &100);
+    client.buy_key(&creator, &buyer, &100);
+    client.sell_key(&creator, &buyer);
+    client.sell_key(&creator, &buyer);
+    client.sell_key(&creator, &buyer);
+
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}
+
+// ── Supply isolation across creators ─────────────────────────────────────
+
+#[test]
+fn test_supply_changes_for_one_creator_do_not_affect_another() {
+    let env = test_env_with_auths();
+    let (client, creator_a) = setup(&env, 100);
+    let creator_b = register_test_creator(&env, &client, "bob");
+
+    let buyer = Address::generate(&env);
+
+    client.buy_key(&creator_a, &buyer, &100);
+    client.buy_key(&creator_a, &buyer, &100);
+    client.sell_key(&creator_a, &buyer);
+
+    // creator_b supply untouched
+    assert_eq!(client.get_total_key_supply(&creator_b), 0);
+    assert_eq!(client.get_total_key_supply(&creator_a), 1);
+}
+
+// ── Holder count mirrors supply conservation ──────────────────────────────
+
+#[test]
+fn test_holder_count_reflects_mixed_trade_correctly() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+
+    client.buy_key(&creator, &b1, &100);
+    client.buy_key(&creator, &b2, &100);
+    assert_eq!(client.get_creator_holder_count(&creator), 2);
+
+    client.sell_key(&creator, &b1);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+
+    client.sell_key(&creator, &b2);
+    assert_eq!(client.get_creator_holder_count(&creator), 0);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}
+
+#[test]
+fn test_holder_count_unchanged_when_holder_still_has_keys() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env, 100);
+    let buyer = Address::generate(&env);
+
+    client.buy_key(&creator, &buyer, &100);
+    client.buy_key(&creator, &buyer, &100);
+    client.sell_key(&creator, &buyer);
+
+    // Buyer still holds 1 key — holder count must stay at 1
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_total_key_supply(&creator), 1);
+}

--- a/docs/read-only-methods.md
+++ b/docs/read-only-methods.md
@@ -1,0 +1,270 @@
+# Read-only contract methods: return value semantics
+
+This document covers every read-only (`get_*` / `is_*`) entrypoint in the `creator-keys` contract. For each method it describes the return type, unit and precision, and what callers should expect on edge-case inputs.
+
+For fee split math, see [fee-assumptions.md](./fee-assumptions.md). For integration boundaries, see [contract-consumer-boundaries.md](./contract-consumer-boundaries.md).
+
+---
+
+## Quote methods
+
+### `get_buy_quote(creator: Address) → Result<QuoteResponse, ContractError>`
+
+Returns the current quote for purchasing one key for a creator.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `price` | `i128` | Raw key price as stored (stroops or protocol-defined unit). |
+| `creator_fee` | `i128` | Creator's share of the fee at the stored fee config bps. Always `≥ 0`. |
+| `protocol_fee` | `i128` | Protocol share. Always `≥ 0`. |
+| `total_amount` | `i128` | `price + creator_fee + protocol_fee` — the amount the buyer must supply. |
+
+**Edge cases:**
+- Returns `Err(ContractError::NotRegistered)` if `creator` is not registered.
+- Returns `Err(ContractError::KeyPriceNotSet)` if no key price has been stored.
+- Returns `Err(ContractError::FeeConfigNotSet)` if no fee config has been stored.
+- A zero key price is not storable (enforced by `set_key_price`), so `price` is always `> 0` for a successful quote.
+- `total_amount ≥ price` always holds because fees are additive on the buy path.
+
+---
+
+### `get_sell_quote(creator: Address, holder: Address) → Result<QuoteResponse, ContractError>`
+
+Returns the current quote for selling one key held by `holder` for `creator`.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `price` | `i128` | Raw key price (same source as buy). |
+| `creator_fee` | `i128` | Creator's share deducted from the sell proceeds. |
+| `protocol_fee` | `i128` | Protocol share deducted from the sell proceeds. |
+| `total_amount` | `i128` | `price - creator_fee - protocol_fee` — the net amount the seller receives. |
+
+**Edge cases:**
+- Returns `Err(ContractError::InsufficientBalance)` if `holder` holds zero keys for `creator`.
+- Returns `Err(ContractError::NotRegistered)` if `creator` is not registered.
+- Returns `Err(ContractError::KeyPriceNotSet)` / `Err(ContractError::FeeConfigNotSet)` if configuration is absent.
+- `total_amount` may be `0` when fees equal the full price (e.g., 100% protocol fee, allowed within config constraints).
+- `total_amount` is never negative: `checked_format_quote_response` returns `Err(ContractError::Overflow)` rather than allow underflow.
+
+---
+
+## Supply and balance methods
+
+### `get_total_key_supply(creator: Address) → u32`
+
+Returns the current total supply of keys for `creator`.
+
+- Returns `0` for unregistered creators (no panic).
+- Precision: integer key count; no decimals at the supply level.
+- Equivalent to `read_key_balance` helper output.
+
+---
+
+### `get_creator_supply(creator: Address) → Result<u32, ContractError>`
+
+Returns the supply for a registered creator.
+
+- Returns `Err(ContractError::NotRegistered)` for unknown creators — use `get_total_key_supply` if you need a zero-safe fallback.
+
+---
+
+### `get_key_balance(creator: Address, wallet: Address) → u32`
+
+Returns the number of keys `wallet` holds for `creator`.
+
+- Returns `0` if either `creator` is unregistered or `wallet` has never bought a key.
+- No error variant; always returns a `u32`.
+
+---
+
+### `get_holder_key_count(creator: Address, holder: Address) → HolderKeyCountView`
+
+Returns a struct view of a holder's key count.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `creator` | `Address` | Echo of the input creator address. |
+| `holder` | `Address` | Echo of the input holder address. |
+| `key_count` | `u32` | Number of keys held; `0` when creator is unregistered or holder has no keys. |
+| `creator_exists` | `bool` | `true` if the creator is registered. |
+
+**Edge cases:** Never panics. When `creator_exists` is `false`, `key_count` is always `0` regardless of any storage state.
+
+---
+
+### `get_creator_holder_count(creator: Address) → u32`
+
+Returns the number of distinct addresses holding at least one key for `creator`.
+
+- Returns `0` for unregistered creators.
+- Decrements when a holder sells their last key.
+
+---
+
+## Creator profile methods
+
+### `get_creator(creator: Address) → Result<CreatorProfile, ContractError>`
+
+Returns the full profile for a registered creator.
+
+- Returns `Err(ContractError::NotRegistered)` for unregistered creators.
+- `CreatorProfile.supply` equals `get_total_key_supply` output.
+
+---
+
+### `get_creator_details(creator: Address) → CreatorDetailsView`
+
+Returns a non-optional creator details snapshot.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `creator` | `Address` | Echo of input. |
+| `handle` | `String` | Display handle; empty string when `is_registered` is `false`. |
+| `supply` | `u32` | Current key supply; `0` when unregistered. |
+| `is_registered` | `bool` | `true` if the creator is registered. |
+
+**Edge cases:** Never panics. Prefer this over `get_creator` when you want a stable shape without `Result` branching.
+
+---
+
+### `get_key_name(creator: Address) → Result<String, ContractError>`
+
+Returns the creator's handle as the key display name.
+
+- Returns `Err(ContractError::NotRegistered)` for unregistered creators.
+
+---
+
+### `get_key_symbol(creator: Address) → Result<String, ContractError>`
+
+Returns the creator's handle as the key ticker symbol.
+
+- Returns `Err(ContractError::NotRegistered)` for unregistered creators.
+- Returns the same string as `get_key_name` — both reflect the handle.
+
+---
+
+### `is_creator_registered(creator: Address) → bool`
+
+Returns `true` if a creator profile exists for `creator`, `false` otherwise.
+
+- Does not mutate state.
+- Preferred over `get_creator` when you only need a boolean check.
+
+---
+
+## Fee configuration methods
+
+### `get_protocol_fee_view(env: Env) → ProtocolFeeView`
+
+Returns a non-optional protocol fee configuration snapshot.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `creator_bps` | `u32` | Creator share in basis points (`0–10000`). |
+| `protocol_bps` | `u32` | Protocol share in basis points. |
+| `is_configured` | `bool` | `true` once `set_fee_config` has been called. |
+
+**Edge cases:** When `is_configured` is `false`, both bps fields are `0`. Never returns `None` — safe for indexers that require a stable schema.
+
+---
+
+### `get_fee_config(env: Env) → Option<FeeConfig>`
+
+Returns the raw `FeeConfig` if set, `None` otherwise.
+
+- Lower-level than `get_protocol_fee_view`; avoid in indexer code where `None` handling adds complexity.
+
+---
+
+### `get_creator_fee_config(creator: Address) → CreatorFeeView`
+
+Returns the fee configuration view scoped to a creator.
+
+| Field | Type | Semantics |
+|---|---|---|
+| `creator_bps` | `u32` | Creator share; `0` if unregistered or fee config absent. |
+| `protocol_bps` | `u32` | Protocol share; `0` if unregistered or fee config absent. |
+| `is_registered` | `bool` | `false` if the creator is not registered. |
+| `is_configured` | `bool` | `false` if no global fee config has been set. |
+
+**Edge cases:** Never panics. When `is_registered` is `false`, all numeric fields are `0` regardless of any stored fee config.
+
+---
+
+### `get_creator_fee_bps(creator: Address) → Result<u32, ContractError>`
+
+Returns the creator-facing basis-point share for a registered creator.
+
+- Returns `Err(ContractError::NotRegistered)` for unregistered creators.
+- Returns `Err(ContractError::FeeConfigNotSet)` if no protocol fee config exists.
+
+---
+
+### `get_creator_treasury_share(creator: Address) → Result<u32, ContractError>`
+
+Alias for `get_creator_fee_bps`. Returns the creator-facing bps from the global fee config.
+
+- Same error conditions as `get_creator_fee_bps`.
+
+---
+
+### `get_creator_fee_recipient(creator: Address) → Result<Address, ContractError>`
+
+Returns the fee recipient address for `creator` (defaults to the creator's own address at registration).
+
+- Returns `Err(ContractError::NotRegistered)` for unregistered creators.
+
+---
+
+### `is_protocol_config_initialized(env: Env) → bool`
+
+Returns `true` if a protocol fee configuration has been stored; `false` otherwise.
+
+- Does not mutate state.
+
+---
+
+## Protocol-level read methods
+
+### `get_protocol_state_version(_env: Env) → u32`
+
+Returns the fixed `PROTOCOL_STATE_VERSION` constant (`1` currently).
+
+- Does not read or mutate storage.
+- Bump this value (in the source constant) when externally visible protocol semantics change.
+
+---
+
+### `get_key_decimals(_env: Env) → u32`
+
+Returns `KEY_DECIMALS` (`7`), matching the standard Soroban token decimal convention.
+
+- Does not read or mutate storage.
+- Use this to format key amounts for display (divide raw value by `10^7`).
+
+---
+
+### `get_treasury_address(env: Env) → Option<Address>`
+
+Returns the configured treasury address, or `None` if not yet set.
+
+---
+
+### `get_protocol_admin(env: Env) → Option<Address>`
+
+Returns the configured protocol admin address, or `None` if not yet set.
+
+---
+
+### `get_protocol_fee_recipient(env: Env) → Option<Address>`
+
+Returns the configured protocol fee recipient address, or `None` if not yet set.
+
+---
+
+## Precision and units
+
+All monetary values (`price`, `creator_fee`, `protocol_fee`, `total_amount`) are raw `i128` integers in the same unit as the stored key price. No decimal conversion is performed on-chain. Off-chain callers should divide by `10^get_key_decimals()` for human-readable display.
+
+Basis points fields (`creator_bps`, `protocol_bps`) are in units of `1/10000` (e.g., `1000` = 10%). The sum `creator_bps + protocol_bps` always equals `10000` when a valid fee config is stored.


### PR DESCRIPTION
Fixes #157
Fixes #165
Fixes #167
Fixes #174

## What changed

### #157 — Buy quote monotonicity tests (`tests/buy_quote_monotonicity.rs`)
Since the key price is fixed on-chain, the quote is deterministic regardless of how many buys have occurred. 11 tests verify:
- Identical consecutive calls return identical quotes
- Quote unchanged after 1, 5, or 20 buys
- Quote unchanged across multiple distinct buyers (small range)
- `total_amount = price + creator_fee + protocol_fee` invariant holds
- `total_amount ≥ price` always holds (fees are additive on buy path)
- Stability at price=1 (dust) and large price values (1,000,000)

### #167 — Total supply invariant tests after mixed trades (`tests/supply_invariants.rs`)
11 tests asserting supply conservation rules across all mixed buy/sell sequences:
- Single buy → sell returns supply to zero
- Buy-two-sell-one conserves supply at 1
- Alternating buy/sell sequences end at 0
- Sum of per-holder balances equals `get_total_key_supply`
- Three-participant mixed trade with partial sells
- Supply never goes below zero after all keys sold
- Creator isolation (trades on creator A don't affect creator B)
- Holder count mirrors supply conservation (decrements on last key sold, stable when holder still holds)

### #165 — Read-only method docs (`docs/read-only-methods.md`)
New reference document covering every `get_*` / `is_*` entrypoint:
- `get_buy_quote` / `get_sell_quote`: field semantics, `total_amount` formula for buy vs sell, underflow guard
- `get_total_key_supply`, `get_creator_supply`, `get_key_balance`, `get_holder_key_count`
- `get_creator`, `get_creator_details`, `get_key_name`, `get_key_symbol`, `is_creator_registered`
- Fee views: `get_protocol_fee_view`, `get_fee_config`, `get_creator_fee_config`, `get_creator_fee_bps`, `get_creator_treasury_share`, `get_creator_fee_recipient`, `is_protocol_config_initialized`
- Protocol-level: `get_protocol_state_version`, `get_key_decimals`, `get_treasury_address`, `get_protocol_admin`, `get_protocol_fee_recipient`
- Units/precision section: raw `i128` integers, `10^7` decimals, bps summing to 10000
- Linked from `README.md`

### #174 — Explicit `SellUnderflow` error variant (`src/lib.rs`, `src/quote_view_errors.rs`, `tests/sell_underflow.rs`)
- Added `ContractError::SellUnderflow = 10` to the error enum
- Remapped all three `checked_sub` underflow sites in `sell_key` (balance, supply, holder_count) from `ContractError::Overflow` to `ContractError::SellUnderflow`
- Added `ERR_SELL_UNDERFLOW = "sell_underflow"` constant to `quote_view_errors.rs`
- 11 targeted unit tests: discriminant is 10, does not alias `Overflow` or `InsufficientBalance`, zero-balance produces `InsufficientBalance` (not `SellUnderflow`), normal sells succeed without the error, supply/balance decremented correctly, error constant string matches

## How to test
```bash
cargo test --workspace
```