### PR TITLE
fix: added protocol config read docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ For guidance on writing deterministic quote tests, see [docs/deterministic-quote
 - **[Storage Key Invariants](./docs/storage-key-invariants.md)**: Storage model, key structure, and invariants that must be maintained across all operations
 - **[Deterministic Quote Tests](./docs/deterministic-quote-tests.md)**: Guide for writing tests for quote operations with the fixed price model
 - **[Fee Assumptions](./docs/fee-assumptions.md)**: Fee split logic, rounding behavior, and integration points
+- **[Read-only Methods](./docs/read-only-methods.md)**: Return value semantics, units, and edge-case behaviour for every `get_*` / `is_*` entrypoint including all bps fields
 - **[Error Codes](./docs/error-codes.md)**: Contract error reference with causes and expected caller behavior
 
 For testnet deployment steps, required CLI setup, and the release checklist used for contract updates, see [docs/stellar-testnet-deployment.md](./docs/stellar-testnet-deployment.md). For **wasm artifact** naming, retention, and metadata, see [docs/deploy-artifacts.md](./docs/deploy-artifacts.md). For how **clients and servers** should depend on contract read surfaces and events, see [docs/contract-consumer-boundaries.md](./docs/contract-consumer-boundaries.md).

--- a/docs/read-only-methods.md
+++ b/docs/read-only-methods.md
@@ -194,8 +194,10 @@ Returns the fee configuration view scoped to a creator.
 
 ### `get_creator_fee_bps(creator: Address) → Result<u32, ContractError>`
 
-Returns the creator-facing basis-point share for a registered creator.
+Returns the creator-facing share of the protocol fee in basis points.
 
+- Unit: basis points (1 bps = 1/10000). Example: `9000` = 90%.
+- Valid range: `0–10000`. When a fee config is stored, `creator_bps + protocol_bps == 10000` always holds.
 - Returns `Err(ContractError::NotRegistered)` for unregistered creators.
 - Returns `Err(ContractError::FeeConfigNotSet)` if no protocol fee config exists.
 
@@ -203,9 +205,22 @@ Returns the creator-facing basis-point share for a registered creator.
 
 ### `get_creator_treasury_share(creator: Address) → Result<u32, ContractError>`
 
-Alias for `get_creator_fee_bps`. Returns the creator-facing bps from the global fee config.
+Alias for `get_creator_fee_bps`. Returns the same creator-facing bps value from the global fee config.
 
+- Unit and range: identical to `get_creator_fee_bps` (basis points, `0–10000`).
 - Same error conditions as `get_creator_fee_bps`.
+
+---
+
+### `get_protocol_treasury_share_bps(env: Env) → Result<u32, ContractError>`
+
+Returns the protocol treasury share from the global fee configuration in basis points.
+
+- Unit: basis points (1 bps = 1/10000). Example: `500` = 5%.
+- Valid range: `0–5000`. The protocol share is capped at `PROTOCOL_BPS_MAX` (`5000`) by `set_fee_config`.
+- When a fee config is stored, `creator_bps + protocol_bps == 10000` always holds, so `protocol_bps` is at most half the total.
+- Returns `Err(ContractError::FeeConfigNotSet)` if no protocol fee config has been stored.
+- Does not require a creator argument — reads directly from the global protocol config.
 
 ---
 


### PR DESCRIPTION
## Documentation Updates — Read-Only Methods

### Changes

#### `docs/read-only-methods.md`
- Added missing entry:
  - `get_protocol_treasury_share_bps`
- Expanded existing entries:
  - `get_creator_fee_bps`
  - `get_creator_treasury_share`
- Improvements include:
  - स्पष्ट unit definition: **basis points (bps = 1/10000)**
  - Defined valid ranges for all values
  - Documented invariant:
    - `creator_bps + protocol_bps == 10000`

#### `CONTRIBUTING.md`
- Added link to `docs/read-only-methods.md`
- Included in documentation reference list alongside:
  - Fee Assumptions
  - Error Codes

---

Closes #218 