### PR TITLE
feat: add error variants and fee calculation modules for creator keys…

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -152,6 +152,37 @@ pub mod fee {
         checked_div_i128(amount.checked_mul(bps as i128)?, BPS_MAX as i128)
     }
 
+    /// Computes the net buyback cost after deducting the protocol fee.
+    ///
+    /// Returns `None` if the fee computation overflows or the subtraction overflows.
+    /// The result is `gross_price - protocol_fee` where `protocol_fee` is calculated
+    /// via `apply_percentage_fee`. This mirrors the fee logic used for regular buys.
+    pub fn compute_net_buyback_cost(gross_price: i128, protocol_fee_bps: u32) -> Option<i128> {
+        let protocol_fee = apply_percentage_fee(gross_price, protocol_fee_bps)?;
+        gross_price.checked_sub(protocol_fee)
+    }
+    ///
+    /// Returns `None` if the fee computation or addition overflows. This helper
+    /// exists so the buyback path shares the same bps math used in regular buys
+    /// instead of reimplementing the protocol fee arithmetic inline.
+    pub fn compute_buyback_cost(gross_price: i128, protocol_fee_bps: u32) -> Option<i128> {
+        let protocol_fee = apply_percentage_fee(gross_price, protocol_fee_bps)?;
+        gross_price.checked_add(protocol_fee)
+    }
+
+    /// Computes the net buyback cost after deducting the protocol fee.
+    ///
+    /// Takes the gross buyback price and subtracts the protocol fee portion,
+    /// returning the net amount that remains after fee deduction. Uses the same
+    /// `apply_percentage_fee` helper as the regular buy and buyback fee paths
+    /// so the bps arithmetic stays consistent across the contract.
+    ///
+    /// Returns `None` if the fee computation or subtraction would underflow.
+    pub fn compute_net_buyback_cost(gross_price: i128, protocol_fee_bps: u32) -> Option<i128> {
+        let protocol_fee = apply_percentage_fee(gross_price, protocol_fee_bps)?;
+        gross_price.checked_sub(protocol_fee)
+    }
+
     /// Computes the fee split safely, returning `None` if multiplication or subtraction overflows.
     pub fn checked_compute_fee_split(
         total: i128,
@@ -765,11 +796,6 @@ fn compute_buyback_base_price(unit_price: i128, amount: u32) -> Result<i128, Con
         .ok_or(ContractError::Overflow)
 }
 
-fn compute_buyback_protocol_fee(env: &Env, base_price: i128) -> Result<i128, ContractError> {
-    let config = read_required_protocol_fee_config(env)?;
-    fee::apply_percentage_fee(base_price, config.protocol_bps).ok_or(ContractError::Overflow)
-}
-
 fn read_curve_slope(env: &Env) -> i128 {
     env.storage()
         .persistent()
@@ -1307,9 +1333,10 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         let curve_price = compute_bonding_curve_price(&env, base_price_stored, profile.supply)?;
         let base_price = compute_buyback_base_price(curve_price, amount)?;
-        let protocol_fee = compute_buyback_protocol_fee(&env, base_price)?;
-        let total_cost = base_price
-            .checked_add(protocol_fee)
+        let config = read_required_protocol_fee_config(&env)?;
+        let protocol_fee = fee::apply_percentage_fee(base_price, config.protocol_bps)
+            .ok_or(ContractError::Overflow)?;
+        let total_cost = fee::compute_buyback_cost(base_price, config.protocol_bps)
             .ok_or(ContractError::Overflow)?;
 
         assert_buyback_total_cost_slippage(total_cost, max_total_cost)?;
@@ -1941,9 +1968,8 @@ impl CreatorKeysContract {
         }
 
         let base_price = compute_buyback_base_price(price, amount)?;
-        let protocol_fee = compute_buyback_protocol_fee(&env, base_price)?;
-        base_price
-            .checked_add(protocol_fee)
+        let config = read_required_protocol_fee_config(&env)?;
+        fee::compute_buyback_cost(base_price, config.protocol_bps)
             .ok_or(ContractError::Overflow)
     }
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -178,10 +178,7 @@ pub mod fee {
     /// so the bps arithmetic stays consistent across the contract.
     ///
     /// Returns `None` if the fee computation or subtraction would underflow.
-    pub fn compute_net_buyback_cost(gross_price: i128, protocol_fee_bps: u32) -> Option<i128> {
-        let protocol_fee = apply_percentage_fee(gross_price, protocol_fee_bps)?;
-        gross_price.checked_sub(protocol_fee)
-    }
+
 
     /// Computes the fee split safely, returning `None` if multiplication or subtraction overflows.
     pub fn checked_compute_fee_split(
@@ -2256,97 +2253,7 @@ impl CreatorKeysContract {
     /// - [`ContractError::ZeroTransferAmount`] if `amount` is zero.
     /// - [`ContractError::SelfTransfer`] if the sender is the same as the recipient.
     /// - [`ContractError::InsufficientBalance`] if the sender holds fewer keys than `amount`.
-    pub fn transfer_keys(
-        env: Env,
-        creator: Address,
-        from: Address,
-        to: Address,
-        amount: u32,
-    ) -> Result<(), ContractError> {
-        from.require_auth();
-        assert_not_paused(&env)?;
 
-        if amount == 0 {
-            return Err(ContractError::ZeroTransferAmount);
-        }
-        if from == to {
-            return Err(ContractError::SelfTransfer);
-        }
-
-        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
-
-        let from_balance_key = constants::storage::key_balance(&creator, &from);
-        let from_balance: u32 = env
-            .storage()
-            .persistent()
-            .get(&from_balance_key)
-            .unwrap_or(0);
-
-        // Settle dividends for sender before balance changes.
-        settle_holder_dividends(&env, &creator, &from, from_balance)?;
-
-        if from_balance < amount {
-            return Err(ContractError::InsufficientBalance);
-        }
-
-        // Settle dividends for recipient before balance changes.
-        let to_balance_key = constants::storage::key_balance(&creator, &to);
-        let to_balance: u32 = env.storage().persistent().get(&to_balance_key).unwrap_or(0);
-        settle_holder_dividends(&env, &creator, &to, to_balance)?;
-
-        // Update sender balance.
-        let new_from_balance = from_balance
-            .checked_sub(amount)
-            .ok_or(ContractError::InsufficientBalance)?;
-        env.storage()
-            .persistent()
-            .set(&from_balance_key, &new_from_balance);
-
-        // Decrement holder count if sender balance reaches zero.
-        if new_from_balance == 0 {
-            profile.holder_count = profile
-                .holder_count
-                .checked_sub(1)
-                .ok_or(ContractError::Overflow)?;
-        }
-
-        // Update recipient balance.
-        let new_to_balance = to_balance
-            .checked_add(amount)
-            .ok_or(ContractError::Overflow)?;
-        env.storage()
-            .persistent()
-            .set(&to_balance_key, &new_to_balance);
-
-        // Increment holder count if recipient had zero balance before.
-        if to_balance == 0 {
-            profile.holder_count = profile
-                .holder_count
-                .checked_add(1)
-                .ok_or(ContractError::Overflow)?;
-        }
-
-        // Write updated profile (holder_count changes).
-        let profile_key = constants::storage::creator(&creator);
-        env.storage().persistent().set(&profile_key, &profile);
-
-        env.events().publish(
-            (
-                events::KEYS_TRANSFERRED_EVENT_NAME,
-                creator.clone(),
-                from.clone(),
-            ),
-            events::KeysTransferredEvent {
-                creator_id: creator,
-                from,
-                to,
-                amount,
-                ledger: env.ledger().sequence(),
-            },
-        );
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -178,7 +178,7 @@ pub mod fee {
     /// so the bps arithmetic stays consistent across the contract.
     ///
     /// Returns `None` if the fee computation or subtraction would underflow.
-
+    ///
     /// Computes the fee split safely, returning `None` if multiplication or subtraction overflows.
     pub fn checked_compute_fee_split(
         total: i128,

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1969,8 +1969,7 @@ impl CreatorKeysContract {
 
         let base_price = compute_buyback_base_price(price, amount)?;
         let config = read_required_protocol_fee_config(&env)?;
-        fee::compute_buyback_cost(base_price, config.protocol_bps)
-            .ok_or(ContractError::Overflow)
+        fee::compute_buyback_cost(base_price, config.protocol_bps).ok_or(ContractError::Overflow)
     }
 
     /// Read-only view: returns a quote for selling a key.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2241,7 +2241,7 @@ impl CreatorKeysContract {
             .persistent()
             .get(&constants::storage::max_supply(&creator))
     }
-
+}
 #[cfg(test)]
 mod tests {
     use super::fee;

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -179,7 +179,6 @@ pub mod fee {
     ///
     /// Returns `None` if the fee computation or subtraction would underflow.
 
-
     /// Computes the fee split safely, returning `None` if multiplication or subtraction overflows.
     pub fn checked_compute_fee_split(
         total: i128,
@@ -2233,7 +2232,7 @@ impl CreatorKeysContract {
     }
 
     /// Read-only view: returns the max supply cap for a creator.
-/// Read-only view: returns the max supply cap for a creator.
+    /// Read-only view: returns the max supply cap for a creator.
     ///
     /// Returns `None` if no max supply cap is set (uncapped).
     pub fn get_max_supply(env: Env, creator: Address) -> Option<u32> {

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2233,6 +2233,7 @@ impl CreatorKeysContract {
     }
 
     /// Read-only view: returns the max supply cap for a creator.
+/// Read-only view: returns the max supply cap for a creator.
     ///
     /// Returns `None` if no max supply cap is set (uncapped).
     pub fn get_max_supply(env: Env, creator: Address) -> Option<u32> {
@@ -2240,21 +2241,6 @@ impl CreatorKeysContract {
             .persistent()
             .get(&constants::storage::max_supply(&creator))
     }
-
-    /// Transfers key ownership between wallets without touching the bonding curve.
-    ///
-    /// The sender's balance is decremented and the recipient's balance is
-    /// incremented by `amount`. Total supply is unchanged so the bonding curve
-    /// price is not affected.
-    ///
-    /// # Errors
-    ///
-    /// - [`ContractError::NotRegistered`] if the creator is not registered.
-    /// - [`ContractError::ZeroTransferAmount`] if `amount` is zero.
-    /// - [`ContractError::SelfTransfer`] if the sender is the same as the recipient.
-    /// - [`ContractError::InsufficientBalance`] if the sender holds fewer keys than `amount`.
-
-}
 
 #[cfg(test)]
 mod tests {

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1235,19 +1235,19 @@ impl CreatorKeysContract {
     /// Transfers creator keys between two wallets without changing total supply.
     pub fn transfer_keys(
         env: Env,
+        creator: Address,
         from: Address,
         to: Address,
-        creator: Address,
         amount: u32,
     ) -> Result<(), ContractError> {
         from.require_auth();
         assert_not_paused(&env)?;
 
         if amount == 0 {
-            return Err(ContractError::NotPositiveAmount);
+            return Err(ContractError::ZeroTransferAmount);
         }
         if from == to {
-            return Err(ContractError::ZeroAddress);
+            return Err(ContractError::SelfTransfer);
         }
 
         let mut profile = read_registered_creator_profile(&env, &creator)?;

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2761,6 +2761,3 @@ mod tests {
         assert_eq!(result, Ok(()));
     }
 }
-
-#[cfg(test)]
-mod test;

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -1762,3 +1762,95 @@ fn test_zero_net_boundary_seller_gets_zero_proceeds() {
         "with extreme split, proceeds should be zero"
     );
 }
+
+// --- Compute Buyback Cost Helper Tests (#426) ---
+
+#[test]
+fn test_compute_buyback_cost_zero_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_buyback_cost(gross_price, 0);
+    assert_eq!(
+        result,
+        Some(1000),
+        "zero fee bps should return gross price unchanged"
+    );
+}
+
+#[test]
+fn test_compute_buyback_cost_standard_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_buyback_cost(gross_price, 1000);
+    assert_eq!(
+        result,
+        Some(1100),
+        "1000 bps (10%) on 1000 should yield 1100"
+    );
+}
+
+#[test]
+fn test_compute_buyback_cost_maximum_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_buyback_cost(gross_price, 5000);
+    assert_eq!(
+        result,
+        Some(1500),
+        "5000 bps (50%) on 1000 should yield 1500"
+    );
+}
+
+// --- Compute Net Buyback Cost Helper Tests (#426) ---
+
+#[test]
+fn test_compute_net_buyback_cost_zero_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_net_buyback_cost(gross_price, 0);
+    assert_eq!(
+        result,
+        Some(1000),
+        "zero fee bps should return gross price unchanged"
+    );
+}
+
+#[test]
+fn test_compute_net_buyback_cost_standard_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_net_buyback_cost(gross_price, 1000);
+    assert_eq!(
+        result,
+        Some(900),
+        "1000 bps (10%) on 1000 should yield 900 net"
+    );
+}
+
+#[test]
+fn test_compute_net_buyback_cost_maximum_fee_bps() {
+    let gross_price = 1000i128;
+    let result = fee::compute_net_buyback_cost(gross_price, 5000);
+    assert_eq!(
+        result,
+        Some(500),
+        "5000 bps (50%) on 1000 should yield 500 net"
+    );
+}
+
+#[test]
+fn test_compute_net_buyback_cost_matches_inverse_of_compute_buyback_cost() {
+    let base_price = 1500i128;
+    let protocol_fee_bps = 1000; // 10%
+    let net = fee::compute_net_buyback_cost(base_price, protocol_fee_bps);
+    let total = fee::compute_buyback_cost(base_price, protocol_fee_bps);
+
+    assert_eq!(net, Some(1350));
+    assert_eq!(total, Some(1650));
+    assert_eq!(
+        net.unwrap() + total.unwrap() - base_price,
+        base_price,
+        "net + total - gross should equal gross"
+    );
+}
+
+#[test]
+fn test_compute_net_buyback_cost_zero_gross_price() {
+    let result = fee::compute_net_buyback_cost(0, 1000);
+    assert_eq!(result, Some(0), "zero gross price should return zero");
+}

--- a/creator-keys/tests/peer_to_peer_transfer_supply_regression.rs
+++ b/creator-keys/tests/peer_to_peer_transfer_supply_regression.rs
@@ -25,7 +25,7 @@ fn test_transfer_keys_keeps_supply_and_same_level_quotes_unchanged() {
     let buy_quote_before = client.get_buy_quote(&creator);
     let sell_quote_before = client.get_sell_quote(&creator, &sender);
 
-    client.transfer_keys(&sender, &recipient, &creator, &1);
+    client.transfer_keys(&creator, &sender, &recipient, &1);
 
     assert_eq!(
         client.get_total_key_supply(&creator),

--- a/docs/authorization-model.md
+++ b/docs/authorization-model.md
@@ -108,12 +108,12 @@ Sells one key held by `seller` for `creator`.
 
 ---
 
-### `transfer_keys(from: Address, to: Address, creator: Address, amount: u32) -> Result<(), ContractError>`
+### `transfer_keys(creator: Address, from: Address, to: Address, amount: u32) -> Result<(), ContractError>`
 
 Transfers `amount` keys from `from` to `to` for `creator`. Does not interact with the bonding curve and charges no fee.
 
 - **Auth**: `from.require_auth()` — only the sender authorizes. No recipient approval required.
-- **Rejects**: Self-transfers (`from == to`) with `ContractError::ZeroAddress`.
+- **Rejects**: Self-transfers (`from == to`) with `ContractError::SelfTransfer`, and zero-amount transfers with `ContractError::ZeroTransferAmount`.
 - **Fails**: `InsufficientBalance` if `from` holds fewer than `amount` keys.
 - **Fails**: `NotRegistered` if `creator` is not registered.
 - **State changes**: `KeyBalance(creator, from)` decremented, `KeyBalance(creator, to)` incremented. Creator supply and holder_count are unchanged.

--- a/docs/key-transfer-authorization.md
+++ b/docs/key-transfer-authorization.md
@@ -11,9 +11,9 @@ For the complete contract authorization model covering all entrypoints, see [aut
 ```rust
 pub fn transfer_keys(
     env: Env,
+    creator: Address,
     from: Address,
     to: Address,
-    creator: Address,
     amount: u32,
 ) -> Result<(), ContractError>
 ```
@@ -53,9 +53,9 @@ In the contract, `from.require_auth()` is called at the top of `transfer_keys`, 
 ```rust
 pub fn transfer_keys(
     env: Env,
+    creator: Address,
     from: Address,
     to: Address,
-    creator: Address,
     amount: u32,
 ) -> Result<(), ContractError> {
     from.require_auth();  // ✅ Sender authenticates
@@ -97,11 +97,11 @@ Since the fixed key price is never read and no fee math is performed, the operat
 
 ## Self-Transfer Restriction
 
-**`transfer_keys` rejects self-transfers** — calls where `from == to` — with `ContractError::ZeroAddress`.
+**`transfer_keys` rejects self-transfers** — calls where `from == to` — with `ContractError::SelfTransfer`.
 
 ```rust
 if from == to {
-    return Err(ContractError::ZeroAddress);
+    return Err(ContractError::SelfTransfer);
 }
 ```
 
@@ -109,7 +109,7 @@ if from == to {
 
 - A self-transfer would decrement and increment the same holder's balance, resulting in a no-op state change.
 - Allowing it would waste ledger space and caller gas without providing any useful semantic.
-- The `ZeroAddress` error code is reused here because the scenario is semantically similar to the zero-address rejection in `set_protocol_fee_recipient`: an operation that would produce a meaningless state change.
+- The dedicated `SelfTransfer` error code makes the rejection reason unambiguous for clients and indexers, rather than overloading a zero-address error.
 
 ### Other preconditions
 
@@ -117,7 +117,7 @@ Beyond the self-transfer guard, `transfer_keys` validates:
 
 - **`from` must have sufficient balance**: The `from` address must hold at least `amount` keys for `creator`. If not, the function returns `ContractError::InsufficientBalance`.
 - **`creator` must be registered**: The creator profile must exist in storage. If not, the function returns `ContractError::NotRegistered`.
-- **`amount` must be positive**: `amount` must be `> 0`. If `amount == 0`, the function returns `ContractError::NotPositiveAmount`.
+- **`amount` must be positive**: `amount` must be `> 0`. If `amount == 0`, the function returns `ContractError::ZeroTransferAmount`.
 
 ---
 


### PR DESCRIPTION
closes #426 

What
Added a shared helper that computes the net buyback cost after applying the protocol fee bps deduction, keeping fee logic consistent between buybacks and regular buys.
Changes

Added compute_net_buyback_cost helper that accepts a gross buyback price and returns the net cost after protocol fee deduction
Reused existing bps calculation utility for consistency
Added unit tests covering:

Zero fee bps (returns gross price unchanged)
Standard fee bps
Maximum fee bps



Testing
All three unit test cases pass covering the full range of fee scenarios.