### PR TITLE
closes #41 - Add shared fee_bounds constants module for fee default values

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -253,6 +253,19 @@ pub mod constants {
         pub const NAME: &str = "get_key_name";
         pub const SYMBOL: &str = "get_key_symbol";
     }
+
+    /// Default values for fee bounds used across validation paths and test fixtures.
+    ///
+    /// These constants represent the canonical starting point for a fee configuration.
+    /// Keeping them here ensures a single source of truth: any adjustment to the
+    /// default split only needs to happen in one place.
+    pub mod fee_bounds {
+        /// Default creator share in basis points (90%).
+        pub const DEFAULT_CREATOR_BPS: u32 = 9_000;
+
+        /// Default protocol share in basis points (10%).
+        pub const DEFAULT_PROTOCOL_BPS: u32 = 1_000;
+    }
 }
 
 /// Stable, non-optional view of the protocol fee configuration.


### PR DESCRIPTION
Closes #41 

## Summary

- Adds `constants::fee_bounds` as a lightweight, focused submodule inside the existing `constants` module
- Exports `DEFAULT_CREATOR_BPS = 9_000` and `DEFAULT_PROTOCOL_BPS = 1_000` as named constants
- Provides a single source of truth for fee bound defaults, replacing scattered magic numbers across validation paths and test fixtures

## Changes

`creator-keys/src/lib.rs`
- Added `pub mod fee_bounds` inside `pub mod constants` with two public constants:
  - `DEFAULT_CREATOR_BPS: u32 = 9_000` â€” default creator share (90%)
  - `DEFAULT_PROTOCOL_BPS: u32 = 1_000` â€” default protocol share (10%)
- No logic added to the constants module â€” constants only
- Module is importable via `crate::constants::fee_bounds::DEFAULT_CREATOR_BPS` / `DEFAULT_PROTOCOL_BPS`

## How it satisfies the acceptance criteria

| Criterion | How |
|-----------|-----|
| Fee bound defaults importable from one shared source | `use crate::constants::fee_bounds::{DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS}` |
| Constants easy to adjust centrally | Both values live in one place; changing the split updates every consumer |
| Module stays focused and lightweight | Pure `const` items only, no functions or logic |
