### PR TITLE
Add contracts pre-PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,9 @@
 ## Checklist
 
 - [ ] Linked issue or backlog item
-- [ ] Contract behavior and invariants are described clearly
-- [ ] Docs updated if contract interfaces or workflows changed
-- [ ] Scope stays limited to one contract concern
+- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
+- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
+- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
+- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
+- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
+- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes


### PR DESCRIPTION
Summary
- Adds a contracts-specific pre-PR checklist to the pull request template so contributors have a concrete review-readiness guide before opening changes.
- The checklist calls out the expected verification commands, test coverage expectations, storage-layout safety review, event compatibility review, documentation updates, and scope hygiene for this contracts repo.

Issue
- Closes #372

Changes
- Expanded `.github/PULL_REQUEST_TEMPLATE.md` with actionable checklist items for `creator-keys` tests and failure paths.
- Added explicit checklist coverage for `cargo fmt`, `cargo clippy`, and `cargo test` validation.
- Added storage safety and event compatibility reminders linked to the existing contracts documentation.
- Clarified that unrelated formatting, lockfile, generated artifact, and dependency changes should stay out of scoped contract PRs.

Validation
- Ran `git diff --check upstream/main...HEAD`.
- Did not run cargo fmt, clippy, or tests because this is a Markdown-only PR template update with no Rust code changes.

Notes
- Fork relationship verified: `kitWarse/accesslayer-contracts` is a fork of `accesslayerorg/accesslayer-contracts`.
- Branch was rebased onto the latest fetched `upstream/main` before pushing.