### PR TITLE
test: add assert_claimable helper and update dividend tests (#451)

### DIFF
--- a/creator-keys/tests/claim_dividend.rs
+++ b/creator-keys/tests/claim_dividend.rs
@@ -3,9 +3,9 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    compute_expected_holder_dividend, distribute_test_dividend, register_creator_keys,
-    register_test_creator, set_pricing_and_fees, test_env_with_auths, DEFAULT_CREATOR_BPS,
-    DEFAULT_PROTOCOL_BPS,
+    assert_claimable, compute_expected_holder_dividend, distribute_test_dividend,
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+    DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
 };
 use creator_keys::ContractError;
 use soroban_sdk::{testutils::Address as _, Address};
@@ -73,7 +73,7 @@ fn test_claim_dividend_resets_claimable_to_zero() {
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
     client.claim_dividend(&creator, &buyer);
 
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), 0);
+    assert_claimable(&client, &creator, &buyer, 0);
 }
 
 #[test]

--- a/creator-keys/tests/claimable_dividend_view.rs
+++ b/creator-keys/tests/claimable_dividend_view.rs
@@ -3,7 +3,7 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    capture_snapshot, compute_expected_holder_dividend, distribute_test_dividend,
+    assert_claimable, capture_snapshot, compute_expected_holder_dividend, distribute_test_dividend,
     register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
     DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
 };
@@ -24,7 +24,7 @@ fn test_get_claimable_dividend_zero_before_any_distribution() {
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &100, &None);
 
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), 0);
+    assert_claimable(&client, &creator, &buyer, 0);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn test_get_claimable_dividend_correct_after_distribution() {
     distribute_test_dividend(&client, &creator, &distributor, amount);
 
     let expected = compute_expected_holder_dividend(amount, 1, 1, DEFAULT_PROTOCOL_BPS);
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), expected);
+    assert_claimable(&client, &creator, &buyer, expected);
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn test_get_claimable_dividend_zero_after_claim() {
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
     client.claim_dividend(&creator, &buyer);
 
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), 0);
+    assert_claimable(&client, &creator, &buyer, 0);
 }
 
 #[test]
@@ -118,7 +118,7 @@ fn test_get_claimable_dividend_accumulates_across_distributions() {
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
 
     let expected = compute_expected_holder_dividend(10_000, 1, 1, DEFAULT_PROTOCOL_BPS) * 3;
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), expected);
+    assert_claimable(&client, &creator, &buyer, expected);
 }
 
 #[test]
@@ -145,5 +145,5 @@ fn test_get_claimable_dividend_works_while_paused() {
 
     // Read-only view must work even when protocol is paused.
     let expected = compute_expected_holder_dividend(10_000, 1, 1, DEFAULT_PROTOCOL_BPS);
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), expected);
+    assert_claimable(&client, &creator, &buyer, expected);
 }

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -405,6 +405,24 @@ pub fn distribute_test_dividend(
     client.distribute_dividend(creator, distributor, &amount);
 }
 
+/// Asserts that the claimable dividend for `wallet` on `creator` equals `expected`.
+///
+/// Panics with a descriptive message that includes creator, wallet, expected, and actual values
+/// when the amounts differ, making it easy to identify which holder's dividend is wrong.
+pub fn assert_claimable(
+    client: &CreatorKeysContractClient<'_>,
+    creator: &Address,
+    wallet: &Address,
+    expected: i128,
+) {
+    let actual = client.get_claimable_dividend(creator, wallet);
+    assert_eq!(
+        actual,
+        expected,
+        "claimable dividend mismatch: creator={creator:?} wallet={wallet:?} expected={expected} actual={actual}"
+    );
+}
+
 /// Computes the expected claimable dividend for a holder given distribution parameters.
 ///
 /// Mirrors the contract's per-key accumulator model:

--- a/creator-keys/tests/distribute_dividend.rs
+++ b/creator-keys/tests/distribute_dividend.rs
@@ -3,9 +3,9 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    compute_expected_holder_dividend, distribute_test_dividend, register_creator_keys,
-    register_test_creator, set_key_price_for_tests, set_pricing_and_fees, test_env_with_auths,
-    DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
+    assert_claimable, compute_expected_holder_dividend, distribute_test_dividend,
+    register_creator_keys, register_test_creator, set_key_price_for_tests, set_pricing_and_fees,
+    test_env_with_auths, DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
 };
 use creator_keys::ContractError;
 use soroban_sdk::{testutils::Address as _, Address};
@@ -153,8 +153,7 @@ fn test_distribute_dividend_single_holder_receives_full_net() {
     distribute_test_dividend(&client, &creator, &distributor, amount);
 
     let expected = compute_expected_holder_dividend(amount, 1, 1, DEFAULT_PROTOCOL_BPS);
-    let claimable = client.get_claimable_dividend(&creator, &buyer);
-    assert_eq!(claimable, expected);
+    assert_claimable(&client, &creator, &buyer, expected);
 }
 
 #[test]
@@ -179,14 +178,8 @@ fn test_distribute_dividend_two_equal_holders_split_evenly() {
     distribute_test_dividend(&client, &creator, &distributor, amount);
 
     let expected_each = compute_expected_holder_dividend(amount, 1, 2, DEFAULT_PROTOCOL_BPS);
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &buyer_a),
-        expected_each
-    );
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &buyer_b),
-        expected_each
-    );
+    assert_claimable(&client, &creator, &buyer_a, expected_each);
+    assert_claimable(&client, &creator, &buyer_b, expected_each);
 }
 
 #[test]
@@ -215,14 +208,8 @@ fn test_distribute_dividend_proportional_to_balance() {
 
     let expected_whale = compute_expected_holder_dividend(amount, 3, 4, DEFAULT_PROTOCOL_BPS);
     let expected_small = compute_expected_holder_dividend(amount, 1, 4, DEFAULT_PROTOCOL_BPS);
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &whale),
-        expected_whale
-    );
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &small),
-        expected_small
-    );
+    assert_claimable(&client, &creator, &whale, expected_whale);
+    assert_claimable(&client, &creator, &small, expected_small);
 }
 
 #[test]
@@ -245,7 +232,7 @@ fn test_distribute_dividend_deducts_protocol_fee() {
     assert_eq!(after_protocol_balance - before_protocol_balance, 1_000);
 
     // Holder gets 90% of 10_000 = 9_000
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), 9_000);
+    assert_claimable(&client, &creator, &buyer, 9_000);
 }
 
 #[test]
@@ -268,5 +255,5 @@ fn test_multiple_distributions_accumulate() {
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
 
     let expected = compute_expected_holder_dividend(10_000, 1, 1, DEFAULT_PROTOCOL_BPS) * 2;
-    assert_eq!(client.get_claimable_dividend(&creator, &buyer), expected);
+    assert_claimable(&client, &creator, &buyer, expected);
 }

--- a/creator-keys/tests/dividend_accumulator.rs
+++ b/creator-keys/tests/dividend_accumulator.rs
@@ -5,9 +5,9 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    compute_expected_holder_dividend, distribute_test_dividend, register_creator_keys,
-    register_test_creator, set_pricing_and_fees, test_env_with_auths, DEFAULT_CREATOR_BPS,
-    DEFAULT_PROTOCOL_BPS,
+    assert_claimable, compute_expected_holder_dividend, distribute_test_dividend,
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+    DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
 };
 use soroban_sdk::{testutils::Address as _, Address};
 
@@ -34,7 +34,7 @@ fn test_new_buyer_after_distribution_earns_no_retroactive_dividends() {
     let late_buyer = Address::generate(&env);
     client.buy_key(&creator, &late_buyer, &100, &None);
 
-    assert_eq!(client.get_claimable_dividend(&creator, &late_buyer), 0);
+    assert_claimable(&client, &creator, &late_buyer, 0);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_existing_holder_earns_from_all_distributions_via_checkpoint() {
 
     // Holder was present for both distributions; supply was 1 for both.
     let expected = compute_expected_holder_dividend(10_000, 1, 1, DEFAULT_PROTOCOL_BPS) * 2;
-    assert_eq!(client.get_claimable_dividend(&creator, &holder), expected);
+    assert_claimable(&client, &creator, &holder, expected);
 }
 
 #[test]
@@ -94,10 +94,7 @@ fn test_sell_all_then_rebuy_starts_fresh_on_pending() {
     let per_dist = compute_expected_holder_dividend(10_000, 1, 1, DEFAULT_PROTOCOL_BPS);
     // Total = pending_from_before_sell + earned_since_rebuy
     let expected_total = pending_after_sell + per_dist;
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &holder),
-        expected_total
-    );
+    assert_claimable(&client, &creator, &holder, expected_total);
 }
 
 #[test]
@@ -125,10 +122,7 @@ fn test_accumulator_grows_correctly_across_sequential_distributions() {
         total_expected += compute_expected_holder_dividend(amount, 1, 1, DEFAULT_PROTOCOL_BPS);
     }
 
-    assert_eq!(
-        client.get_claimable_dividend(&creator, &holder),
-        total_expected
-    );
+    assert_claimable(&client, &creator, &holder, total_expected);
 }
 
 #[test]
@@ -161,5 +155,5 @@ fn test_buy_more_keys_mid_stream_does_not_earn_retroactively() {
     let second_dist = compute_expected_holder_dividend(10_000, 2, 2, DEFAULT_PROTOCOL_BPS);
     let expected = first_dist + second_dist;
 
-    assert_eq!(client.get_claimable_dividend(&creator, &holder), expected);
+    assert_claimable(&client, &creator, &holder, expected);
 }


### PR DESCRIPTION
Closes #451

## What changed
- Added `assert_claimable(client, creator, wallet, expected)` to `contract_test_env/mod.rs`
- Updated all `get_claimable_dividend` assertions in `claimable_dividend_view.rs`, `distribute_dividend.rs`, `dividend_accumulator.rs`, and `claim_dividend.rs` to use the new helper

## Why
Multiple test files repeated the same `assert_eq!(client.get_claimable_dividend(&creator, &wallet), expected)` pattern. The helper centralises this assertion and produces a descriptive panic message that includes the creator address, wallet address, expected value, and actual value, making failures easier to diagnose without having to look up which holder or creator is involved.

## How to test
```
cargo test --test claimable_dividend_view
cargo test --test distribute_dividend
cargo test --test dividend_accumulator
cargo test --test claim_dividend
```