### PR TITLE
test: add assert_no_events helper and apply to failed transactions

### DIFF
--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -191,6 +191,7 @@ fn test_duplicate_registration_fails() {
     // Second registration should fail with AlreadyRegistered error
     let result = client.try_register_creator(&creator, &handle);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
+    assert_no_events(&env);
 }
 
 #[test]
@@ -208,6 +209,7 @@ fn test_buy_key_fails_if_not_registered() {
 
     let result = client.try_buy_key(&creator, &buyer, &100);
     assert_eq!(result, Err(Ok(ContractError::NotRegistered)));
+    assert_no_events(&env);
 }
 
 #[test]
@@ -291,6 +293,7 @@ fn test_buy_key_insufficient_payment() {
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99);
     assert_eq!(result, Err(Ok(ContractError::InsufficientPayment)));
+    assert_no_events(&env);
 }
 
 #[test]
@@ -303,9 +306,11 @@ fn test_set_key_price_invalid_amount() {
     let admin = Address::generate(&env);
     let result = client.try_set_key_price(&admin, &0);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
+    assert_no_events(&env);
 
     let result = client.try_set_key_price(&admin, &-1);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
+    assert_no_events(&env);
 }
 
 #[test]
@@ -841,5 +846,21 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
     assert_eq!(
         numeric_fields,
         &["supply", "holder_count", "creator_bps", "protocol_bps"]
+    );
+}
+
+/// Asserts that no events were emitted during the most recent contract call.
+///
+/// In the Soroban test environment, `env.events().all()` returns events from
+/// the most recent top-level invocation only. This helper confirms that the
+/// event log for the last call is empty, typically used to verify that failed
+/// transactions did not leave side-effect artifacts in the event stream.
+fn assert_no_events(env: &Env) {
+    let all_events = env.events().all();
+    assert_eq!(
+        all_events.len(),
+        0,
+        "Expected no events to be emitted, but found: {:?}",
+        all_events
     );
 }


### PR DESCRIPTION
## Summary

- Added a new test helper `assert_no_events(&Env)` in `creator-keys/src/test.rs`.
- Applied the helper to existing failed transaction tests to explicitly verify that no side-effect events are emitted on contract errors.
- Tests updated:
    - `test_duplicate_registration_fails`
    - `test_buy_key_fails_if_not_registered`
    - `test_buy_key_insufficient_payment`
    - `test_set_key_price_invalid_amount`

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (All 89 tests passed)

## Checklist

- [ ] Linked issue or backlog item
- [x] Contract behavior and invariants are described clearly
- [ ] Docs updated if contract interfaces or workflows changed
- [x] Scope stays limited to one contract concern (Event validation)

## Linked Issues

Close #356 
Close #321 
Close #320 
Close #318