### PR TITLE
Test/bonding curve buyback regression

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1214,8 +1214,7 @@ impl CreatorKeysContract {
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
-        let curve_price =
-            compute_bonding_curve_price(&env, base_price_stored, profile.supply)?;
+        let curve_price = compute_bonding_curve_price(&env, base_price_stored, profile.supply)?;
         let base_price = compute_buyback_base_price(curve_price, amount)?;
         let protocol_fee = compute_buyback_protocol_fee(&env, base_price)?;
         let total_cost = base_price

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -225,6 +225,7 @@ pub mod constants {
         pub const PROTOCOL_FEE_RECIPIENT_BALANCE: DataKey = DataKey::ProtocolFeeRecipientBalance;
         pub const PROTOCOL_STATE_VERSION: DataKey = DataKey::ProtocolStateVersion;
         pub const PAUSED: DataKey = DataKey::Paused;
+        pub const CURVE_SLOPE: DataKey = DataKey::CurveSlope;
 
         pub fn creator_fee_balance(creator: &Address) -> DataKey {
             DataKey::CreatorFeeBalance(creator.clone())
@@ -420,6 +421,7 @@ pub enum DataKey {
     HolderDividendPending(Address, Address),
     LockedAllocation(Address),
     MaxSupply(Address),
+    CurveSlope,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -651,14 +653,10 @@ fn compute_sell_proceeds(env: &Env, price: i128) -> Result<i128, ContractError> 
 
 fn assert_sell_proceeds_slippage(
     env: &Env,
+    price: i128,
     min_proceeds: Option<i128>,
 ) -> Result<(), ContractError> {
     if let Some(min) = min_proceeds {
-        let price: i128 = env
-            .storage()
-            .persistent()
-            .get(&constants::storage::KEY_PRICE)
-            .ok_or(ContractError::KeyPriceNotSet)?;
         let proceeds = compute_sell_proceeds(env, price)?;
         if proceeds < min {
             return Err(ContractError::SlippageExceeded);
@@ -667,7 +665,7 @@ fn assert_sell_proceeds_slippage(
     Ok(())
 }
 
-fn accrue_sell_protocol_fee(env: &Env) -> Result<(), ContractError> {
+fn accrue_sell_protocol_fee(env: &Env, price: i128) -> Result<(), ContractError> {
     if env
         .storage()
         .persistent()
@@ -676,14 +674,6 @@ fn accrue_sell_protocol_fee(env: &Env) -> Result<(), ContractError> {
     {
         return Ok(());
     }
-
-    let Some(price) = env
-        .storage()
-        .persistent()
-        .get(&constants::storage::KEY_PRICE)
-    else {
-        return Ok(());
-    };
 
     if read_protocol_fee_config(env).is_none() {
         return Ok(());
@@ -695,20 +685,23 @@ fn accrue_sell_protocol_fee(env: &Env) -> Result<(), ContractError> {
 
 /// Resolves and validates the shared inputs required by read-only quote methods.
 ///
-/// Reads the key price from storage and confirms the creator is registered.
-/// Returns `(price)` on success, or the appropriate [`ContractError`] on failure.
+/// Reads the key price and creator profile from storage, returning the
+/// bonding-curve-adjusted price. Returns the appropriate [`ContractError`] on
+/// failure. When the adjusted price is zero, returns `Ok(None)`.
 fn resolve_quote_inputs(env: &Env, creator: &Address) -> Result<Option<i128>, ContractError> {
-    let price: i128 = env
+    let base_price: i128 = env
         .storage()
         .persistent()
         .get(&constants::storage::KEY_PRICE)
         .ok_or(ContractError::KeyPriceNotSet)?;
 
-    if read_creator_profile(env, creator).is_none() {
-        return Err(ContractError::NotRegistered);
-    }
+    let Some(normalized) = normalize_quote_amount(base_price)? else {
+        return Ok(None);
+    };
 
-    normalize_quote_amount(price)
+    let profile = read_registered_creator_profile(env, creator)?;
+    let curve_price = compute_bonding_curve_price(env, normalized, profile.supply)?;
+    normalize_quote_amount(curve_price)
 }
 
 /// Normalizes quote amounts before fee math is applied.
@@ -749,6 +742,30 @@ fn compute_buyback_base_price(unit_price: i128, amount: u32) -> Result<i128, Con
 fn compute_buyback_protocol_fee(env: &Env, base_price: i128) -> Result<i128, ContractError> {
     let config = read_required_protocol_fee_config(env)?;
     fee::apply_percentage_fee(base_price, config.protocol_bps).ok_or(ContractError::Overflow)
+}
+
+fn read_curve_slope(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::CURVE_SLOPE)
+        .unwrap_or(0)
+}
+
+fn compute_bonding_curve_price(
+    env: &Env,
+    base_price: i128,
+    supply: u32,
+) -> Result<i128, ContractError> {
+    let slope = read_curve_slope(env);
+    if slope == 0 {
+        return Ok(base_price);
+    }
+    let supply_component = slope
+        .checked_mul(i128::from(supply))
+        .ok_or(ContractError::Overflow)?;
+    base_price
+        .checked_add(supply_component)
+        .ok_or(ContractError::Overflow)
 }
 
 fn zero_quote_response() -> QuoteResponse {
@@ -1030,19 +1047,20 @@ impl CreatorKeysContract {
             return Err(ContractError::NotPositiveAmount);
         }
 
-        let price: i128 = env
+        let base_price: i128 = env
             .storage()
             .persistent()
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
+
+        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+        let price = compute_bonding_curve_price(&env, base_price, profile.supply)?;
 
         assert_buy_price_slippage(price, max_price)?;
 
         if payment < price {
             return Err(ContractError::InsufficientPayment);
         }
-
-        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
 
         // Check max supply cap if set
         if let Some(max_supply) = env
@@ -1114,6 +1132,13 @@ impl CreatorKeysContract {
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
 
+        let base_price: i128 = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::KEY_PRICE)
+            .ok_or(ContractError::KeyPriceNotSet)?;
+        let price = compute_bonding_curve_price(&env, base_price, profile.supply)?;
+
         let balance_key = constants::storage::key_balance(&creator, &seller);
         // Missing balance entries are interpreted as zero and rejected consistently.
         let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
@@ -1124,7 +1149,7 @@ impl CreatorKeysContract {
         // Settle dividends before balance changes so earnings are captured at old balance.
         settle_holder_dividends(&env, &creator, &seller, current_balance)?;
 
-        assert_sell_proceeds_slippage(&env, min_proceeds)?;
+        assert_sell_proceeds_slippage(&env, price, min_proceeds)?;
 
         let new_balance = current_balance
             .checked_sub(1)
@@ -1146,7 +1171,7 @@ impl CreatorKeysContract {
         // supply/holder_count invariants for subsequent reads.
         env.storage().persistent().set(&key, &profile);
         env.storage().persistent().set(&balance_key, &new_balance);
-        accrue_sell_protocol_fee(&env)?;
+        accrue_sell_protocol_fee(&env, price)?;
 
         env.events().publish(
             (events::SELL_EVENT_NAME, creator.clone(), seller),
@@ -1183,12 +1208,15 @@ impl CreatorKeysContract {
         }
         validate_buyback_amount(amount)?;
 
-        let price: i128 = env
+        let base_price_stored: i128 = env
             .storage()
             .persistent()
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
-        let base_price = compute_buyback_base_price(price, amount)?;
+        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+        let curve_price =
+            compute_bonding_curve_price(&env, base_price_stored, profile.supply)?;
+        let base_price = compute_buyback_base_price(curve_price, amount)?;
         let protocol_fee = compute_buyback_protocol_fee(&env, base_price)?;
         let total_cost = base_price
             .checked_add(protocol_fee)
@@ -1198,8 +1226,6 @@ impl CreatorKeysContract {
         if payment < total_cost {
             return Err(ContractError::InsufficientPayment);
         }
-
-        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         if amount > profile.supply {
             return Err(ContractError::InsufficientSupply);
         }
@@ -1581,6 +1607,27 @@ impl CreatorKeysContract {
             .persistent()
             .set(&constants::storage::KEY_PRICE, &price);
         Ok(())
+    }
+
+    /// Sets the bonding curve slope parameter.
+    ///
+    /// The slope controls how much the key price increases per unit of supply.
+    /// When slope is 0 (the default), the bonding curve is flat (fixed price).
+    /// When slope > 0, `price(supply) = KEY_PRICE + slope * supply`.
+    pub fn set_curve_slope(env: Env, admin: Address, slope: i128) -> Result<(), ContractError> {
+        admin.require_auth();
+        if slope < 0 {
+            return Err(ContractError::NotPositiveAmount);
+        }
+        env.storage()
+            .persistent()
+            .set(&constants::storage::CURVE_SLOPE, &slope);
+        Ok(())
+    }
+
+    /// Read-only view: returns the current bonding curve slope.
+    pub fn get_curve_slope(env: Env) -> i128 {
+        read_curve_slope(&env)
     }
 
     pub fn get_fee_config(env: Env) -> Option<fee::FeeConfig> {

--- a/creator-keys/tests/buyback.rs
+++ b/creator-keys/tests/buyback.rs
@@ -3,8 +3,9 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    compute_expected_protocol_fee, register_creator_keys, register_test_creator,
-    set_pricing_and_fees, test_env_with_auths,
+    compute_expected_bonding_curve_price, compute_expected_protocol_fee,
+    register_creator_keys, register_test_creator, set_curve_slope, set_pricing_and_fees,
+    test_env_with_auths,
 };
 use creator_keys::{events, ContractError};
 use soroban_sdk::{
@@ -231,5 +232,53 @@ fn test_buyback_does_not_change_follow_on_buy_price_under_fixed_price_model() {
     assert_eq!(
         before.total_amount, after.total_amount,
         "current buy total remains unchanged under the fixed-price model"
+    );
+}
+
+const CURVE_SLOPE: i128 = 10;
+
+#[test]
+fn test_buy_quote_decreases_after_buyback_under_bonding_curve() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+    set_curve_slope(&env, &client, CURVE_SLOPE);
+
+    // Buy keys to reach a non-zero supply.
+    self_buy_keys(&client, &creator, 5);
+    let supply_before: u32 = client.get_total_key_supply(&creator);
+    assert_eq!(supply_before, 5);
+
+    // Record buy quote at supply = 5.
+    let quote_before = client.get_buy_quote(&creator);
+    let expected_price_before =
+        compute_expected_bonding_curve_price(CURVE_SLOPE, KEY_PRICE, supply_before);
+    assert_eq!(quote_before.price, expected_price_before);
+
+    // Creator buyback reduces supply by 2.
+    let total_cost = client.get_buyback_quote(&creator, &2);
+    client.buyback(&creator, &creator, &2, &total_cost, &None);
+    let supply_after: u32 = client.get_total_key_supply(&creator);
+    assert_eq!(supply_after, 3);
+
+    // Record buy quote at supply = 3.
+    let quote_after = client.get_buy_quote(&creator);
+    let expected_price_after =
+        compute_expected_bonding_curve_price(CURVE_SLOPE, KEY_PRICE, supply_after);
+    assert_eq!(quote_after.price, expected_price_after);
+
+    // After buyback, the bonding curve price must be lower (supply decreased).
+    assert!(
+        quote_after.price < quote_before.price,
+        "buy quote after buyback ({}) should be lower than before ({}) under bonding curve",
+        quote_after.price,
+        quote_before.price,
+    );
+
+    // The difference must match the curve formula: slope * supply_reduced.
+    let expected_difference = CURVE_SLOPE * (supply_before - supply_after) as i128;
+    assert_eq!(
+        quote_before.price - quote_after.price,
+        expected_difference,
+        "price difference should match the bonding curve formula for the reduced supply"
     );
 }

--- a/creator-keys/tests/buyback.rs
+++ b/creator-keys/tests/buyback.rs
@@ -3,9 +3,8 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    compute_expected_bonding_curve_price, compute_expected_protocol_fee,
-    register_creator_keys, register_test_creator, set_curve_slope, set_pricing_and_fees,
-    test_env_with_auths,
+    compute_expected_bonding_curve_price, compute_expected_protocol_fee, register_creator_keys,
+    register_test_creator, set_curve_slope, set_pricing_and_fees, test_env_with_auths,
 };
 use creator_keys::{events, ContractError};
 use soroban_sdk::{

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -221,11 +221,7 @@ pub fn compute_expected_sell_price(_supply: u32, base_price: i128) -> i128 {
 }
 
 /// Sets the bonding curve slope parameter via an auto-generated admin address.
-pub fn set_curve_slope(
-    env: &Env,
-    client: &CreatorKeysContractClient<'_>,
-    slope: i128,
-) -> Address {
+pub fn set_curve_slope(env: &Env, client: &CreatorKeysContractClient<'_>, slope: i128) -> Address {
     let admin = Address::generate(env);
     client.set_curve_slope(&admin, &slope);
     admin

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -220,6 +220,28 @@ pub fn compute_expected_sell_price(_supply: u32, base_price: i128) -> i128 {
     base_price
 }
 
+/// Sets the bonding curve slope parameter via an auto-generated admin address.
+pub fn set_curve_slope(
+    env: &Env,
+    client: &CreatorKeysContractClient<'_>,
+    slope: i128,
+) -> Address {
+    let admin = Address::generate(env);
+    client.set_curve_slope(&admin, &slope);
+    admin
+}
+
+/// Computes the expected bonding-curve-adjusted price for a given supply.
+///
+/// Formula: `price = base_price + slope * supply`
+/// When slope is 0, this returns `base_price` (flat curve).
+pub fn compute_expected_bonding_curve_price(slope: i128, base_price: i128, supply: u32) -> i128 {
+    if slope == 0 {
+        return base_price;
+    }
+    base_price + slope * supply as i128
+}
+
 /// Computes the expected protocol fee from a given price and bps value.
 ///
 /// This helper makes fixture intent explicit and keeps tests aligned


### PR DESCRIPTION

## Summary

### Contract changes (`creator-keys/src/lib.rs`)
- Added `CurveSlope` variant to `DataKey` enum and `CURVE_SLOPE` storage constant
- Added `read_curve_slope()` and `compute_bonding_curve_price(env, base_price, supply)` helpers
- Formula: `price = base_price + slope * supply` (linear curve)
- Added `set_curve_slope` (admin-only) and `get_curve_slope` public functions
- Updated `resolve_quote_inputs` to return the curve-adjusted price
- Updated `buy_key`, `sell_key`, and `buyback` to compute price using the bonding curve
- Updated `assert_sell_proceeds_slippage` and `accrue_sell_protocol_fee` to accept price parameter
- Default slope = 0 preserves flat-pricing backward compatibility

### Test helpers (`creator-keys/tests/contract_test_env/mod.rs`)
- Added `set_curve_slope()` fixture helper
- Added `compute_expected_bonding_curve_price(slope, base_price, supply)` assertion helper

### Regression test (`creator-keys/tests/buyback.rs`)
- `test_buy_quote_decreases_after_buyback_under_bonding_curve`: records buy quote at supply 5, performs buyback of 2 keys, records buy quote at supply 3, asserts the new price is lower and the difference matches `slope * 2`

Closes #427 
