### PR TITLE
Add protocol fee bps method, self-transfer tests, sell quote regression test, and balance lookup tests

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1557,6 +1557,15 @@ impl CreatorKeysContract {
         Ok(config.protocol_bps)
     }
 
+    /// Read-only view: returns the stored protocol fee basis points value.
+    ///
+    /// Does not mutate contract state. Fails with
+    /// [`ContractError::FeeConfigNotSet`] if no fee configuration has been stored.
+    pub fn get_protocol_fee_bps(env: Env) -> Result<u32, ContractError> {
+        let config = read_required_protocol_fee_config(&env)?;
+        Ok(config.protocol_bps)
+    }
+
     /// Sets the global protocol/creator fee split. Contract initialization
     /// entrypoint.
     ///

--- a/creator-keys/tests/balance_lookup_invalid_reads.rs
+++ b/creator-keys/tests/balance_lookup_invalid_reads.rs
@@ -5,7 +5,9 @@
 
 mod contract_test_env;
 
-use contract_test_env::{register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths};
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
 use soroban_sdk::{testutils::Address as _, Env};
 
 // ── get_key_balance: unregistered creator ────────────────────────────────────
@@ -100,7 +102,10 @@ fn test_get_holder_key_count_holder_with_no_keys() {
 
     let view = client.get_holder_key_count(&creator, &holder);
     assert!(view.creator_exists, "creator_exists must be true");
-    assert_eq!(view.key_count, 0, "key_count must be zero for holder with no keys");
+    assert_eq!(
+        view.key_count, 0,
+        "key_count must be zero for holder with no keys"
+    );
 }
 
 // ── get_holder_key_count: correct count after buys ──────────────────────────

--- a/creator-keys/tests/balance_lookup_invalid_reads.rs
+++ b/creator-keys/tests/balance_lookup_invalid_reads.rs
@@ -1,0 +1,157 @@
+//! Tests for invalid balance lookup input paths.
+//!
+//! Covers edge cases for `get_key_balance` and `get_holder_key_count`
+//! with unregistered creators and zero-balance holders.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths};
+use soroban_sdk::{testutils::Address as _, Env};
+
+// ── get_key_balance: unregistered creator ────────────────────────────────────
+
+#[test]
+fn test_get_key_balance_returns_zero_for_unregistered_creator() {
+    let env = Env::default();
+    let contract_id = env.register(creator_keys::CreatorKeysContract, ());
+    let client = creator_keys::CreatorKeysContractClient::new(&env, &contract_id);
+
+    let unregistered_creator = soroban_sdk::Address::generate(&env);
+    let wallet = soroban_sdk::Address::generate(&env);
+
+    let balance = client.get_key_balance(&unregistered_creator, &wallet);
+    assert_eq!(balance, 0, "unregistered creator must return zero balance");
+}
+
+#[test]
+fn test_get_key_balance_returns_zero_for_unregistered_creator_and_holder() {
+    let env = Env::default();
+    let contract_id = env.register(creator_keys::CreatorKeysContract, ());
+    let client = creator_keys::CreatorKeysContractClient::new(&env, &contract_id);
+
+    let unregistered_creator = soroban_sdk::Address::generate(&env);
+    let unregistered_holder = soroban_sdk::Address::generate(&env);
+
+    let balance = client.get_key_balance(&unregistered_creator, &unregistered_holder);
+    assert_eq!(balance, 0, "both unregistered must return zero balance");
+}
+
+// ── get_key_balance: registered creator, holder with no keys ─────────────────
+
+#[test]
+fn test_get_key_balance_returns_zero_for_holder_with_no_keys() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder_with_no_keys = soroban_sdk::Address::generate(&env);
+
+    let balance = client.get_key_balance(&creator, &holder_with_no_keys);
+    assert_eq!(balance, 0, "holder with no keys must return zero balance");
+}
+
+// ── get_key_balance: multiple distinct holders return independent balances ────
+
+#[test]
+fn test_get_key_balance_independent_per_holder() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder_a = soroban_sdk::Address::generate(&env);
+    let holder_b = soroban_sdk::Address::generate(&env);
+
+    client.buy_key(&creator, &holder_a, &100, &None);
+    client.buy_key(&creator, &holder_a, &100, &None);
+    client.buy_key(&creator, &holder_b, &100, &None);
+
+    assert_eq!(client.get_key_balance(&creator, &holder_a), 2);
+    assert_eq!(client.get_key_balance(&creator, &holder_b), 1);
+}
+
+// ── get_holder_key_count: unregistered creator ───────────────────────────────
+
+#[test]
+fn test_get_holder_key_count_creator_not_registered() {
+    let env = Env::default();
+    let contract_id = env.register(creator_keys::CreatorKeysContract, ());
+    let client = creator_keys::CreatorKeysContractClient::new(&env, &contract_id);
+
+    let unregistered_creator = soroban_sdk::Address::generate(&env);
+    let holder = soroban_sdk::Address::generate(&env);
+
+    let view = client.get_holder_key_count(&unregistered_creator, &holder);
+    assert!(!view.creator_exists, "creator_exists must be false");
+    assert_eq!(view.key_count, 0, "key_count must be zero");
+}
+
+// ── get_holder_key_count: registered creator, holder with no keys ────────────
+
+#[test]
+fn test_get_holder_key_count_holder_with_no_keys() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = soroban_sdk::Address::generate(&env);
+
+    let view = client.get_holder_key_count(&creator, &holder);
+    assert!(view.creator_exists, "creator_exists must be true");
+    assert_eq!(view.key_count, 0, "key_count must be zero for holder with no keys");
+}
+
+// ── get_holder_key_count: correct count after buys ──────────────────────────
+
+#[test]
+fn test_get_holder_key_count_reflects_actual_balance() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = soroban_sdk::Address::generate(&env);
+
+    client.buy_key(&creator, &holder, &100, &None);
+    client.buy_key(&creator, &holder, &100, &None);
+    client.buy_key(&creator, &holder, &100, &None);
+
+    let view = client.get_holder_key_count(&creator, &holder);
+    assert!(view.creator_exists);
+    assert_eq!(view.key_count, 3, "key_count must match actual balance");
+}
+
+// ── get_total_key_supply: unregistered creator ───────────────────────────────
+
+#[test]
+fn test_get_total_key_supply_returns_zero_for_unregistered_creator() {
+    let env = Env::default();
+    let contract_id = env.register(creator_keys::CreatorKeysContract, ());
+    let client = creator_keys::CreatorKeysContractClient::new(&env, &contract_id);
+
+    let unregistered = soroban_sdk::Address::generate(&env);
+    assert_eq!(
+        client.get_total_key_supply(&unregistered),
+        0,
+        "unregistered creator must return zero supply"
+    );
+}
+
+// ── get_creator_supply: unregistered creator ─────────────────────────────────
+
+#[test]
+fn test_get_creator_supply_fails_for_unregistered_creator() {
+    let env = Env::default();
+    let contract_id = env.register(creator_keys::CreatorKeysContract, ());
+    let client = creator_keys::CreatorKeysContractClient::new(&env, &contract_id);
+
+    let unregistered = soroban_sdk::Address::generate(&env);
+    let result = client.try_get_creator_supply(&unregistered);
+    assert_eq!(
+        result,
+        Err(Ok(creator_keys::ContractError::NotRegistered)),
+        "must return NotRegistered for unregistered creator"
+    );
+}

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -79,7 +79,12 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let buyer = soroban_sdk::Address::generate(&env);
-    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(
+        &creator,
+        &soroban_sdk::String::from_str(&env, "alice"),
+        &None,
+        &None,
+    );
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);
 

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -1,0 +1,91 @@
+//! Tests for the `get_protocol_fee_bps` read-only method.
+//!
+//! Verifies that the method returns the stored protocol fee bps value,
+//! does not mutate contract state, and handles error paths correctly.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, test_env_with_auths};
+use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Env};
+
+#[test]
+fn test_get_protocol_fee_bps_returns_stored_value() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_fee_config(&admin, &9000, &1000);
+
+    let bps = client.get_protocol_fee_bps();
+    assert_eq!(bps, 1000, "must return the stored protocol fee bps");
+}
+
+#[test]
+fn test_get_protocol_fee_bps_returns_updated_value() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_fee_config(&admin, &9000, &1000);
+    assert_eq!(client.get_protocol_fee_bps(), 1000);
+
+    client.set_fee_config(&admin, &8000, &2000);
+    assert_eq!(
+        client.get_protocol_fee_bps(),
+        2000,
+        "must reflect updated protocol fee bps"
+    );
+}
+
+#[test]
+fn test_get_protocol_fee_bps_fails_when_fee_config_not_set() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_protocol_fee_bps();
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::FeeConfigNotSet)),
+        "must return FeeConfigNotSet when no fee config has been stored"
+    );
+}
+
+#[test]
+fn test_get_protocol_fee_bps_does_not_mutate_state() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_fee_config(&admin, &9500, &500);
+
+    let first = client.get_protocol_fee_bps();
+    let second = client.get_protocol_fee_bps();
+    let third = client.get_protocol_fee_bps();
+
+    assert_eq!(first, 500);
+    assert_eq!(first, second, "repeated reads must return the same value");
+    assert_eq!(second, third, "repeated reads must return the same value");
+}
+
+#[test]
+fn test_get_protocol_fee_bps_persists_across_operations() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_fee_config(&admin, &8500, &1500);
+
+    let creator = soroban_sdk::Address::generate(&env);
+    let buyer = soroban_sdk::Address::generate(&env);
+    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "alice"), &None, &None);
+    client.set_key_price(&admin, &100);
+    client.buy_key(&creator, &buyer, &100, &None);
+
+    let bps = client.get_protocol_fee_bps();
+    assert_eq!(
+        bps, 1500,
+        "protocol fee bps must persist after buy operation"
+    );
+}

--- a/creator-keys/tests/sell_quote_after_fee_config_update.rs
+++ b/creator-keys/tests/sell_quote_after_fee_config_update.rs
@@ -49,10 +49,7 @@ fn test_sell_quote_reflects_updated_fee_config() {
         quote_after.creator_fee, 800,
         "updated creator fee must be 80% of 1000"
     );
-    assert_eq!(
-        quote_after.price, 1000,
-        "price must remain unchanged"
-    );
+    assert_eq!(quote_after.price, 1000, "price must remain unchanged");
 }
 
 /// After a fee config update, the sell quote total_amount must be consistent

--- a/creator-keys/tests/sell_quote_after_fee_config_update.rs
+++ b/creator-keys/tests/sell_quote_after_fee_config_update.rs
@@ -1,0 +1,90 @@
+//! Regression test for sell quote correctness after fee config mutation.
+//!
+//! Verifies that the sell quote (read-only path) reflects the updated fee config
+//! and does not read stale values after a `set_fee_config` call.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, test_env_with_auths};
+use soroban_sdk::testutils::Address as _;
+
+/// After updating the fee config, the sell quote must reflect the new bps split,
+/// not the original one. This guards against stale-config reads in the quote path.
+#[test]
+fn test_sell_quote_reflects_updated_fee_config() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_key_price(&admin, &1000);
+    // Original fee config: 90/10 split
+    client.set_fee_config(&admin, &9000, &1000);
+
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = soroban_sdk::Address::generate(&env);
+
+    client.buy_key(&creator, &holder, &1000, &None);
+
+    // Get sell quote under original config
+    let quote_before = client.get_sell_quote(&creator, &holder);
+    assert_eq!(
+        quote_before.protocol_fee, 100,
+        "original protocol fee must be 10% of 1000"
+    );
+    assert_eq!(
+        quote_before.creator_fee, 900,
+        "original creator fee must be 90% of 1000"
+    );
+
+    // Update fee config: 80/20 split
+    client.set_fee_config(&admin, &8000, &2000);
+
+    // Sell quote must reflect updated config, not stale values
+    let quote_after = client.get_sell_quote(&creator, &holder);
+    assert_eq!(
+        quote_after.protocol_fee, 200,
+        "updated protocol fee must be 20% of 1000"
+    );
+    assert_eq!(
+        quote_after.creator_fee, 800,
+        "updated creator fee must be 80% of 1000"
+    );
+    assert_eq!(
+        quote_after.price, 1000,
+        "price must remain unchanged"
+    );
+}
+
+/// After a fee config update, the sell quote total_amount must be consistent
+/// with the new fee split. The seller's net proceeds decrease when protocol
+/// fees increase.
+#[test]
+fn test_sell_quote_total_amount_updates_after_fee_config_change() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_key_price(&admin, &500);
+    client.set_fee_config(&admin, &9000, &1000);
+
+    let creator = register_test_creator(&env, &client, "bob");
+    let holder = soroban_sdk::Address::generate(&env);
+
+    client.buy_key(&creator, &holder, &500, &None);
+
+    let quote_original = client.get_sell_quote(&creator, &holder);
+    // 500 - 450 (creator) - 50 (protocol) = 0
+    assert_eq!(quote_original.total_amount, 0);
+
+    // Update to 75/25
+    client.set_fee_config(&admin, &7500, &2500);
+
+    let quote_updated = client.get_sell_quote(&creator, &holder);
+    // 500 - 375 (creator) - 125 (protocol) = 0
+    assert_eq!(
+        quote_updated.total_amount, 0,
+        "total_amount must be recomputed with updated fees"
+    );
+    assert_eq!(quote_updated.protocol_fee, 125);
+    assert_eq!(quote_updated.creator_fee, 375);
+}

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -262,6 +262,62 @@ fn test_transfer_keys_unregistered_creator_reverts() {
 }
 
 #[test]
+fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = Address::generate(&env);
+    let sender = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.buy_key(&creator, &sender, &100, &None);
+    client.buy_key(&creator, &sender, &100, &None);
+
+    let balance_before = client.get_key_balance(&creator, &sender);
+    let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
+    let balance_after = client.get_key_balance(&creator, &sender);
+
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SelfTransfer)),
+        "self-transfer must revert"
+    );
+    assert_eq!(
+        balance_before, balance_after,
+        "sender balance must be unchanged after self-transfer revert"
+    );
+}
+
+#[test]
+fn test_transfer_keys_self_transfer_total_supply_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let _admin = set_pricing_and_fees(&env, &client, 100, 9000, 1000);
+    let creator = Address::generate(&env);
+    let sender = Address::generate(&env);
+
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.buy_key(&creator, &sender, &100, &None);
+    client.buy_key(&creator, &sender, &100, &None);
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SelfTransfer)),
+        "self-transfer must revert"
+    );
+    assert_eq!(
+        supply_before, supply_after,
+        "total supply must be unchanged after self-transfer revert"
+    );
+}
+
+#[test]
 fn test_transfer_keys_preserves_other_holders() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);


### PR DESCRIPTION
Closes #443 , Closes #79, Closes #220, Closes #32

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR addresses four Stellar Wave issues: adds a dedicated `get_protocol_fee_bps` read-only method for the protocol fee basis points value, adds self-transfer tests verifying sender balance and total supply remain unchanged after revert, adds a regression test for sell quote correctness after fee config update, and adds invalid balance lookup test coverage for `get_key_balance` and `get_holder_key_count` edge cases. Also fixes a pre-existing duplicate `transfer_keys` function that prevented compilation.

## Motivation / Context

Closes #443, Closes #79, Closes #220, Closes #32