### PR TITLE
test: add regression tests for dividend distribution, buyback, and bonding curve (#444, #445, #446, #447)

### DIFF
--- a/creator-keys/tests/bonding_curve_preset_regression.rs
+++ b/creator-keys/tests/bonding_curve_preset_regression.rs
@@ -1,0 +1,207 @@
+//! Regression test for bonding curve preset pricing ordering (#446).
+//!
+//! A steeper bonding curve must always produce a higher buy price than a
+//! flatter curve at the same supply level. This test locks in the ordering
+//! so that a formula change cannot accidentally invert the relationship.
+//!
+//! Uses two different slope values to represent Linear (lower slope) vs
+//! Quadratic-like (higher slope) pricing behavior.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    compute_expected_bonding_curve_price, register_creator_keys, register_test_creator,
+    set_curve_slope, set_pricing_and_fees, test_env_with_auths,
+};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Address;
+
+const KEY_PRICE: i128 = 1_000;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;
+
+/// Lower slope representing Linear preset behavior.
+const LINEAR_SLOPE: i128 = 10;
+
+/// Higher slope representing steeper (Quadratic-like) curve behavior.
+const QUADRATIC_SLOPE: i128 = 100;
+
+/// Advance supply to exactly `target` by buying keys.
+fn advance_supply_to(
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    creator: &Address,
+    buyer: &Address,
+    target: u32,
+) {
+    let current = client.get_total_key_supply(creator);
+    for _ in current..target {
+        let quote = client.get_buy_quote(creator);
+        client.buy_key(creator, buyer, &quote.total_amount, &None);
+    }
+}
+
+#[test]
+fn test_steeper_curve_higher_at_supply_10() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let steeper_creator = register_test_creator(&env, &client, "steep");
+    let flatter_creator = register_test_creator(&env, &client, "flat");
+
+    set_curve_slope(&env, &client, QUADRATIC_SLOPE);
+    // Note: curve slope is global, so we test sequentially
+    // First test with steeper slope
+    let buyer = Address::generate(&env);
+    advance_supply_to(&client, &steeper_creator, &buyer, 10);
+    let quote_steeper = client.get_buy_quote(&steeper_creator);
+
+    // Change slope and test with flatter curve
+    set_curve_slope(&env, &client, LINEAR_SLOPE);
+    let buyer2 = Address::generate(&env);
+    advance_supply_to(&client, &flatter_creator, &buyer2, 10);
+    let quote_flatter = client.get_buy_quote(&flatter_creator);
+
+    assert!(
+        quote_steeper.price > quote_flatter.price,
+        "steeper curve ({}) must exceed flatter curve ({}) at supply 10",
+        quote_steeper.price,
+        quote_flatter.price,
+    );
+}
+
+#[test]
+fn test_steeper_curve_higher_at_supply_100() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let steeper_creator = register_test_creator(&env, &client, "steep");
+    let flatter_creator = register_test_creator(&env, &client, "flat");
+
+    // Test with steeper slope
+    set_curve_slope(&env, &client, QUADRATIC_SLOPE);
+    let buyer = Address::generate(&env);
+    advance_supply_to(&client, &steeper_creator, &buyer, 100);
+    let quote_steeper = client.get_buy_quote(&steeper_creator);
+
+    // Test with flatter slope
+    set_curve_slope(&env, &client, LINEAR_SLOPE);
+    let buyer2 = Address::generate(&env);
+    advance_supply_to(&client, &flatter_creator, &buyer2, 100);
+    let quote_flatter = client.get_buy_quote(&flatter_creator);
+
+    assert!(
+        quote_steeper.price > quote_flatter.price,
+        "steeper curve ({}) must exceed flatter curve ({}) at supply 100",
+        quote_steeper.price,
+        quote_flatter.price,
+    );
+}
+
+#[test]
+fn test_steeper_curve_higher_at_supply_1000() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let steeper_creator = register_test_creator(&env, &client, "steep");
+    let flatter_creator = register_test_creator(&env, &client, "flat");
+
+    // Test with steeper slope
+    set_curve_slope(&env, &client, QUADRATIC_SLOPE);
+    let buyer = Address::generate(&env);
+    advance_supply_to(&client, &steeper_creator, &buyer, 1000);
+    let quote_steeper = client.get_buy_quote(&steeper_creator);
+
+    // Test with flatter slope
+    set_curve_slope(&env, &client, LINEAR_SLOPE);
+    let buyer2 = Address::generate(&env);
+    advance_supply_to(&client, &flatter_creator, &buyer2, 1000);
+    let quote_flatter = client.get_buy_quote(&flatter_creator);
+
+    assert!(
+        quote_steeper.price > quote_flatter.price,
+        "steeper curve ({}) must exceed flatter curve ({}) at supply 1000",
+        quote_steeper.price,
+        quote_flatter.price,
+    );
+}
+
+#[test]
+fn test_steeper_curve_higher_at_supply_1() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let steeper_creator = register_test_creator(&env, &client, "steep");
+    let flatter_creator = register_test_creator(&env, &client, "flat");
+
+    // Test with steeper slope
+    set_curve_slope(&env, &client, QUADRATIC_SLOPE);
+    let buyer = Address::generate(&env);
+    advance_supply_to(&client, &steeper_creator, &buyer, 1);
+    let quote_steeper = client.get_buy_quote(&steeper_creator);
+
+    // Test with flatter slope
+    set_curve_slope(&env, &client, LINEAR_SLOPE);
+    let buyer2 = Address::generate(&env);
+    advance_supply_to(&client, &flatter_creator, &buyer2, 1);
+    let quote_flatter = client.get_buy_quote(&flatter_creator);
+
+    assert!(
+        quote_steeper.price > quote_flatter.price,
+        "steeper curve ({}) must exceed flatter curve ({}) at supply 1",
+        quote_steeper.price,
+        quote_flatter.price,
+    );
+}
+
+#[test]
+fn test_steeper_curve_price_grows_faster_with_supply() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let creator = register_test_creator(&env, &client, "test");
+
+    // Test with steeper slope
+    set_curve_slope(&env, &client, QUADRATIC_SLOPE);
+    let buyer = Address::generate(&env);
+
+    // At supply 1
+    advance_supply_to(&client, &creator, &buyer, 1);
+    let price_at_1 = client.get_buy_quote(&creator).price;
+
+    // At supply 10
+    advance_supply_to(&client, &creator, &buyer, 10);
+    let price_at_10 = client.get_buy_quote(&creator).price;
+
+    // At supply 100
+    advance_supply_to(&client, &creator, &buyer, 100);
+    let price_at_100 = client.get_buy_quote(&creator).price;
+
+    // Price should grow with supply
+    assert!(
+        price_at_10 > price_at_1,
+        "price at 10 ({}) should exceed price at 1 ({})",
+        price_at_10,
+        price_at_1,
+    );
+    assert!(
+        price_at_100 > price_at_10,
+        "price at 100 ({}) should exceed price at 10 ({})",
+        price_at_100,
+        price_at_10,
+    );
+
+    // The price difference should be proportional to the slope
+    let expected_price_at_1 = compute_expected_bonding_curve_price(QUADRATIC_SLOPE, KEY_PRICE, 1);
+    let expected_price_at_10 = compute_expected_bonding_curve_price(QUADRATIC_SLOPE, KEY_PRICE, 10);
+    let expected_price_at_100 =
+        compute_expected_bonding_curve_price(QUADRATIC_SLOPE, KEY_PRICE, 100);
+
+    assert_eq!(price_at_1, expected_price_at_1);
+    assert_eq!(price_at_10, expected_price_at_10);
+    assert_eq!(price_at_100, expected_price_at_100);
+}

--- a/creator-keys/tests/buyback_no_wallet_credit.rs
+++ b/creator-keys/tests/buyback_no_wallet_credit.rs
@@ -1,0 +1,231 @@
+//! Regression test for creator buyback not crediting any wallet key balance (#444).
+//!
+//! A buyback burns keys from total supply without crediting any wallet. This test
+//! confirms that after a buyback no wallet's balance has increased, distinguishing
+//! it from a regular buy.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Address;
+
+const KEY_PRICE: i128 = 1_000;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;
+
+fn setup(env: &soroban_sdk::Env) -> (creator_keys::CreatorKeysContractClient<'_>, Address) {
+    let (client, _) = register_creator_keys(env);
+    set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, creator)
+}
+
+/// Records all holder balances for a creator.
+fn record_balances(
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    creator: &Address,
+    holders: &[&Address],
+) -> Vec<u32> {
+    holders
+        .iter()
+        .map(|h| client.get_key_balance(creator, h))
+        .collect()
+}
+
+#[test]
+fn test_buyback_does_not_increase_any_wallet_balance() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+
+    // Create multiple holders with different balances
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+    let holder_c = Address::generate(&env);
+
+    // holder_a buys 3 keys
+    client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+
+    // holder_b buys 2 keys
+    client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+    client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+
+    // holder_c buys 1 key
+    client.buy_key(&creator, &holder_c, &KEY_PRICE, &None);
+
+    let holders = vec![&holder_a, &holder_b, &holder_c];
+    let balances_before = record_balances(&client, &creator, &holders);
+
+    // Creator buys 2 keys
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let total_balance_before: u32 = balances_before.iter().sum();
+
+    // Creator buyback 2 keys from their own balance
+    let total_cost = client.get_buyback_quote(&creator, &2);
+    client.buyback(&creator, &creator, &2, &total_cost, &None);
+
+    // Check balances after buyback
+    let balances_after = record_balances(&client, &creator, &holders);
+    let supply_after = client.get_total_key_supply(&creator);
+    let total_balance_after: u32 = balances_after.iter().sum();
+
+    // No holder's balance should have increased
+    for (i, (before, after)) in balances_before
+        .iter()
+        .zip(balances_after.iter())
+        .enumerate()
+    {
+        assert!(
+            *after <= *before,
+            "holder {} balance increased from {} to {} after buyback",
+            i,
+            before,
+            after
+        );
+    }
+
+    // Total supply should have decreased by the buyback amount
+    assert_eq!(
+        supply_after,
+        supply_before - 2,
+        "total supply should decrease by buyback amount"
+    );
+
+    // Total balances across all holders should remain unchanged
+    // (since the buyback only affects the creator's own balance)
+    assert_eq!(
+        total_balance_after, total_balance_before,
+        "total balances across all holders should not change"
+    );
+}
+
+#[test]
+fn test_buyback_creator_balance_decreases_no_others_change() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+
+    // Create holders
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    // holder_a buys 2 keys
+    client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+
+    // holder_b buys 1 key
+    client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+
+    // Creator buys 3 keys
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+
+    // Record all balances
+    let creator_balance_before = client.get_key_balance(&creator, &creator);
+    let holder_a_balance_before = client.get_key_balance(&creator, &holder_a);
+    let holder_b_balance_before = client.get_key_balance(&creator, &holder_b);
+    let supply_before = client.get_total_key_supply(&creator);
+
+    // Creator buyback 2 keys
+    let total_cost = client.get_buyback_quote(&creator, &2);
+    client.buyback(&creator, &creator, &2, &total_cost, &None);
+
+    // Check balances
+    let creator_balance_after = client.get_key_balance(&creator, &creator);
+    let holder_a_balance_after = client.get_key_balance(&creator, &holder_a);
+    let holder_b_balance_after = client.get_key_balance(&creator, &holder_b);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    // Creator's balance should decrease by buyback amount
+    assert_eq!(
+        creator_balance_after,
+        creator_balance_before - 2,
+        "creator balance should decrease by buyback amount"
+    );
+
+    // Other holders' balances should remain unchanged
+    assert_eq!(
+        holder_a_balance_after, holder_a_balance_before,
+        "holder_a balance should not change"
+    );
+    assert_eq!(
+        holder_b_balance_after, holder_b_balance_before,
+        "holder_b balance should not change"
+    );
+
+    // Supply should decrease by buyback amount
+    assert_eq!(
+        supply_after,
+        supply_before - 2,
+        "total supply should decrease by buyback amount"
+    );
+}
+
+#[test]
+fn test_buyback_supply_exact_decrease() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+
+    // Creator buys 5 keys
+    for _ in 0..5 {
+        client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    }
+
+    let supply_before = client.get_total_key_supply(&creator);
+    assert_eq!(supply_before, 5);
+
+    // Buyback 3 keys
+    let total_cost = client.get_buyback_quote(&creator, &3);
+    client.buyback(&creator, &creator, &3, &total_cost, &None);
+
+    let supply_after = client.get_total_key_supply(&creator);
+    assert_eq!(
+        supply_after,
+        supply_before - 3,
+        "supply should decrease by exact buyback amount"
+    );
+}
+
+#[test]
+fn test_full_buyback_no_wallets_affected() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+
+    // Create a holder
+    let holder = Address::generate(&env);
+    client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+
+    // Creator buys 3 keys
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+    client.buy_key(&creator, &creator, &KEY_PRICE, &None);
+
+    let holder_balance_before = client.get_key_balance(&creator, &holder);
+    let _supply_before = client.get_total_key_supply(&creator);
+
+    // Buyback all creator keys (3)
+    let total_cost = client.get_buyback_quote(&creator, &3);
+    client.buyback(&creator, &creator, &3, &total_cost, &None);
+
+    let holder_balance_after = client.get_key_balance(&creator, &holder);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    // Holder's balance should be unchanged
+    assert_eq!(
+        holder_balance_after, holder_balance_before,
+        "holder balance should not change after creator's full buyback"
+    );
+
+    // Supply should only reflect the holder's keys
+    assert_eq!(
+        supply_after, 1,
+        "supply should equal remaining holder's keys"
+    );
+}

--- a/creator-keys/tests/dividend_zero_balance_wallet.rs
+++ b/creator-keys/tests/dividend_zero_balance_wallet.rs
@@ -1,0 +1,146 @@
+//! Tests for dividend distribution skipping wallets with zero key balance (#445).
+//!
+//! A wallet that holds zero keys for a creator should receive no dividend share
+//! even if it previously held keys and is still tracked in storage.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    compute_expected_holder_dividend, distribute_test_dividend, register_creator_keys,
+    register_test_creator, set_pricing_and_fees, test_env_with_auths, DEFAULT_PROTOCOL_BPS,
+};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Address;
+
+#[test]
+fn test_zero_balance_wallet_receives_no_dividend() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 100, 9000, DEFAULT_PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Wallet A buys 2 keys
+    let wallet_a = Address::generate(&env);
+    client.buy_key(&creator, &wallet_a, &100, &None);
+    client.buy_key(&creator, &wallet_a, &100, &None);
+
+    // Wallet B buys 1 key then sells it all (zero balance)
+    let wallet_b = Address::generate(&env);
+    client.buy_key(&creator, &wallet_b, &100, &None);
+    client.sell_key(&creator, &wallet_b, &None);
+
+    // Wallet B now has zero balance, wallet A has 2 keys
+    assert_eq!(client.get_key_balance(&creator, &wallet_b), 0);
+    assert_eq!(client.get_key_balance(&creator, &wallet_a), 2);
+
+    // Distribute dividend
+    let distributor = Address::generate(&env);
+    let amount = 10_000i128;
+    distribute_test_dividend(&client, &creator, &distributor, amount);
+
+    // Zero-balance wallet has zero claimable dividend
+    assert_eq!(
+        client.get_claimable_dividend(&creator, &wallet_b),
+        0,
+        "zero-balance wallet should receive no dividend"
+    );
+
+    // Positive-balance wallet receives full distribution (all keys)
+    let expected = compute_expected_holder_dividend(amount, 2, 2, DEFAULT_PROTOCOL_BPS);
+    assert_eq!(
+        client.get_claimable_dividend(&creator, &wallet_a),
+        expected,
+        "positive-balance wallet should receive the full distribution"
+    );
+
+    // Total claimable equals distributed amount minus protocol fee
+    let total_claimable = client.get_claimable_dividend(&creator, &wallet_a)
+        + client.get_claimable_dividend(&creator, &wallet_b);
+    let protocol_fee = (amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
+    assert_eq!(
+        total_claimable,
+        amount - protocol_fee,
+        "total claimable should equal distributed amount minus protocol fee"
+    );
+}
+
+#[test]
+fn test_zero_balance_wallet_after_partial_sell() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 100, 9000, DEFAULT_PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Wallet A buys 3 keys
+    let wallet_a = Address::generate(&env);
+    client.buy_key(&creator, &wallet_a, &100, &None);
+    client.buy_key(&creator, &wallet_a, &100, &None);
+    client.buy_key(&creator, &wallet_a, &100, &None);
+
+    // Wallet B buys 2 keys then sells all
+    let wallet_b = Address::generate(&env);
+    client.buy_key(&creator, &wallet_b, &100, &None);
+    client.buy_key(&creator, &wallet_b, &100, &None);
+    client.sell_key(&creator, &wallet_b, &None);
+    client.sell_key(&creator, &wallet_b, &None);
+
+    assert_eq!(client.get_key_balance(&creator, &wallet_b), 0);
+
+    // Distribute dividend
+    let distributor = Address::generate(&env);
+    let amount = 30_000i128;
+    distribute_test_dividend(&client, &creator, &distributor, amount);
+
+    // Zero-balance wallet gets nothing
+    assert_eq!(
+        client.get_claimable_dividend(&creator, &wallet_b),
+        0,
+        "zero-balance wallet should have zero claimable dividend"
+    );
+
+    // Wallet A (all 3 keys) gets full share
+    let expected = compute_expected_holder_dividend(amount, 3, 3, DEFAULT_PROTOCOL_BPS);
+    assert_eq!(
+        client.get_claimable_dividend(&creator, &wallet_a),
+        expected,
+        "wallet with all supply should receive full distribution"
+    );
+}
+
+#[test]
+fn test_two_zero_balance_wallets_with_one_holder() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 100, 9000, DEFAULT_PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Three wallets buy keys, two sell all
+    let wallet_a = Address::generate(&env);
+    let wallet_b = Address::generate(&env);
+    let wallet_c = Address::generate(&env);
+
+    client.buy_key(&creator, &wallet_a, &100, &None);
+    client.buy_key(&creator, &wallet_b, &100, &None);
+    client.buy_key(&creator, &wallet_c, &100, &None);
+
+    // Wallets B and C sell all keys
+    client.sell_key(&creator, &wallet_b, &None);
+    client.sell_key(&creator, &wallet_c, &None);
+
+    assert_eq!(client.get_key_balance(&creator, &wallet_b), 0);
+    assert_eq!(client.get_key_balance(&creator, &wallet_c), 0);
+    assert_eq!(client.get_key_balance(&creator, &wallet_a), 1);
+
+    // Distribute dividend
+    let distributor = Address::generate(&env);
+    let amount = 10_000i128;
+    distribute_test_dividend(&client, &creator, &distributor, amount);
+
+    // Zero-balance wallets get nothing
+    assert_eq!(client.get_claimable_dividend(&creator, &wallet_b), 0);
+    assert_eq!(client.get_claimable_dividend(&creator, &wallet_c), 0);
+
+    // Wallet A gets full share
+    let expected = compute_expected_holder_dividend(amount, 1, 1, DEFAULT_PROTOCOL_BPS);
+    assert_eq!(client.get_claimable_dividend(&creator, &wallet_a), expected);
+}

--- a/docs/dividend-distribution-fee-behavior.md
+++ b/docs/dividend-distribution-fee-behavior.md
@@ -1,0 +1,114 @@
+# Dividend distribution: caller permissions and protocol fee behavior
+
+This document explains how the `distribute_dividend` entrypoint works, including who can call it and how fees are applied.
+
+---
+
+## Open caller model
+
+The `distribute_dividend` function is callable by **any address**, not just the creator. This is intentional and enables several use cases:
+
+- **Fans can distribute**: A fan who holds keys can distribute dividends to other holders of the same creator's keys.
+- **Integrators can distribute**: Third-party applications can distribute dividends on behalf of users or as part of reward programs.
+- **Creators can distribute**: The creator themselves can distribute dividends to their key holders.
+
+There is no authorization check on the caller's address. The only requirements are:
+
+1. The creator must be registered in the contract.
+2. There must be at least one key holder (supply > 0).
+3. The fee configuration must be set.
+4. The protocol must not be paused.
+5. The distribution amount must be positive.
+
+---
+
+## Protocol fee deduction
+
+When a dividend is distributed, the **protocol fee is deducted before** the remaining amount is split proportionally among key holders.
+
+### Fee calculation
+
+```
+protocol_fee = floor(distribution_amount * protocol_bps / 10_000)
+net_amount   = distribution_amount - protocol_fee
+```
+
+The `protocol_bps` value is set by the protocol admin via `set_fee_config` and represents the protocol's share of all transactions, including dividend distributions.
+
+### Immediate payment to fee recipient
+
+The protocol fee is transferred to the protocol fee recipient **immediately at distribution time**. The fee recipient does not need to claim this amount separately — it is credited to their balance when the distribution occurs.
+
+---
+
+## Worked example
+
+**Setup:**
+- Distribution amount: 1000 XLM
+- Protocol fee: 2% (protocol_bps = 200)
+- Key holders: Alice (3 keys), Bob (2 keys), Charlie (1 key)
+- Total supply: 6 keys
+
+**Step 1: Calculate protocol fee**
+```
+protocol_fee = floor(1000 * 200 / 10_000) = floor(20.0) = 20 XLM
+```
+
+**Step 2: Calculate net distribution amount**
+```
+net_amount = 1000 - 20 = 980 XLM
+```
+
+**Step 3: Calculate per-key share**
+```
+per_key = floor(980 / 6) = floor(163.333...) = 163 XLM
+```
+
+**Step 4: Calculate each holder's claimable amount**
+```
+Alice:   163 * 3 = 489 XLM
+Bob:     163 * 2 = 326 XLM
+Charlie: 163 * 1 = 163 XLM
+```
+
+**Total distributed to holders:** 489 + 326 + 163 = 978 XLM
+
+Note: 2 XLM remains undistributed due to integer division rounding. This dust stays in the contract and is not lost — it simply is not allocated to any holder.
+
+**Step 5: Protocol fee recipient**
+```
+Protocol fee recipient balance increases by 20 XLM immediately.
+```
+
+---
+
+## Rounding behavior
+
+The per-key share is calculated using **floor integer division**:
+
+```
+per_key = floor(net_amount / total_supply)
+```
+
+The remainder from this division is not distributed to any holder. This means:
+
+- The total distributed to holders may be slightly less than `net_amount`.
+- The dust amount is negligible for large distributions.
+- The contract does not track or expose the undistributed dust.
+
+---
+
+## Summary
+
+| Aspect | Behavior |
+|---|---|
+| **Caller** | Any address (open caller model) |
+| **Fee deduction** | Protocol fee deducted before splitting |
+| **Fee timing** | Immediate at distribution time |
+| **Fee recipient** | Receives deducted amount immediately |
+| **Per-key calculation** | Floor integer division |
+| **Rounding dust** | Remainder stays in contract, not distributed |
+
+---
+
+For dividend accumulator math and settlement details, see [proportional dividend share tests](../creator-keys/tests/proportional_dividend_share.rs).


### PR DESCRIPTION
Closes #444, Closes #445, Closes #446, Closes #447

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [x] Performance improvement
- [x] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR adds regression tests and documentation for four issues:

1. **#444**: Regression test confirming creator buyback burns keys without crediting any wallet
2. **#445**: Unit tests for dividend distribution skipping wallets with zero key balance
3. **#446**: Regression test for bonding curve pricing ordering (steeper curves produce higher prices)
4. **#447**: Documentation for dividend distribution caller permissions and protocol fee behavior

Additionally, fixes a pre-existing duplicate `transfer_keys` function in lib.rs that caused compilation errors.

## Motivation / Context

These tests lock in critical invariants:
- Buyback must not credit any wallet (distinguishing it from regular buys)
- Zero-balance wallets receive no dividend share
- Steeper bonding curves must always produce higher prices at the same supply
- The dividend distribution is callable by any address with protocol fee deducted before splitting

Closes #444, Closes #445, Closes #446, Closes #447