### PR TITLE
docs: implement storage key invariants for quote-related state (Issue…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo test --workspace
 
 ## Testnet deployment
 
-For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). Store and name release wasm files using [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For client and server integration expectations (read methods, events, version bumps), see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md). For detailed return value semantics of every read-only entrypoint (units, precision, edge-case outputs), see [docs/read-only-methods.md](./docs/read-only-methods.md).
+For contributor test deployments and release checks, use the guide in [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). Store and name release wasm files using [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For client and server integration expectations (read methods, events, version bumps), see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md). For detailed return value semantics of every read-only entrypoint (units, precision, edge-case outputs), see [docs/read-only-methods.md](./docs/read-only-methods.md). For quote-related storage key behavior and invariants, see [docs/quote-storage-keys.md](./docs/quote-storage-keys.md).
 
 ## Open source workflow
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -219,6 +219,10 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
 
+/// Canonical storage key schema for persistent protocol state.
+///
+/// For quote-related key usage and invariants, see
+/// [`docs/quote-storage-keys.md`](../../docs/quote-storage-keys.md).
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {

--- a/docs/quote-storage-keys.md
+++ b/docs/quote-storage-keys.md
@@ -1,0 +1,78 @@
+# Quote Storage Keys and Invariants
+
+This document defines the storage keys involved in quote computation for `get_buy_quote` and `get_sell_quote` in the `creator-keys` contract.
+
+Quotes are derived views. No `QuoteResponse` values are persisted in storage.
+
+## Scope
+
+Quote input validation and quote math are implemented in:
+
+- `resolve_quote_inputs`
+- `compute_fees_for_payment`
+- `get_buy_quote`
+- `get_sell_quote`
+
+## Storage Keys Used By Quotes
+
+| Storage Key | Value Type | Used By | Purpose |
+| --- | --- | --- | --- |
+| `DataKey::KeyPrice` | `i128` | buy + sell quotes | Base quote price shared by all creators |
+| `DataKey::Creator(creator)` | `CreatorProfile` | buy + sell quotes | Registration gate; quotes require creator to exist |
+| `DataKey::FeeConfig` | `FeeConfig` | buy + sell quotes | Fee split source (`creator_bps`, `protocol_bps`) |
+| `DataKey::KeyBalance(creator, holder)` | `u32` | sell quotes only | Holder balance gate; sell quotes require balance > 0 |
+
+## Key Invariants
+
+### `DataKey::KeyPrice`
+
+- Must exist before quote methods can return non-error values.
+- Missing key must yield `ContractError::KeyPriceNotSet`.
+- Negative values are invalid for quotes and must yield `ContractError::NotPositiveAmount`.
+- Zero is treated as a no-op quote input and returns a zeroed `QuoteResponse`.
+
+### `DataKey::Creator(creator)`
+
+- Creator must be registered for both buy and sell quotes.
+- Missing creator must yield `ContractError::NotRegistered`.
+- Quote methods only read this key; they never mutate creator state.
+
+### `DataKey::FeeConfig`
+
+- Must exist for quote fee computation.
+- Missing key must yield `ContractError::FeeConfigNotSet`.
+- Stored config must satisfy protocol fee constraints established by `set_fee_config`:
+  - `creator_bps + protocol_bps == 10_000`
+  - `protocol_bps <= 5_000`
+- Quote math assumes this invariant and computes fees with checked arithmetic.
+
+### `DataKey::KeyBalance(creator, holder)`
+
+- Read only for sell quote eligibility.
+- Missing key is interpreted as `0`.
+- Sell quote requires effective balance > 0, otherwise returns `ContractError::InsufficientBalance`.
+- Quote path does not mutate holder balances.
+
+## Update Expectations
+
+Quote methods are read-only with respect to contract storage.
+
+Expected quote-path storage behavior:
+
+- `get_buy_quote`: reads `KeyPrice`, `Creator(creator)`, `FeeConfig`; performs no writes.
+- `get_sell_quote`: reads `KeyPrice`, `Creator(creator)`, `KeyBalance(creator, holder)`, `FeeConfig`; performs no writes.
+
+State-changing methods (`set_key_price`, `set_fee_config`, `register_creator`, `buy_key`, `sell_key`) may change future quote outputs by updating those underlying keys.
+
+## Formula and Consistency Expectations
+
+For price `p`, creator fee `c`, and protocol fee `f`:
+
+- Buy quote: `total_amount = p + c + f`
+- Sell quote: `total_amount = p - c - f`
+
+Additional expectations:
+
+- Fees are derived from `FeeConfig` with checked arithmetic.
+- Overflow in fee/total computations must return contract errors (`Overflow` or `SellUnderflow`).
+- Quote values are deterministic for unchanged storage state.

--- a/docs/storage-key-invariants.md
+++ b/docs/storage-key-invariants.md
@@ -2,6 +2,8 @@
 
 This document describes the storage model, key structure, and invariants that must be maintained across all contract operations in Access Layer contracts.
 
+For quote-specific storage behavior (`get_buy_quote`, `get_sell_quote`), see [quote-storage-keys.md](./quote-storage-keys.md).
+
 ## Overview
 
 Access Layer contracts use Soroban's persistent storage to maintain creator profiles, key balances, and protocol configuration. Understanding these storage invariants is critical for contributors working on contract logic.


### PR DESCRIPTION
This pull request improves the documentation around quote-related storage keys and their invariants in the `creator-keys` contract. It introduces a new, detailed guide on quote storage key usage, updates cross-references in existing documentation, and adds clarifying comments in the codebase.

**Documentation improvements for quote storage keys:**

* Added a new document, `docs/quote-storage-keys.md`, detailing the storage keys, invariants, and behaviors related to quote computation for `get_buy_quote` and `get_sell_quote`.
* Updated `README.md` to reference the new quote storage keys documentation for further details on storage key behavior and invariants.
* Added a reference in `docs/storage-key-invariants.md` to the new quote-specific storage key document for clarity.

**Code comments and documentation:**

* Added a doc comment to the `DataKey` enum in `creator-keys/src/lib.rs` pointing to the new quote storage key documentation.

Closes #200 