### PR TITLE
test: add regression test for minimum handle length

### DIFF
--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -22,7 +22,7 @@ fn test_register_creator_minimum_handle_length_success() {
 
     // State assertion: after a successful call, storage and derived views match expectations
     assert!(client.is_creator_registered(&creator));
-    let profile = client.get_creator(&creator).unwrap();
+    let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
 }
 

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -1,0 +1,47 @@
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, test_env_with_auths};
+use creator_keys::{ContractError, HANDLE_LEN_MIN};
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+#[test]
+fn test_register_creator_minimum_handle_length_success() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let creator = Address::generate(&env);
+
+    // Create a handle of exactly HANDLE_LEN_MIN characters
+    let handle_bytes = [b'a'; HANDLE_LEN_MIN as usize];
+    let handle_str = core::str::from_utf8(&handle_bytes).unwrap();
+    let handle = String::from_str(&env, handle_str);
+
+    let result = client.try_register_creator(&creator, &handle);
+
+    // Happy path: the function succeeds
+    assert_eq!(result, Ok(Ok(())));
+
+    // State assertion: after a successful call, storage and derived views match expectations
+    assert!(client.is_creator_registered(&creator));
+    let profile = client.get_creator(&creator).unwrap();
+    assert_eq!(profile.handle, handle);
+}
+
+#[test]
+fn test_register_creator_below_minimum_handle_length_fails() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let creator = Address::generate(&env);
+
+    // Create a handle one character below HANDLE_LEN_MIN
+    let handle_bytes = [b'a'; (HANDLE_LEN_MIN - 1) as usize];
+    let handle_str = core::str::from_utf8(&handle_bytes).unwrap();
+    let handle = String::from_str(&env, handle_str);
+
+    let result = client.try_register_creator(&creator, &handle);
+
+    // Error case: expected failure
+    assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
+
+    // State assertion: failed calls do not leave partial state behind
+    assert!(!client.is_creator_registered(&creator));
+}


### PR DESCRIPTION
## Summary
This PR adds regression testing to cover the minimum boundary of the handle validation during creator registration. While the maximum and empty-string boundaries were previously tested, this ensures that the shortest allowed handle is accepted without error.

## Changes
- **Added minimum length success test:** Registers a creator with a handle of exactly `HANDLE_LEN_MIN` characters and asserts that the registration succeeds and the state is updated correctly.
- **Added below-minimum length failure test:** Attempts to register a creator with a handle of `HANDLE_LEN_MIN - 1` characters and asserts it is cleanly rejected with `ContractError::HandleTooShort`.
- **Dynamic Constant Reference:** Both tests import and reference the `HANDLE_LEN_MIN` constant directly from the contract to size the byte arrays dynamically, avoiding hardcoded values.

## Related Issues
Closes #367

## Checklist
- [x] Happy-path test exists for the exact minimum valid length.
- [x] Failure path asserts no unintended state is stored when the handle is too short.
- [x] Tests use `contract_test_env` helpers where possible.
- [x] Code passes `cargo test --workspace` locally.
