### PR TITLE
test: add creator fee bps update read coverage

### DIFF
--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -37,3 +37,26 @@ fn test_get_creator_fee_bps_is_read_only() {
 
     assert_eq!(first, second);
 }
+
+#[test]
+fn test_get_creator_fee_bps_tracks_fee_config_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"));
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    let before_update = client.get_creator_fee_bps(&creator);
+    assert_eq!(before_update, 9000);
+
+    client.set_fee_config(&admin, &7500u32, &2500u32);
+
+    let after_update = client.get_creator_fee_bps(&creator);
+    assert_eq!(after_update, 7500);
+    assert_ne!(after_update, before_update);
+}


### PR DESCRIPTION
## Description
Add a focused regression test that verifies `get_creator_fee_bps` returns the latest stored creator fee basis points immediately after a fee config update.

Closes #270

## Changes proposed

### What were you told to do?
Add a unit test that reads the creator fee bps before and after a fee config update, confirms the getter returns the updated value, and keeps the scope on the read method rather than quote outputs.

### What did I do?
#### Creator fee bps regression coverage
- Added a dedicated `get_creator_fee_bps` test that reads the initial configured value, updates the fee config, and verifies the getter returns the new basis points.
- Asserted that the pre-update value is no longer returned after the config change.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
Validated with `cargo test -p creator-keys --test creator_fee_bps`.
