### PR TITLE
test: add holder count regression for full exits

### DIFF
--- a/creator-keys/tests/sell_key.rs
+++ b/creator-keys/tests/sell_key.rs
@@ -112,3 +112,21 @@ fn test_sell_full_exit_then_rebuy_updates_state() {
     assert_eq!(client.get_key_balance(&creator, &trader), 1);
     assert_eq!(client.get_creator_holder_count(&creator), 1);
 }
+
+#[test]
+fn test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy() {
+    let env = test_env_with_auths();
+    set_test_timestamp(&env, DEFAULT_TEST_TIMESTAMP);
+    let (client, creator) = setup(&env);
+    let trader = Address::generate(&env);
+
+    client.buy_key(&creator, &trader, &100_i128);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+
+    client.sell_key(&creator, &trader);
+    assert_eq!(client.get_creator_holder_count(&creator), 0);
+
+    let supply_after_rebuy = client.buy_key(&creator, &trader, &100_i128);
+    assert_eq!(supply_after_rebuy, 1);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+}


### PR DESCRIPTION
## Description
Add a focused regression test for the holder-count transition when the final holder exits, ensuring the count returns to zero and recovers correctly on a later buy.

Closes #272

## Changes proposed

### What were you told to do?
Add a buy/sell regression test where a single holder buys keys, sells all of them, verifies holder count returns to zero, and then confirms a later buy succeeds and increments the holder count back to one.

### What did I do?
#### Holder count regression coverage
- Added a dedicated sell-flow regression test using the existing test fixtures.
- Asserted that the creator holder count is `1` after the initial buy, `0` after the full exit, and `1` again after the next buy succeeds.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
Validated with `cargo test -p creator-keys --test sell_key`.
