### PR TITLE
feat: add quote edge regressions and fee config guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ For guidance on writing deterministic quote tests, see [docs/deterministic-quote
 - **[CI Contract Checks](./docs/ci-contract-checks.md)**: Understanding the CI pipeline, running checks locally, and troubleshooting failures
 - **[Storage Key Invariants](./docs/storage-key-invariants.md)**: Storage model, key structure, and invariants that must be maintained across all operations
 - **[Deterministic Quote Tests](./docs/deterministic-quote-tests.md)**: Guide for writing tests for quote operations with the fixed price model
+- **[Quote Math Refactor Guidelines](./docs/quote-math-refactor-guidelines.md)**: Checklist for preserving quote invariants and required regression coverage during quote-path refactors
 - **[Fee Assumptions](./docs/fee-assumptions.md)**: Fee split logic, rounding behavior, and integration points
 - **[Error Codes](./docs/error-codes.md)**: Contract error reference with causes and expected caller behavior
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -26,6 +26,8 @@ pub enum ContractError {
 }
 
 pub mod fee {
+    use crate::ContractError;
+
     use soroban_sdk::contracttype;
 
     /// Basis points per 100% (10000 = 100%).

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -58,6 +58,20 @@ pub mod fee {
         true
     }
 
+    /// Shared guard for fee config updates that need structured contract errors.
+    pub fn assert_valid_fee_bps(creator_bps: u32, protocol_bps: u32) -> Result<(), ContractError> {
+        let Some(sum) = creator_bps.checked_add(protocol_bps) else {
+            return Err(ContractError::InvalidFeeConfig);
+        };
+        if sum != BPS_MAX {
+            return Err(ContractError::InvalidFeeConfig);
+        }
+        if protocol_bps > PROTOCOL_BPS_MAX {
+            return Err(ContractError::ProtocolFeeExceedsCap);
+        }
+        Ok(())
+    }
+
     /// Computes the fee split for a given total amount.
     ///
     /// Returns `(creator_amount, protocol_amount)`. Remainder from integer division
@@ -710,15 +724,7 @@ impl CreatorKeysContract {
         protocol_bps: u32,
     ) -> Result<(), ContractError> {
         admin.require_auth();
-        let Some(sum) = creator_bps.checked_add(protocol_bps) else {
-            return Err(ContractError::InvalidFeeConfig);
-        };
-        if sum != fee::BPS_MAX {
-            return Err(ContractError::InvalidFeeConfig);
-        }
-        if protocol_bps > fee::PROTOCOL_BPS_MAX {
-            return Err(ContractError::ProtocolFeeExceedsCap);
-        }
+        fee::assert_valid_fee_bps(creator_bps, protocol_bps)?;
 
         let config = fee::FeeConfig {
             creator_bps,

--- a/creator-keys/tests/quote_supply_edge_transitions.rs
+++ b/creator-keys/tests/quote_supply_edge_transitions.rs
@@ -17,7 +17,10 @@ fn test_buy_quote_deterministic_across_zero_supply_transition() {
     let buyer = Address::generate(&env);
 
     let q_before = client.get_buy_quote(&creator);
-    assert!(q_before.total_amount >= 0, "buy quote total must be bounded");
+    assert!(
+        q_before.total_amount >= 0,
+        "buy quote total must be bounded"
+    );
     client.buy_key(&creator, &buyer, &q_before.total_amount);
 
     // Transition back to zero supply.
@@ -41,5 +44,8 @@ fn test_sell_quote_zero_supply_boundary_is_rejected() {
     let holder = Address::generate(&env);
 
     let err = client.try_get_sell_quote(&creator, &holder);
-    assert!(err.is_err(), "zero-supply holder must not receive sell quote");
+    assert!(
+        err.is_err(),
+        "zero-supply holder must not receive sell quote"
+    );
 }

--- a/creator-keys/tests/quote_supply_edge_transitions.rs
+++ b/creator-keys/tests/quote_supply_edge_transitions.rs
@@ -1,0 +1,45 @@
+//! Regression coverage for quote outputs across supply edge transitions.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
+use soroban_sdk::{testutils::Address as _, Address};
+
+#[test]
+fn test_buy_quote_deterministic_across_zero_supply_transition() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 100_i128, 9000, 1000);
+
+    let creator = register_test_creator(&env, &client, "edge1");
+    let buyer = Address::generate(&env);
+
+    let q_before = client.get_buy_quote(&creator);
+    assert!(q_before.total_amount >= 0, "buy quote total must be bounded");
+    client.buy_key(&creator, &buyer, &q_before.total_amount);
+
+    // Transition back to zero supply.
+    client.sell_key(&creator, &buyer);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+
+    let q_after = client.get_buy_quote(&creator);
+    assert_eq!(q_before.price, q_after.price);
+    assert_eq!(q_before.creator_fee, q_after.creator_fee);
+    assert_eq!(q_before.protocol_fee, q_after.protocol_fee);
+    assert_eq!(q_before.total_amount, q_after.total_amount);
+}
+
+#[test]
+fn test_sell_quote_zero_supply_boundary_is_rejected() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 100_i128, 9000, 1000);
+
+    let creator = register_test_creator(&env, &client, "edge2");
+    let holder = Address::generate(&env);
+
+    let err = client.try_get_sell_quote(&creator, &holder);
+    assert!(err.is_err(), "zero-supply holder must not receive sell quote");
+}

--- a/docs/quote-math-refactor-guidelines.md
+++ b/docs/quote-math-refactor-guidelines.md
@@ -1,0 +1,28 @@
+# Quote Math Refactor Guidelines
+
+Use this checklist when changing buy/sell quote math paths.
+
+## Invariants Checklist
+
+1. Preserve deterministic output for identical inputs before and after state transitions.
+2. Keep totals bounded: buy quote `total_amount >= price`, sell quote `total_amount <= price`.
+3. Preserve fee accounting identity:
+   - Buy path: `total_amount = price + creator_fee + protocol_fee`
+   - Sell path: `total_amount = price - creator_fee - protocol_fee`
+4. Maintain zero-supply boundary behavior:
+   - Buy quote at zero supply is valid and deterministic.
+   - Sell quote without holder balance remains rejected.
+5. Keep rounding behavior stable (`protocol_fee` floor, remainder to creator).
+
+## Test Update Checklist
+
+1. Add or update regression tests that cross supply edges (`0 -> 1 -> 0`).
+2. Include at least one zero-supply boundary case.
+3. Cover both quote determinism and boundedness assertions.
+4. Update snapshot tests when expected outputs intentionally change.
+
+## Implementation Notes
+
+1. Reuse shared helpers (`normalize_quote_amount`, fee helpers) instead of duplicating math.
+2. Keep error mapping stable for callers and indexers.
+3. Document externally visible quote behavior changes in docs and PR notes.

--- a/docs/storage-key-invariants.md
+++ b/docs/storage-key-invariants.md
@@ -36,6 +36,15 @@ pub enum DataKey {
 | `AdminAddress`                 | Global             | `Address`        | Protocol admin address for configuration                   |
 | `ProtocolFeeRecipient`         | Global             | `Address`        | Protocol fee recipient address                             |
 
+### Fee Configuration Storage-Key Notes
+
+| Field | Storage Key | Read Ownership | Write Ownership |
+| ----- | ----------- | -------------- | --------------- |
+| Protocol fee split (`creator_bps`, `protocol_bps`) | `DataKey::FeeConfig` (`constants::storage::FEE_CONFIG`) | `get_fee_config`, `get_protocol_fee_view`, `get_creator_fee_bps`, `get_creator_treasury_share`, quote methods through shared readers | `set_fee_config` (admin-auth only) |
+| Protocol fee recipient | `DataKey::ProtocolFeeRecipient` (`constants::storage::PROTOCOL_FEE_RECIPIENT`) | `get_protocol_fee_recipient` | `set_protocol_fee_recipient` (admin-auth only) |
+
+`set_fee_config` uses the shared `fee::assert_valid_fee_bps` guard to keep key writes aligned with the current constants (`BPS_MAX = 10_000`, `PROTOCOL_BPS_MAX = 5_000`) before persisting the config.
+
 ## Storage Invariants
 
 These invariants must hold true after every contract operation:


### PR DESCRIPTION
## Description
Implements the four scoped items in one focused PR: quote edge-transition regression coverage, shared safe bps validation helper usage, storage-key fee configuration notes, and contributor guidance for quote math refactors.

Closes #234
Closes #236
Closes #238
Closes #239

## Changes proposed

### What were you told to do?
Address four open issues by adding quote regression coverage around supply edge transitions, documenting fee storage-key mapping/ownership, introducing shared bps range validation in config update paths, and adding contributor guidance for quote math refactors linked from CONTRIBUTING.

### What did I do?
#### Quote + fee validation updates
- Added creator-keys/tests/quote_supply_edge_transitions.rs with deterministic quote assertions across 