### PR TITLE
Fix: Add regression test for fee config update stale reads (#219)

### DIFF
--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -359,3 +359,64 @@ fn test_buy_quote_multiple_creators_independent_monotonicity() {
     assert_eq!(alice_supply, 1, "alice should have 1 key sold");
     assert_eq!(bob_supply, 1, "bob should have 1 key sold");
 }
+
+// ── Fee config update regression test (#219) ─────────────────────────────────
+
+#[test]
+fn test_buy_quote_updates_after_fee_config_mutation() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let price = 1_000_i128;
+
+    // Set initial fee config: 90% creator, 10% protocol
+    set_pricing_and_fees(&env, &client, price, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Get quote with initial fee config
+    let q_before = client.get_buy_quote(&creator);
+
+    // Verify initial fee distribution
+    assert_eq!(q_before.price, price);
+    assert_eq!(q_before.creator_fee, 900);
+    assert_eq!(q_before.protocol_fee, 100);
+    assert_eq!(q_before.total_amount, price + 900 + 100);
+
+    // Update fee config: 50% creator, 50% protocol
+    let admin = Address::generate(&env);
+    client.set_fee_config(&admin, &5000u32, &5000u32);
+
+    // Get quote after fee config update
+    let q_after = client.get_buy_quote(&creator);
+
+    // Verify quote reflects updated fee config (no stale reads)
+    assert_eq!(q_after.price, price, "price should remain unchanged");
+    assert_eq!(q_after.creator_fee, 500, "creator_fee should reflect new config");
+    assert_eq!(q_after.protocol_fee, 500, "protocol_fee should reflect new config");
+    assert_eq!(
+        q_after.total_amount,
+        price + 500 + 500,
+        "total_amount should reflect new fee split"
+    );
+
+    // Assert fees are different (no stale config)
+    assert_ne!(
+        q_before.creator_fee, q_after.creator_fee,
+        "creator_fee must change after config update"
+    );
+    assert_ne!(
+        q_before.protocol_fee, q_after.protocol_fee,
+        "protocol_fee must change after config update"
+    );
+    assert_ne!(
+        q_before.total_amount, q_after.total_amount,
+        "total_amount must change after config update"
+    );
+
+    // Verify fee invariant: total_amount = price + creator_fee + protocol_fee
+    assert_eq!(
+        q_after.total_amount,
+        q_after.price + q_after.creator_fee + q_after.protocol_fee,
+        "buy quote invariant must hold after fee config update"
+    );
+}

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -391,8 +391,14 @@ fn test_buy_quote_updates_after_fee_config_mutation() {
 
     // Verify quote reflects updated fee config (no stale reads)
     assert_eq!(q_after.price, price, "price should remain unchanged");
-    assert_eq!(q_after.creator_fee, 500, "creator_fee should reflect new config");
-    assert_eq!(q_after.protocol_fee, 500, "protocol_fee should reflect new config");
+    assert_eq!(
+        q_after.creator_fee, 500,
+        "creator_fee should reflect new config"
+    );
+    assert_eq!(
+        q_after.protocol_fee, 500,
+        "protocol_fee should reflect new config"
+    );
     assert_eq!(
         q_after.total_amount,
         price + 500 + 500,

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -414,9 +414,10 @@ fn test_buy_quote_updates_after_fee_config_mutation() {
         q_before.protocol_fee, q_after.protocol_fee,
         "protocol_fee must change after config update"
     );
-    assert_ne!(
+    // Total amount should remain the same (fee redistribution)
+    assert_eq!(
         q_before.total_amount, q_after.total_amount,
-        "total_amount must change after config update"
+        "total_amount should remain same after fee redistribution"
     );
 
     // Verify fee invariant: total_amount = price + creator_fee + protocol_fee


### PR DESCRIPTION
 This commit adds a comprehensive regression test for issue #219 to ensure buy quotes correctly reflect updated fee configurations after set_fee_config calls. The test verifies that when fee splits are modified (e.g., from 90% creator/10% protocol to 50%/50%), subsequent buy quote calculations immediately use the new values rather than stale cached configurations. This prevents pricing inconsistencies and maintains the critical invariant where total_amount = price + creator_fee + protocol_fee. The test covers both the fee distribution updates and validates that all fee components change appropriately after configuration mutations, ensuring robust fee handling in the creator keys marketplace.
 closes #219 