### PR TITLE
docs: add event schema compatibility guidance and creator registration storage key metadata docs (#209, #207)

### DIFF
--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -143,6 +143,8 @@ fn test_register_creator_persists_registration_metadata() {
     assert_eq!(profile.holder_count, 0);
     assert_eq!(profile.fee_recipient, creator);
 }
+
+#[test]
 fn test_duplicate_registration_fails() {
     let env = Env::default();
     env.mock_all_auths();

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -120,9 +120,29 @@ fn test_register_creator() {
     assert_eq!(profile.handle, handle);
     assert_eq!(profile.creator, creator);
     assert_eq!(profile.supply, 0);
+    assert_eq!(profile.holder_count, 0);
+    assert_eq!(profile.fee_recipient, creator);
 }
 
 #[test]
+fn test_register_creator_persists_registration_metadata() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let handle = String::from_str(&env, "alice");
+
+    client.register_creator(&creator, &handle);
+
+    let profile = client.get_creator(&creator);
+    assert_eq!(profile.creator, creator);
+    assert_eq!(profile.handle, handle);
+    assert_eq!(profile.supply, 0);
+    assert_eq!(profile.holder_count, 0);
+    assert_eq!(profile.fee_recipient, creator);
+}
 fn test_duplicate_registration_fails() {
     let env = Env::default();
     env.mock_all_auths();

--- a/docs/contract-consumer-boundaries.md
+++ b/docs/contract-consumer-boundaries.md
@@ -24,6 +24,18 @@ Stable structs returned by read-only methods are part of the integration contrac
 
 State-changing entrypoints that emit events (for example `register_creator`, `buy_key`) are consumption boundaries for **indexers and analytics**: payload shape and event names are stable API for the server. Any change to event name, field order, or field meaning should be treated as a **breaking** change for indexers unless versioned (e.g. a new event name) or coordinated with consumers.
 
+### Event schema compatibility checklist
+
+For any event payload or event name change, contributors should follow this compatibility checklist:
+
+- Do not rename existing event names or fields without creating a new versioned event. Renames are breaking for downstream indexers that decode by field position or name.
+- Do not change field semantics, types, or encoded meaning without explicit coordination and a documented migration plan.
+- Prefer adding new optional fields only when clients and indexers can safely ignore unknown fields.
+- If an event schema change is required, consider a versioned event name and bump `get_protocol_state_version` when consumer parsing expectations change.
+- Coordinate with downstream indexers before deploying any event payload change; treat event payloads as a stable public API.
+
+For storage key details tied to creator registration metadata and ownership expectations, see [Storage Key Invariants](./storage-key-invariants.md).
+
 ## Compatibility expectations
 
 | Change | Expectation |

--- a/docs/storage-key-invariants.md
+++ b/docs/storage-key-invariants.md
@@ -28,7 +28,7 @@ pub enum DataKey {
 
 | Key                            | Type               | Value Type       | Purpose                                                    |
 | ------------------------------ | ------------------ | ---------------- | ---------------------------------------------------------- |
-| `Creator(Address)`             | Per-creator        | `CreatorProfile` | Stores creator registration data, supply, and holder count |
+| `Creator(Address)`             | Per-creator        | `CreatorProfile` | Stores creator registration metadata, supply, holder_count, and fee recipient |
 | `FeeConfig`                    | Global             | `FeeConfig`      | Stores protocol-wide fee split configuration               |
 | `KeyPrice`                     | Global             | `i128`           | Stores the fixed price for all keys across all creators    |
 | `KeyBalance(Address, Address)` | Per-creator-holder | `u32`            | Stores how many keys a holder owns for a specific creator  |
@@ -43,6 +43,18 @@ These invariants must hold true after every contract operation:
 ### 1. Creator Profile Invariants
 
 **Invariant**: A creator exists if and only if `DataKey::Creator(address)` is present in storage.
+
+### Creator registration metadata ownership
+
+**Key ownership**: `DataKey::Creator(address)` is the single source of truth for creator registration metadata and may only be created by `register_creator`.
+
+- `register_creator` must set this key exactly once for a new creator address.
+- The creator address must authorize registration via `creator.require_auth()`.
+- The profile stores `creator`, `handle`, `supply`, `holder_count`, and `fee_recipient`.
+- Indexers may derive registration status, handle, supply, holder_count, and fee recipient from this single entry.
+- Any future change to creator registration metadata storage shape should be treated like an event/schema breaking change and require explicit coordination.
+
+**Implications**:
 
 **Implications**:
 


### PR DESCRIPTION
This PR adds contributor-facing documentation for safe event schema evolution and creator registration storage key metadata.

Changes included:
- Added an event schema compatibility checklist to `docs/contract-consumer-boundaries.md`
- Linked event compatibility guidance to storage key expectations
- Documented creator registration metadata ownership and invariants in `docs/storage-key-invariants.md`
- Added a focused creator-keys test verifying registration metadata persistence

Closes #209
Closes #207