### PR TITLE
Issue 349 event payload builder

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -41,8 +41,14 @@ pub const REGISTER_EVENT_DATA_FIELDS: [&str; 6] = [
     "protocol_bps",
 ];
 
+/// Number of fields in the registration event data payload.
+pub const REGISTER_EVENT_FIELD_COUNT: usize = REGISTER_EVENT_DATA_FIELDS.len();
+
 /// Stable field order for buy event tuple payloads.
 pub const BUY_EVENT_DATA_FIELDS: [&str; 2] = ["supply", "payment"];
+
+/// Number of fields in the buy event data payload.
+pub const BUY_EVENT_FIELD_COUNT: usize = BUY_EVENT_DATA_FIELDS.len();
 
 /// Stable registration event payload for downstream indexers.
 ///

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -305,10 +305,7 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     assert_eq!(topics.creator, fixture.creator);
     assert_eq!(topics.actor, buyer);
 
-    let expected = BuyEventPayloadBuilder::new()
-        .supply(1)
-        .payment(150)
-        .build();
+    let expected = BuyEventPayloadBuilder::new().supply(1).payment(150).build();
 
     assert_eq!(payload.supply, expected.0);
     assert_eq!(payload.payment, expected.1);

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -104,7 +104,7 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
 fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: usize) {
     let data_vec: Vec<Val> = event.2.clone().into_val(env);
     assert_eq!(
-        data_vec.len(),
+        data_vec.len() as usize,
         expected,
         "expected event to have {} fields, got {}: {:?}",
         expected,

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -101,7 +101,7 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     );
 }
 
-fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: u32) {
+fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: usize) {
     let data_vec: Vec<Val> = event.2.clone().into_val(env);
     assert_eq!(
         data_vec.len(),

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -101,7 +101,7 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     );
 }
 
-fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: usize) {
+fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: u32) {
     let data_vec: Vec<Val> = event.2.clone().into_val(env);
     assert_eq!(
         data_vec.len(),
@@ -156,7 +156,11 @@ fn test_register_creator_event_data_is_indexer_friendly() {
     assert_eq!(payload.protocol_bps, 0);
 
     // Ensure the event contains exactly the documented number of fields.
-    assert_event_field_count(last, &env, creator_keys::events::REGISTER_EVENT_FIELD_COUNT);
+    assert_event_field_count(
+        &last,
+        &env,
+        creator_keys::events::REGISTER_EVENT_FIELD_COUNT,
+    );
 }
 
 #[test]
@@ -225,7 +229,7 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     let all_events = env.events().all();
     let last_event = all_events.last().unwrap();
     assert_event_field_count(
-        last_event,
+        &last_event,
         &env,
         creator_keys::events::BUY_EVENT_FIELD_COUNT,
     );

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -101,6 +101,18 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     );
 }
 
+fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: usize) {
+    let data_vec: Vec<Val> = event.2.clone().into_val(env);
+    assert_eq!(
+        data_vec.len(),
+        expected,
+        "expected event to have {} fields, got {}: {:?}",
+        expected,
+        data_vec.len(),
+        data_vec
+    );
+}
+
 #[test]
 fn test_register_creator_emits_event() {
     let env = Env::default();
@@ -142,6 +154,9 @@ fn test_register_creator_event_data_is_indexer_friendly() {
     assert_eq!(payload.holder_count, 0);
     assert_eq!(payload.creator_bps, 0);
     assert_eq!(payload.protocol_bps, 0);
+
+    // Ensure the event contains exactly the documented number of fields.
+    assert_event_field_count(last, &env, creator_keys::events::REGISTER_EVENT_FIELD_COUNT);
 }
 
 #[test]
@@ -205,6 +220,11 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     assert_eq!(topics.actor, buyer);
     assert_eq!(payload.supply, 1);
     assert_eq!(payload.payment, 150);
+
+    // Ensure the buy event contains exactly the documented number of fields.
+    let all_events = env.events().all();
+    let last_event = all_events.last().unwrap();
+    assert_event_field_count(last_event, &env, creator_keys::events::BUY_EVENT_FIELD_COUNT);
 }
 
 #[test]

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -101,18 +101,6 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     );
 }
 
-fn assert_event_field_count(event: &(Address, Vec<Val>, Val), env: &Env, expected: usize) {
-    let data_vec: Vec<Val> = event.2.clone().into_val(env);
-    assert_eq!(
-        data_vec.len() as usize,
-        expected,
-        "expected event to have {} fields, got {}: {:?}",
-        expected,
-        data_vec.len(),
-        data_vec
-    );
-}
-
 #[test]
 fn test_register_creator_emits_event() {
     let env = Env::default();
@@ -154,13 +142,6 @@ fn test_register_creator_event_data_is_indexer_friendly() {
     assert_eq!(payload.holder_count, 0);
     assert_eq!(payload.creator_bps, 0);
     assert_eq!(payload.protocol_bps, 0);
-
-    // Ensure the event contains exactly the documented number of fields.
-    assert_event_field_count(
-        &last,
-        &env,
-        creator_keys::events::REGISTER_EVENT_FIELD_COUNT,
-    );
 }
 
 #[test]
@@ -224,15 +205,6 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     assert_eq!(topics.actor, buyer);
     assert_eq!(payload.supply, 1);
     assert_eq!(payload.payment, 150);
-
-    // Ensure the buy event contains exactly the documented number of fields.
-    let all_events = env.events().all();
-    let last_event = all_events.last().unwrap();
-    assert_event_field_count(
-        &last_event,
-        &env,
-        creator_keys::events::BUY_EVENT_FIELD_COUNT,
-    );
 }
 
 #[test]

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -101,6 +101,103 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     );
 }
 
+/// Builder for constructing expected CreatorRegisteredEvent payloads in tests.
+///
+/// This helper simplifies building the full expected event payload struct
+/// from named parameters, making assertions more readable and easier to
+/// update when the schema changes.
+struct CreatorRegisteredEventBuilder {
+    creator: Option<Address>,
+    handle: Option<String>,
+    supply: u32,
+    holder_count: u32,
+    creator_bps: u32,
+    protocol_bps: u32,
+}
+
+impl CreatorRegisteredEventBuilder {
+    fn new() -> Self {
+        Self {
+            creator: None,
+            handle: None,
+            supply: 0,
+            holder_count: 0,
+            creator_bps: 0,
+            protocol_bps: 0,
+        }
+    }
+
+    fn creator(mut self, creator: Address) -> Self {
+        self.creator = Some(creator);
+        self
+    }
+
+    fn handle(mut self, handle: String) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+
+    fn supply(mut self, supply: u32) -> Self {
+        self.supply = supply;
+        self
+    }
+
+    fn holder_count(mut self, holder_count: u32) -> Self {
+        self.holder_count = holder_count;
+        self
+    }
+
+    fn creator_bps(mut self, creator_bps: u32) -> Self {
+        self.creator_bps = creator_bps;
+        self
+    }
+
+    fn protocol_bps(mut self, protocol_bps: u32) -> Self {
+        self.protocol_bps = protocol_bps;
+        self
+    }
+
+    fn build(self) -> events::CreatorRegisteredEvent {
+        events::CreatorRegisteredEvent {
+            creator: self.creator.expect("creator must be set"),
+            handle: self.handle.expect("handle must be set"),
+            supply: self.supply,
+            holder_count: self.holder_count,
+            creator_bps: self.creator_bps,
+            protocol_bps: self.protocol_bps,
+        }
+    }
+}
+
+/// Builder for constructing expected buy event payloads in tests.
+struct BuyEventPayloadBuilder {
+    supply: u32,
+    payment: i128,
+}
+
+impl BuyEventPayloadBuilder {
+    fn new() -> Self {
+        Self {
+            supply: 0,
+            payment: 0,
+        }
+    }
+
+    fn supply(mut self, supply: u32) -> Self {
+        self.supply = supply;
+        self
+    }
+
+    fn payment(mut self, payment: i128) -> Self {
+        self.payment = payment;
+        self
+    }
+
+    fn build(self) -> (u32, i128) {
+        (self.supply, self.payment)
+    }
+}
+
 #[test]
 fn test_register_creator_emits_event() {
     let env = Env::default();
@@ -136,12 +233,16 @@ fn test_register_creator_event_data_is_indexer_friendly() {
     let last = events.last().unwrap();
     let payload: events::CreatorRegisteredEvent = last.2.into_val(&env);
 
-    assert_eq!(payload.creator, fixture.creator);
-    assert_eq!(payload.handle, handle);
-    assert_eq!(payload.supply, 0);
-    assert_eq!(payload.holder_count, 0);
-    assert_eq!(payload.creator_bps, 0);
-    assert_eq!(payload.protocol_bps, 0);
+    let expected = CreatorRegisteredEventBuilder::new()
+        .creator(fixture.creator)
+        .handle(handle)
+        .supply(0)
+        .holder_count(0)
+        .creator_bps(0)
+        .protocol_bps(0)
+        .build();
+
+    assert_eq!(payload, expected);
 }
 
 #[test]
@@ -203,8 +304,14 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     assert_eq!(topics.event_name, events::BUY_EVENT_NAME);
     assert_eq!(topics.creator, fixture.creator);
     assert_eq!(topics.actor, buyer);
-    assert_eq!(payload.supply, 1);
-    assert_eq!(payload.payment, 150);
+
+    let expected = BuyEventPayloadBuilder::new()
+        .supply(1)
+        .payment(150)
+        .build();
+
+    assert_eq!(payload.supply, expected.0);
+    assert_eq!(payload.payment, expected.1);
 }
 
 #[test]

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -224,7 +224,11 @@ fn test_buy_key_event_payload_fields_are_validated_from_fixture() {
     // Ensure the buy event contains exactly the documented number of fields.
     let all_events = env.events().all();
     let last_event = all_events.last().unwrap();
-    assert_event_field_count(last_event, &env, creator_keys::events::BUY_EVENT_FIELD_COUNT);
+    assert_event_field_count(
+        last_event,
+        &env,
+        creator_keys::events::BUY_EVENT_FIELD_COUNT,
+    );
 }
 
 #[test]


### PR DESCRIPTION
closes #349 
--
This PR introduces fluent builder helpers for constructing expected event payloads in test assertions, resolving #349. The `CreatorRegisteredEventBuilder` and `BuyEventPayloadBuilder` structs replace inline field construction with chainable, named-parameter methods, making test assertions more readable and significantly easier to maintain when event schemas change. The builders are applied to two existing test cases (`test_register_creator_event_data_is_indexer_friendly` and `test_buy_key_event_payload_fields_are_validated_from_fixture`), demonstrating how the approach scales across the test suite while keeping the test module implementation self-contained.