### PR TITLE
test: add unit test for treasury address read after admin update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .DS_Store
 .soroban/
+claude.md

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -420,6 +420,27 @@ fn test_get_treasury_address_persists_across_reads() {
 }
 
 #[test]
+fn test_get_treasury_address_returns_updated_value_after_admin_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury_old = Address::generate(&env);
+    let treasury_new = Address::generate(&env);
+
+    client.set_treasury_address(&admin, &treasury_old);
+    assert_eq!(client.get_treasury_address(), Some(treasury_old.clone()));
+
+    client.set_treasury_address(&admin, &treasury_new);
+    let result = client.get_treasury_address();
+
+    assert_eq!(result, Some(treasury_new));
+    assert_ne!(result, Some(treasury_old));
+}
+
+#[test]
 fn test_get_buy_quote_success() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Fixes #283

## What changed
- Added `test_get_treasury_address_returns_updated_value_after_admin_update` unit test in `creator-keys/src/test.rs`
- Added `claude.md` to `.gitignore`

## Why
The treasury address read was tested for initial set and persistence, but not for the sequence of reading after an admin updates the value. This confirms the storage read reflects the updated value immediately and the old address is no longer returned.

## How to test
- `cargo test test_get_treasury_address_returns_updated_value_after_admin_update` — passes

Closes #283