### PR TITLE
docs: document read-only constraint of get_key_name method

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1039,8 +1039,9 @@ impl CreatorKeysContract {
 
     /// Read-only view: returns the display name for a creator's key.
     ///
-    /// Returns the creator's handle for registered creators. Fails with
-    /// [`ContractError::NotRegistered`] if the creator is not registered.
+    /// Does not mutate the contract state. Returns the creator's handle for
+    /// registered creators. Fails with [`ContractError::NotRegistered`] if
+    /// the creator is not registered.
     pub fn get_key_name(env: Env, creator: Address) -> Result<String, ContractError> {
         let profile = read_registered_creator_profile(&env, &creator)?;
         Ok(profile.handle)


### PR DESCRIPTION
I have verified the implementation of the read-only method and its corresponding unit tests. Everything is complete:

1. **Read-Only Method**: `get_key_name(env: Env, creator: Address) -> Result<String, ContractError>` is already implemented at lines [1044-1047 in creator-keys/src/lib.rs](file:///c:/Users/USER/Desktop/accesslayer-contracts/creator-keys/src/lib.rs#L1044-L1047). It queries persistent storage and returns the stored handle for a registered creator without mutating state.
2. **Tests**: A dedicated test file [key_name.rs](file:///c:/Users/USER/Desktop/accesslayer-contracts/creator-keys/tests/key_name.rs) tests successful reads and error conditions.
3. **Artifacts**: 
   - [task.md](file:///C:/Users/USER/.gemini/antigravity-ide/brain/b58ed0bc-1bb5-40bc-a949-968c1893b993/task.md) tracks the verification checklist.
   - [walkthrough.md](file:///C:/Users/USER/.gemini/antigravity-ide/brain/b58ed0bc-1bb5-40bc-a949-968c1893b993/walkthrough.md) documents the details.

closes #110 