### PR TITLE
docs/tests: curve preset immutability docs + unpause/buyback/max-supply regression tests (#467-470)

### DIFF
--- a/creator-keys/tests/buyback_protocol_fee_regression.rs
+++ b/creator-keys/tests/buyback_protocol_fee_regression.rs
@@ -14,3 +14,118 @@ use contract_test_env::{
 const KEY_PRICE: i128 = 1_000;
 const CREATOR_BPS: u32 = 9_000;
 const PROTOCOL_BPS: u32 = 1_000;
+
+// ---------------------------------------------------------------------------
+// Treasury receives protocol fee on buyback
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_treasury_balance_increases_by_protocol_fee_on_buyback() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Creator self-buys 2 keys
+    for _ in 0..2 {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &creator, &quote.total_amount, &None);
+    }
+
+    let treasury_before = client.get_protocol_recipient_balance();
+    let expected_protocol_fee = compute_expected_protocol_fee(KEY_PRICE, PROTOCOL_BPS);
+
+    let total_cost = client.get_buyback_quote(&creator, &1);
+    client.buyback(&creator, &creator, &1, &total_cost, &None);
+
+    let treasury_after = client.get_protocol_recipient_balance();
+    assert_eq!(
+        treasury_after,
+        treasury_before + expected_protocol_fee,
+        "treasury must increase by exactly the protocol fee on a single-key buyback"
+    );
+}
+
+#[test]
+fn test_treasury_balance_increases_by_protocol_fee_on_multi_key_buyback() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Creator self-buys 3 keys
+    for _ in 0..3 {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &creator, &quote.total_amount, &None);
+    }
+
+    let treasury_before = client.get_protocol_recipient_balance();
+    let buyback_amount: u32 = 2;
+    let base_price = KEY_PRICE * buyback_amount as i128;
+    let expected_protocol_fee = compute_expected_protocol_fee(base_price, PROTOCOL_BPS);
+
+    let total_cost = client.get_buyback_quote(&creator, &buyback_amount);
+    client.buyback(&creator, &creator, &buyback_amount, &total_cost, &None);
+
+    let treasury_after = client.get_protocol_recipient_balance();
+    assert_eq!(
+        treasury_after,
+        treasury_before + expected_protocol_fee,
+        "treasury must increase by protocol fee on a {}-key buyback",
+        buyback_amount,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Creator is charged bonding curve price plus protocol fee (not creator fee)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_buyback_quote_equals_bonding_curve_price_plus_protocol_fee() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    for _ in 0..2 {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &creator, &quote.total_amount, &None);
+    }
+
+    let expected_base = KEY_PRICE;
+    let expected_protocol_fee = compute_expected_protocol_fee(expected_base, PROTOCOL_BPS);
+    let expected_total = expected_base + expected_protocol_fee;
+
+    let actual_quote = client.get_buyback_quote(&creator, &1);
+    assert_eq!(
+        actual_quote, expected_total,
+        "buyback quote must equal bonding curve price plus protocol fee (no creator fee)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Creator fee recipient balance unchanged — creator fee waived on buyback
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_creator_fee_recipient_balance_unchanged_on_buyback() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    for _ in 0..2 {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &creator, &quote.total_amount, &None);
+    }
+
+    let creator_fee_before = client.get_creator_fee_balance(&creator);
+    let total_cost = client.get_buyback_quote(&creator, &1);
+    client.buyback(&creator, &creator, &1, &total_cost, &None);
+
+    let creator_fee_after = client.get_creator_fee_balance(&creator);
+    assert_eq!(
+        creator_fee_after, creator_fee_before,
+        "creator fee recipient balance must not change on buyback — creator fee is waived"
+    );
+}

--- a/creator-keys/tests/buyback_protocol_fee_regression.rs
+++ b/creator-keys/tests/buyback_protocol_fee_regression.rs
@@ -1,0 +1,16 @@
+//! Regression tests for protocol fee applied during creator buyback (#469).
+//!
+//! Covers: treasury balance increases by the correct protocol fee on buyback,
+//! creator is charged bonding curve price plus protocol fee, and creator fee
+//! recipient balance is unchanged (creator fee is waived on buyback).
+
+mod contract_test_env;
+
+use contract_test_env::{
+    compute_expected_protocol_fee, register_creator_keys, register_test_creator,
+    set_pricing_and_fees, test_env_with_auths,
+};
+
+const KEY_PRICE: i128 = 1_000;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;

--- a/creator-keys/tests/buyback_protocol_fee_regression.rs
+++ b/creator-keys/tests/buyback_protocol_fee_regression.rs
@@ -129,3 +129,31 @@ fn test_creator_fee_recipient_balance_unchanged_on_buyback() {
         "creator fee recipient balance must not change on buyback — creator fee is waived"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Treasury balance is unchanged when buyback reverts (zero amount)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_treasury_balance_unchanged_when_buyback_reverts() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Buy one key so the creator has a position
+    let quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &creator, &quote.total_amount, &None);
+
+    let treasury_before = client.get_protocol_recipient_balance();
+
+    // Buyback with zero amount reverts
+    let result = client.try_buyback(&creator, &creator, &0, &1, &None);
+    assert!(result.is_err(), "buyback with zero amount must revert");
+
+    let treasury_after = client.get_protocol_recipient_balance();
+    assert_eq!(
+        treasury_after, treasury_before,
+        "treasury must be unchanged after a reverted buyback"
+    );
+}

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -1,0 +1,167 @@
+//! Unit tests for supply cap of zero rejected at creator registration (#470).
+//!
+//! Covers: Some(0) supply cap reverts at registration, no creator state is written
+//! after a failed registration, and Some(1) is accepted as the minimum valid cap.
+
+use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn make_client(env: &Env) -> CreatorKeysContractClient<'_> {
+    let id = env.register(CreatorKeysContract, ());
+    CreatorKeysContractClient::new(env, &id)
+}
+
+// ---------------------------------------------------------------------------
+// Some(0) reverts with NotPositiveAmount
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_supply_zero_reverts_at_registration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &Some(0),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::NotPositiveAmount)),
+        "max_supply: Some(0) must revert with NotPositiveAmount"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// No creator state written after failed registration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let _ = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &Some(0),
+    );
+
+    // Creator must not appear as registered
+    assert!(
+        !client.is_creator_registered(&creator),
+        "creator must not be registered after a failed registration"
+    );
+
+    // Max supply must not have been written
+    let stored_cap = client.get_max_supply(&creator);
+    assert_eq!(
+        stored_cap, None,
+        "max_supply storage must be empty after a failed registration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Some(1) accepted as the minimum valid cap
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_supply_one_accepted_as_minimum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &Some(1),
+    );
+    assert!(
+        result.is_ok(),
+        "max_supply: Some(1) must be accepted as the minimum valid cap"
+    );
+    assert!(
+        client.is_creator_registered(&creator),
+        "creator must be registered after successful registration with max_supply: Some(1)"
+    );
+    assert_eq!(
+        client.get_max_supply(&creator),
+        Some(1),
+        "stored max_supply must equal 1"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// None (no cap) is accepted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_supply_none_accepted_no_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+    );
+    assert!(
+        result.is_ok(),
+        "max_supply: None must be accepted (no cap)"
+    );
+    assert!(client.is_creator_registered(&creator));
+    assert_eq!(
+        client.get_max_supply(&creator),
+        None,
+        "no max_supply must be stored when None is passed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Some(2) and larger values accepted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_supply_two_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &Some(2),
+    );
+    assert!(result.is_ok(), "max_supply: Some(2) must be accepted");
+    assert_eq!(client.get_max_supply(&creator), Some(2));
+}
+
+#[test]
+fn test_max_supply_large_value_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+
+    let creator = Address::generate(&env);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &Some(1_000_000),
+    );
+    assert!(result.is_ok(), "max_supply: Some(1_000_000) must be accepted");
+    assert_eq!(client.get_max_supply(&creator), Some(1_000_000));
+}

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -22,12 +22,8 @@ fn test_max_supply_zero_reverts_at_registration() {
     let client = make_client(&env);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
-        &None,
-        &Some(0),
-    );
+    let result =
+        client.try_register_creator(&creator, &String::from_str(&env, "alice"), &None, &Some(0));
     assert_eq!(
         result,
         Err(Ok(ContractError::NotPositiveAmount)),
@@ -46,12 +42,8 @@ fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
     let client = make_client(&env);
 
     let creator = Address::generate(&env);
-    let _ = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
-        &None,
-        &Some(0),
-    );
+    let _ =
+        client.try_register_creator(&creator, &String::from_str(&env, "alice"), &None, &Some(0));
 
     // Creator must not appear as registered
     assert!(
@@ -78,12 +70,8 @@ fn test_max_supply_one_accepted_as_minimum() {
     let client = make_client(&env);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
-        &None,
-        &Some(1),
-    );
+    let result =
+        client.try_register_creator(&creator, &String::from_str(&env, "alice"), &None, &Some(1));
     assert!(
         result.is_ok(),
         "max_supply: Some(1) must be accepted as the minimum valid cap"
@@ -110,16 +98,9 @@ fn test_max_supply_none_accepted_no_cap() {
     let client = make_client(&env);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
-        &None,
-        &None,
-    );
-    assert!(
-        result.is_ok(),
-        "max_supply: None must be accepted (no cap)"
-    );
+    let result =
+        client.try_register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    assert!(result.is_ok(), "max_supply: None must be accepted (no cap)");
     assert!(client.is_creator_registered(&creator));
     assert_eq!(
         client.get_max_supply(&creator),
@@ -139,12 +120,8 @@ fn test_max_supply_two_accepted() {
     let client = make_client(&env);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
-        &None,
-        &Some(2),
-    );
+    let result =
+        client.try_register_creator(&creator, &String::from_str(&env, "alice"), &None, &Some(2));
     assert!(result.is_ok(), "max_supply: Some(2) must be accepted");
     assert_eq!(client.get_max_supply(&creator), Some(2));
 }
@@ -162,6 +139,9 @@ fn test_max_supply_large_value_accepted() {
         &None,
         &Some(1_000_000),
     );
-    assert!(result.is_ok(), "max_supply: Some(1_000_000) must be accepted");
+    assert!(
+        result.is_ok(),
+        "max_supply: Some(1_000_000) must be accepted"
+    );
     assert_eq!(client.get_max_supply(&creator), Some(1_000_000));
 }

--- a/creator-keys/tests/unpause_restores_buy_sell_regression.rs
+++ b/creator-keys/tests/unpause_restores_buy_sell_regression.rs
@@ -80,3 +80,109 @@ fn test_buy_succeeds_immediately_after_unpause() {
     assert_eq!(client.get_total_key_supply(&creator), 2);
     assert_eq!(client.get_key_balance(&creator, &buyer), 2);
 }
+
+// ---------------------------------------------------------------------------
+// sell reverts while paused; sell succeeds immediately after unpause
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sell_reverts_while_paused() {
+    let env = test_env_with_auths();
+    let (client, admin, creator) = setup_with_admin(&env);
+    let buyer = Address::generate(&env);
+
+    // Buy a key first so the seller has something to sell
+    let quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &buyer, &quote.total_amount, &None);
+
+    client.pause(&admin);
+    assert!(client.get_is_paused());
+
+    let result = client.try_sell_key(&creator, &buyer, &None);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ProtocolPaused)),
+        "sell must revert with ProtocolPaused while protocol is paused"
+    );
+    // Balance must be unchanged — no partial sell
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+}
+
+#[test]
+fn test_sell_succeeds_immediately_after_unpause() {
+    let env = test_env_with_auths();
+    let (client, admin, creator) = setup_with_admin(&env);
+    let buyer = Address::generate(&env);
+
+    // Buy two keys so post-sell state can be meaningfully asserted
+    for _ in 0..2 {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &buyer, &quote.total_amount, &None);
+    }
+    assert_eq!(client.get_total_key_supply(&creator), 2);
+
+    client.pause(&admin);
+    // Sell must fail while paused
+    let paused_result = client.try_sell_key(&creator, &buyer, &None);
+    assert_eq!(paused_result, Err(Ok(ContractError::ProtocolPaused)));
+
+    client.unpause(&admin);
+    assert!(!client.get_is_paused());
+
+    // Sell must succeed in the very next call after unpause
+    let new_supply = client.sell_key(&creator, &buyer, &None);
+    assert_eq!(new_supply, 1, "supply must be 1 after successful sell post-unpause");
+    assert_eq!(client.get_total_key_supply(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Full cycle: buy → pause → buy fails → unpause → buy → sell
+// State after unpause must match expected values as if the pause never occurred
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_post_unpause_state_matches_baseline() {
+    let env = test_env_with_auths();
+    let (client, admin, creator) = setup_with_admin(&env);
+    let buyer = Address::generate(&env);
+
+    // Baseline buy before the pause
+    let quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &buyer, &quote.total_amount, &None);
+    let supply_pre_pause = client.get_total_key_supply(&creator);
+    let balance_pre_pause = client.get_key_balance(&creator, &buyer);
+    assert_eq!(supply_pre_pause, 1);
+    assert_eq!(balance_pre_pause, 1);
+
+    client.pause(&admin);
+
+    // Attempted buy during pause must not mutate state
+    let _ = client.try_buy_key(&creator, &buyer, &quote.total_amount, &None);
+    assert_eq!(client.get_total_key_supply(&creator), supply_pre_pause);
+    assert_eq!(client.get_key_balance(&creator, &buyer), balance_pre_pause);
+
+    client.unpause(&admin);
+
+    // Post-unpause buy: supply advances exactly by 1
+    let quote_post = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &buyer, &quote_post.total_amount, &None);
+    assert_eq!(
+        client.get_total_key_supply(&creator),
+        supply_pre_pause + 1,
+        "post-unpause supply must equal pre-pause supply plus the new buy"
+    );
+    assert_eq!(
+        client.get_key_balance(&creator, &buyer),
+        balance_pre_pause + 1,
+    );
+
+    // Post-unpause sell: supply retreats by 1
+    client.sell_key(&creator, &buyer, &None);
+    assert_eq!(
+        client.get_total_key_supply(&creator),
+        supply_pre_pause,
+        "supply after post-unpause sell must equal the pre-pause baseline"
+    );
+    assert_eq!(client.get_key_balance(&creator, &buyer), balance_pre_pause);
+}

--- a/creator-keys/tests/unpause_restores_buy_sell_regression.rs
+++ b/creator-keys/tests/unpause_restores_buy_sell_regression.rs
@@ -7,12 +7,14 @@
 mod contract_test_env;
 
 use contract_test_env::{
-    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
 };
 use creator_keys::ContractError;
 use soroban_sdk::{testutils::Address as _, Address};
 
 const KEY_PRICE: i128 = 1_000;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;
 
 fn setup_with_admin(
     env: &soroban_sdk::Env,
@@ -22,9 +24,59 @@ fn setup_with_admin(
     Address,
 ) {
     let (client, _) = register_creator_keys(env);
-    set_key_price_for_tests(env, &client, KEY_PRICE);
+    set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
     let admin = Address::generate(env);
     client.set_protocol_admin(&admin, &admin);
     let creator = register_test_creator(env, &client, "alice");
     (client, admin, creator)
+}
+
+// ---------------------------------------------------------------------------
+// buy reverts while paused; buy succeeds immediately after unpause
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_buy_reverts_while_paused() {
+    let env = test_env_with_auths();
+    let (client, admin, creator) = setup_with_admin(&env);
+    let buyer = Address::generate(&env);
+    let quote = client.get_buy_quote(&creator);
+
+    client.pause(&admin);
+    assert!(client.get_is_paused());
+
+    let result = client.try_buy_key(&creator, &buyer, &quote.total_amount, &None);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ProtocolPaused)),
+        "buy must revert with ProtocolPaused while protocol is paused"
+    );
+}
+
+#[test]
+fn test_buy_succeeds_immediately_after_unpause() {
+    let env = test_env_with_auths();
+    let (client, admin, creator) = setup_with_admin(&env);
+    let buyer = Address::generate(&env);
+
+    // Establish baseline: one buy before pause
+    let quote_before = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &buyer, &quote_before.total_amount, &None);
+    let supply_before_pause = client.get_total_key_supply(&creator);
+    assert_eq!(supply_before_pause, 1);
+
+    client.pause(&admin);
+    // Buy attempt must fail
+    let paused_result = client.try_buy_key(&creator, &buyer, &quote_before.total_amount, &None);
+    assert_eq!(paused_result, Err(Ok(ContractError::ProtocolPaused)));
+
+    client.unpause(&admin);
+    assert!(!client.get_is_paused());
+
+    // Buy must succeed in the very next call after unpause
+    let quote_after = client.get_buy_quote(&creator);
+    let new_supply = client.buy_key(&creator, &buyer, &quote_after.total_amount, &None);
+    assert_eq!(new_supply, 2, "supply must be 2 after successful buy post-unpause");
+    assert_eq!(client.get_total_key_supply(&creator), 2);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 2);
 }

--- a/creator-keys/tests/unpause_restores_buy_sell_regression.rs
+++ b/creator-keys/tests/unpause_restores_buy_sell_regression.rs
@@ -76,7 +76,10 @@ fn test_buy_succeeds_immediately_after_unpause() {
     // Buy must succeed in the very next call after unpause
     let quote_after = client.get_buy_quote(&creator);
     let new_supply = client.buy_key(&creator, &buyer, &quote_after.total_amount, &None);
-    assert_eq!(new_supply, 2, "supply must be 2 after successful buy post-unpause");
+    assert_eq!(
+        new_supply, 2,
+        "supply must be 2 after successful buy post-unpause"
+    );
     assert_eq!(client.get_total_key_supply(&creator), 2);
     assert_eq!(client.get_key_balance(&creator, &buyer), 2);
 }
@@ -131,7 +134,10 @@ fn test_sell_succeeds_immediately_after_unpause() {
 
     // Sell must succeed in the very next call after unpause
     let new_supply = client.sell_key(&creator, &buyer, &None);
-    assert_eq!(new_supply, 1, "supply must be 1 after successful sell post-unpause");
+    assert_eq!(
+        new_supply, 1,
+        "supply must be 1 after successful sell post-unpause"
+    );
     assert_eq!(client.get_total_key_supply(&creator), 1);
     assert_eq!(client.get_key_balance(&creator, &buyer), 1);
 }

--- a/creator-keys/tests/unpause_restores_buy_sell_regression.rs
+++ b/creator-keys/tests/unpause_restores_buy_sell_regression.rs
@@ -1,0 +1,30 @@
+//! Regression tests for unpause restoring full buy and sell functionality (#468).
+//!
+//! Covers: buy reverts while paused, buy succeeds immediately after unpause,
+//! sell succeeds immediately after unpause, and post-unpause state matches
+//! expected values as if the pause never occurred.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address};
+
+const KEY_PRICE: i128 = 1_000;
+
+fn setup_with_admin(
+    env: &soroban_sdk::Env,
+) -> (
+    creator_keys::CreatorKeysContractClient<'_>,
+    Address,
+    Address,
+) {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, KEY_PRICE);
+    let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, admin, creator)
+}

--- a/docs/curve-preset-immutability.md
+++ b/docs/curve-preset-immutability.md
@@ -72,3 +72,12 @@ This is the only read path. The return value is the global slope stored at
 This absence is intentional. Providing an update path would introduce the holder-harm
 scenarios described above. Any contributor who adds such a function must first address
 the migration and consent mechanism for existing holders.
+
+---
+
+## Related documents
+
+- [bonding-curve-formula.md](./bonding-curve-formula.md) — full price formula and fee pipeline
+- [fee-assumptions.md](./fee-assumptions.md) — fee split math and rounding
+- [read-only-methods.md](./read-only-methods.md) — all read-only contract entry points
+- [deterministic-quote-tests.md](./deterministic-quote-tests.md) — how quote regression tests are structured

--- a/docs/curve-preset-immutability.md
+++ b/docs/curve-preset-immutability.md
@@ -3,3 +3,72 @@
 This document explains why the bonding curve configuration (slope) for a creator's keys
 is treated as immutable after registration, what "curve preset" means in this codebase,
 and how to read the current value.
+
+---
+
+## What is the curve preset?
+
+The **curve preset** is the bonding curve slope configured via `set_curve_slope` before a
+creator registers. The slope determines how the key price scales with supply:
+
+```
+price(supply) = base_price + slope * supply
+```
+
+When `slope == 0` the curve is flat (constant price regardless of supply). A positive slope
+makes each successive key more expensive than the last — a classic bonding curve shape.
+
+The slope value in effect at registration time is the implicit preset for that creator.
+Buyers who purchase that creator's keys are pricing their positions against the curve that
+was active when the creator first appeared on-chain.
+
+---
+
+## Why the preset is immutable after registration
+
+Once a creator has registered and buyers have purchased keys, changing the curve slope would
+retroactively reprice all outstanding positions:
+
+- A buyer who paid `base_price + slope_old * 5` for the sixth key made that decision knowing
+  the exit price follows the same curve. Swapping the slope mid-life invalidates that
+  expectation.
+- Holders cannot hedge against an unknown future slope change. A steeper slope raises the
+  exit cost for late sellers; a flatter slope reduces the return for early buyers who paid
+  a premium. Either direction harms some subset of holders.
+- Price continuity is a social contract. Breaking it mid-stream would destroy trust in the
+  key market for that creator.
+
+To prevent these harms, **no `set_curve_slope` call can retroactively alter the price
+history of keys that were already bought at a different slope**. The slope is effectively
+locked for each cohort of buyers from the moment they transact.
+
+---
+
+## Deploying with a different curve
+
+A creator who wants a different curve shape must complete a new creator registration:
+
+1. Deploy a new contract instance (or re-register on a fork/new protocol instance).
+2. Set the desired slope via `set_curve_slope` *before* registration.
+3. Register the creator address under the new slope.
+
+Existing holders of the old creator's keys are unaffected — their positions remain priced
+on the original curve until they choose to sell.
+
+---
+
+## Read path and absence of an update path
+
+To inspect the current slope:
+
+```
+get_curve_slope() -> i128
+```
+
+This is the only read path. The return value is the global slope stored at
+`constants::storage::CURVE_SLOPE`.
+
+**There is no `set_curve_slope_for_creator` or equivalent per-creator update function.**
+This absence is intentional. Providing an update path would introduce the holder-harm
+scenarios described above. Any contributor who adds such a function must first address
+the migration and consent mechanism for existing holders.

--- a/docs/curve-preset-immutability.md
+++ b/docs/curve-preset-immutability.md
@@ -1,0 +1,5 @@
+# Curve preset immutability
+
+This document explains why the bonding curve configuration (slope) for a creator's keys
+is treated as immutable after registration, what "curve preset" means in this codebase,
+and how to read the current value.


### PR DESCRIPTION
Fixes #467
Fixes #468
Fixes #469
Fixes #470

## What changed

- **#467** — Added `docs/curve-preset-immutability.md`: explains why the bonding curve slope is immutable after creator registration, documents the holder-harm of a mid-life curve change, and points to `get_curve_slope` as the sole read path with no update path by design.
- **#468** — Added `creator-keys/tests/unpause_restores_buy_sell_regression.rs`: 5 regression tests covering buy reverts while paused, buy succeeds immediately after unpause, sell reverts while paused, sell succeeds immediately after unpause, and full buy→pause→buy-fails→unpause→buy→sell cycle with state assertions.
- **#469** — Added `creator-keys/tests/buyback_protocol_fee_regression.rs`: 5 regression tests confirming treasury balance increases by the correct protocol fee on buyback, buyback quote equals bonding curve price plus protocol fee only (creator fee waived), creator fee recipient balance is unchanged, and treasury is unaffected by a reverted buyback.
- **#470** — Added `creator-keys/tests/max_supply_zero_rejected.rs`: 6 unit tests confirming `max_supply: Some(0)` reverts with `NotPositiveAmount`, no creator state is written after the failure, `Some(1)` is accepted as the minimum valid cap, and `None`/larger values are also accepted.

## Why

These four issues document a design invariant (#467), prevent regressions in pause/unpause behaviour (#468), pin the fee-waiver logic for creator buybacks (#469), and guard the supply-cap validation against zero-cap registrations (#470).

## How to test

```bash
cargo test -p creator-keys --test unpause_restores_buy_sell_regression
cargo test -p creator-keys --test buyback_protocol_fee_regression
cargo test -p creator-keys --test max_supply_zero_rejected
```

All 16 new tests pass locally.