### PR TITLE
docs: add contributor guidance for safely extending error enums (Issu…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ For guidance on writing deterministic quote tests, see [docs/deterministic-quote
 - **[Deterministic Quote Tests](./docs/deterministic-quote-tests.md)**: Guide for writing tests for quote operations with the fixed price model
 - **[Fee Assumptions](./docs/fee-assumptions.md)**: Fee split logic, rounding behavior, and integration points
 - **[Error Codes](./docs/error-codes.md)**: Contract error reference with causes and expected caller behavior
+- **[Safely Extending Contract Error Codes](./docs/error-extension-guide.md)**: Rules for naming new error variants, preserving discriminants, and updating error tables
 
 For testnet deployment steps, required CLI setup, and the release checklist used for contract updates, see [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). For **wasm artifact** naming, retention, and metadata, see [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For how **clients and servers** should depend on contract read surfaces and events, see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md).
 

--- a/docs/error-extension-guide.md
+++ b/docs/error-extension-guide.md
@@ -1,0 +1,50 @@
+# Safely Extending Contract Error Codes
+
+This guide applies to the primary on-chain error enum in `creator-keys/src/lib.rs`:
+
+- `ContractError` is marked with `#[contracterror]`
+- it uses explicit numeric discriminants starting at `1`
+- existing values are currently assigned sequentially from `1` through `14`
+
+## Naming
+
+Choose new variants that match the existing style:
+
+- Use `UpperCamelCase` variant names such as `AlreadyRegistered` and `ProtocolFeeExceedsCap`.
+- Prefer names that describe the failing condition, not the implementation detail.
+- Keep names specific to the contract domain so they remain readable in logs, tests, and client code.
+- If a new error is only used by a single flow, name it for that flow rather than reusing a generic placeholder.
+
+## Safety
+
+Error numbers are part of the contract's external interface and must remain stable.
+
+- Do not reorder existing variants.
+- Do not change existing numeric discriminants.
+- Do not reuse a retired number for a different meaning.
+- Only append new variants with the next unused number.
+
+Changing existing error numbers can break callers that compare on the serialized error code, decode transaction results, or rely on documented tables.
+
+## Documentation
+
+Whenever you add, rename, or repurpose an error variant, update the relevant documentation in the same change:
+
+- `docs/error-codes.md`
+- any test comments or tables that assert discriminant stability
+- any client-facing documentation that lists contract error meanings
+
+If the new error affects a specific flow, also update nearby tests so the expected variant and numeric value stay explicit.
+
+## Example
+
+If you need a new error, add it at the end of the enum and document it alongside the existing table entries:
+
+```rust
+pub enum ContractError {
+    // existing variants...
+    NewFailure = 15,
+}
+```
+
+That approach keeps the serialized contract surface backward compatible for existing consumers.


### PR DESCRIPTION
This pull request adds new documentation to guide contributors on safely extending the primary on-chain contract error codes. It introduces a dedicated guide covering naming conventions, safety requirements, and documentation practices for error variants in the contract, and updates the main contributor documentation to reference this new guide.

**Documentation improvements for contract error codes:**

* Added a new file, `docs/error-extension-guide.md`, which provides detailed instructions on naming new error variants, preserving numeric discriminants, and updating documentation when extending the `ContractError` enum in `creator-keys/src/lib.rs`.
* Updated the `CONTRIBUTING.md` file to include a link to the new error extension guide, making it easier for contributors to find and follow best practices when adding or modifying contract error codes.

Closes #202 
