### PR TITLE
feat: Add read-only protocol treasury share bps accessor

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -694,6 +694,15 @@ impl CreatorKeysContract {
         Self::get_creator_fee_bps(env, creator)
     }
 
+    /// Read-only view: returns the configured protocol treasury share in basis points.
+    ///
+    /// This value is sourced from the current protocol fee configuration and is
+    /// expressed in stable basis-point units.
+    pub fn get_protocol_treasury_share_bps(env: Env) -> Result<u32, ContractError> {
+        let config = read_required_protocol_fee_config(&env)?;
+        Ok(config.protocol_bps)
+    }
+
     pub fn set_fee_config(
         env: Env,
         admin: Address,

--- a/creator-keys/tests/protocol_treasury_share.rs
+++ b/creator-keys/tests/protocol_treasury_share.rs
@@ -1,0 +1,36 @@
+//! Tests for the `get_protocol_treasury_share_bps` read-only method.
+
+use creator_keys::{CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_get_protocol_treasury_share_bps_returns_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.set_fee_config(&admin, &8000u32, &2000u32);
+
+    assert_eq!(client.get_protocol_treasury_share_bps(), 2000);
+}
+
+#[test]
+fn test_get_protocol_treasury_share_bps_is_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.set_fee_config(&admin, &7000u32, &3000u32);
+
+    let first = client.get_protocol_treasury_share_bps();
+    let second = client.get_protocol_treasury_share_bps();
+
+    assert_eq!(first, second);
+    assert_eq!(first, 3000);
+}


### PR DESCRIPTION


Description:
## Summary
Adds a read-only method exposing the protocol treasury share in basis points.

## Changes
- Implemented `get_protocol_treasury_share_bps()` in `creator-keys/src/lib.rs`
- Added tests in `creator-keys/tests/protocol_treasury_share.rs`
- Ensures the method returns the configured protocol share and is stable across repeated calls

## Testing
- Validate locally with `cargo test --test protocol_treasury_share`

Fixes #196 