### PR TITLE
test: regression tests for issues #463, #464, #465, #466

### DIFF
--- a/creator-keys/tests/dividend_total_claimable_cap.rs
+++ b/creator-keys/tests/dividend_total_claimable_cap.rs
@@ -47,8 +47,7 @@ fn test_sum_claimable_never_exceeds_distributed_minus_protocol_fee() {
     let distributor = Address::generate(&env);
     distribute_test_dividend(&client, &creator, &distributor, distribution_amount);
 
-    let protocol_fee =
-        (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
+    let protocol_fee = (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
     let net_amount = distribution_amount - protocol_fee;
 
     let claimable_a = client.get_claimable_dividend(&creator, &holder_a);
@@ -104,8 +103,7 @@ fn test_rounding_dust_stays_within_contract() {
     let distributor = Address::generate(&env);
     distribute_test_dividend(&client, &creator, &distributor, distribution_amount);
 
-    let protocol_fee =
-        (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
+    let protocol_fee = (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
     let net_amount = distribution_amount - protocol_fee;
 
     let claimable_a = client.get_claimable_dividend(&creator, &holder_a);

--- a/creator-keys/tests/dividend_total_claimable_cap.rs
+++ b/creator-keys/tests/dividend_total_claimable_cap.rs
@@ -1,0 +1,121 @@
+//! Regression test: after a dividend distribution the sum of all claimable
+//! amounts across every holder must never exceed the distributed amount minus
+//! the protocol fee. Covers unequal holder balances to catch proportional
+//! split errors and rounding issues.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    assert_claimable, compute_expected_holder_dividend, distribute_test_dividend,
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+    DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
+};
+use soroban_sdk::{testutils::Address as _, Address};
+
+const KEY_PRICE: i128 = 100;
+
+#[test]
+fn test_sum_claimable_never_exceeds_distributed_minus_protocol_fee() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(
+        &env,
+        &client,
+        KEY_PRICE,
+        DEFAULT_CREATOR_BPS,
+        DEFAULT_PROTOCOL_BPS,
+    );
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+    let holder_c = Address::generate(&env);
+
+    // holder_a: 3 keys, holder_b: 2 keys, holder_c: 1 key → supply = 6
+    for _ in 0..3 {
+        client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    }
+    for _ in 0..2 {
+        client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+    }
+    client.buy_key(&creator, &holder_c, &KEY_PRICE, &None);
+
+    let total_supply = client.get_total_key_supply(&creator);
+    assert_eq!(total_supply, 6);
+
+    let distribution_amount: i128 = 100_000;
+    let distributor = Address::generate(&env);
+    distribute_test_dividend(&client, &creator, &distributor, distribution_amount);
+
+    let protocol_fee =
+        (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
+    let net_amount = distribution_amount - protocol_fee;
+
+    let claimable_a = client.get_claimable_dividend(&creator, &holder_a);
+    let claimable_b = client.get_claimable_dividend(&creator, &holder_b);
+    let claimable_c = client.get_claimable_dividend(&creator, &holder_c);
+
+    let total_claimable = claimable_a + claimable_b + claimable_c;
+
+    assert!(
+        total_claimable <= net_amount,
+        "sum of claimable ({total_claimable}) must not exceed net distributed ({net_amount})"
+    );
+
+    let expected_a =
+        compute_expected_holder_dividend(distribution_amount, 3, 6, DEFAULT_PROTOCOL_BPS);
+    let expected_b =
+        compute_expected_holder_dividend(distribution_amount, 2, 6, DEFAULT_PROTOCOL_BPS);
+    let expected_c =
+        compute_expected_holder_dividend(distribution_amount, 1, 6, DEFAULT_PROTOCOL_BPS);
+
+    assert_claimable(&client, &creator, &holder_a, expected_a);
+    assert_claimable(&client, &creator, &holder_b, expected_b);
+    assert_claimable(&client, &creator, &holder_c, expected_c);
+}
+
+#[test]
+fn test_rounding_dust_stays_within_contract() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(
+        &env,
+        &client,
+        KEY_PRICE,
+        DEFAULT_CREATOR_BPS,
+        DEFAULT_PROTOCOL_BPS,
+    );
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+    let holder_c = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    }
+    for _ in 0..2 {
+        client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+    }
+    client.buy_key(&creator, &holder_c, &KEY_PRICE, &None);
+
+    // Use an amount that doesn't divide evenly by 6 to trigger rounding.
+    let distribution_amount: i128 = 99_999;
+    let distributor = Address::generate(&env);
+    distribute_test_dividend(&client, &creator, &distributor, distribution_amount);
+
+    let protocol_fee =
+        (distribution_amount * DEFAULT_PROTOCOL_BPS as i128) / 10_000;
+    let net_amount = distribution_amount - protocol_fee;
+
+    let claimable_a = client.get_claimable_dividend(&creator, &holder_a);
+    let claimable_b = client.get_claimable_dividend(&creator, &holder_b);
+    let claimable_c = client.get_claimable_dividend(&creator, &holder_c);
+
+    let total_claimable = claimable_a + claimable_b + claimable_c;
+
+    assert!(
+        total_claimable <= net_amount,
+        "rounding dust must stay within contract: sum={total_claimable} net={net_amount}"
+    );
+}

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -49,11 +49,17 @@ fn test_get_locked_allocation_returns_some_when_set() {
     );
 
     let result = client.get_locked_allocation(&creator);
-    assert!(result.is_some(), "get_locked_allocation must return Some when locked allocation was set");
+    assert!(
+        result.is_some(),
+        "get_locked_allocation must return Some when locked allocation was set"
+    );
 
     let alloc = result.unwrap();
     assert_eq!(alloc.amount, amount, "locked amount must match");
-    assert_eq!(alloc.unlock_ledger, unlock_ledger, "unlock_ledger must match");
+    assert_eq!(
+        alloc.unlock_ledger, unlock_ledger,
+        "unlock_ledger must match"
+    );
     assert!(!alloc.claimed, "allocation must not be claimed initially");
 }
 

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -1,0 +1,72 @@
+//! Unit tests for `get_locked_allocation` returning `None` when a creator
+//! was registered without a locked allocation, and `Some` when one was set.
+//! Also asserts the expected error for a non-existent creator.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, test_env_with_auths};
+use creator_keys::LockedAllocation;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, String};
+
+#[test]
+fn test_get_locked_allocation_returns_none_when_not_set() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let result = client.get_locked_allocation(&creator);
+    assert_eq!(
+        result, None,
+        "get_locked_allocation must return None for creator registered without locked allocation"
+    );
+}
+
+#[test]
+fn test_get_locked_allocation_returns_some_when_set() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let creator = Address::generate(&env);
+    let handle = String::from_str(&env, "bob");
+    let unlock_ledger: u32 = 5000;
+    let amount: u32 = 100;
+
+    let mut ledger_info = env.ledger().get();
+    ledger_info.sequence_number = 1;
+    env.ledger().set(ledger_info);
+
+    client.register_creator(
+        &creator,
+        &handle,
+        &Some(LockedAllocation {
+            amount,
+            unlock_ledger,
+            claimed: false,
+        }),
+        &None,
+    );
+
+    let result = client.get_locked_allocation(&creator);
+    assert!(result.is_some(), "get_locked_allocation must return Some when locked allocation was set");
+
+    let alloc = result.unwrap();
+    assert_eq!(alloc.amount, amount, "locked amount must match");
+    assert_eq!(alloc.unlock_ledger, unlock_ledger, "unlock_ledger must match");
+    assert!(!alloc.claimed, "allocation must not be claimed initially");
+}
+
+#[test]
+fn test_get_locked_allocation_returns_none_for_nonexistent_creator() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let unknown = Address::generate(&env);
+
+    let result = client.get_locked_allocation(&unknown);
+    assert_eq!(
+        result, None,
+        "get_locked_allocation must return None for a non-existent creator"
+    );
+}

--- a/creator-keys/tests/slippage_boundary_regression.rs
+++ b/creator-keys/tests/slippage_boundary_regression.rs
@@ -1,0 +1,106 @@
+//! Regression tests for slippage protection boundary conditions.
+//! Buy must succeed when `max_price` equals the actual price exactly and
+//! revert when `max_price` is one stroop below. Symmetric tests for sell
+//! with `min_proceeds`.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    capture_snapshot, register_creator_keys, register_test_creator, set_pricing_and_fees,
+    test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address};
+
+const KEY_PRICE: i128 = 1_000;
+
+// ---------------------------------------------------------------------------
+// Buy: max_price boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_buy_succeeds_when_max_price_equals_actual_price() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
+
+    let quote = client.get_buy_quote(&creator);
+
+    let supply = client.buy_key(&creator, &buyer, &quote.total_amount, &Some(quote.price));
+    assert_eq!(supply, 1, "buy must succeed when max_price == actual price");
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+}
+
+#[test]
+fn test_buy_reverts_when_max_price_is_one_stroop_below() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
+
+    let quote = client.get_buy_quote(&creator);
+
+    let before = capture_snapshot(&client, &creator, &buyer);
+    let result =
+        client.try_buy_key(&creator, &buyer, &quote.total_amount, &Some(quote.price - 1));
+    let after = capture_snapshot(&client, &creator, &buyer);
+
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SlippageExceeded)),
+        "buy must revert when max_price is one stroop below actual price"
+    );
+    before.assert_unchanged(&after);
+}
+
+// ---------------------------------------------------------------------------
+// Sell: min_proceeds boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sell_succeeds_when_min_proceeds_equals_actual_proceeds() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+
+    let buy_quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &holder, &buy_quote.total_amount, &None);
+
+    let sell_quote = client.get_sell_quote(&creator, &holder);
+
+    let supply = client.sell_key(&creator, &holder, &Some(sell_quote.total_amount));
+    assert_eq!(
+        supply, 0,
+        "sell must succeed when min_proceeds == actual proceeds"
+    );
+}
+
+#[test]
+fn test_sell_reverts_when_min_proceeds_is_one_stroop_above() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+
+    let buy_quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &holder, &buy_quote.total_amount, &None);
+
+    let sell_quote = client.get_sell_quote(&creator, &holder);
+
+    let before = capture_snapshot(&client, &creator, &holder);
+    let result = client.try_sell_key(&creator, &holder, &Some(sell_quote.total_amount + 1));
+    let after = capture_snapshot(&client, &creator, &holder);
+
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SlippageExceeded)),
+        "sell must revert when min_proceeds is one stroop above actual proceeds"
+    );
+    before.assert_unchanged(&after);
+}

--- a/creator-keys/tests/slippage_boundary_regression.rs
+++ b/creator-keys/tests/slippage_boundary_regression.rs
@@ -44,8 +44,12 @@ fn test_buy_reverts_when_max_price_is_one_stroop_below() {
     let quote = client.get_buy_quote(&creator);
 
     let before = capture_snapshot(&client, &creator, &buyer);
-    let result =
-        client.try_buy_key(&creator, &buyer, &quote.total_amount, &Some(quote.price - 1));
+    let result = client.try_buy_key(
+        &creator,
+        &buyer,
+        &quote.total_amount,
+        &Some(quote.price - 1),
+    );
     let after = capture_snapshot(&client, &creator, &buyer);
 
     assert_eq!(

--- a/creator-keys/tests/transfer_keys_insufficient_balance.rs
+++ b/creator-keys/tests/transfer_keys_insufficient_balance.rs
@@ -1,0 +1,75 @@
+//! Regression tests: `transfer_keys` must revert with `InsufficientBalance`
+//! when the sender tries to transfer more keys than they hold.
+//! Sender balance and total supply must remain unchanged after the revert.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    capture_snapshot, register_creator_keys, register_test_creator, set_pricing_and_fees,
+    test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address};
+
+const KEY_PRICE: i128 = 100;
+
+#[test]
+fn test_transfer_exceeding_balance_reverts_with_insufficient_balance() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    assert_eq!(client.get_key_balance(&creator, &sender), 2);
+
+    let result = client.try_transfer_keys(&creator, &sender, &recipient, &3);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::InsufficientBalance)),
+        "transfer exceeding balance must revert with InsufficientBalance"
+    );
+}
+
+#[test]
+fn test_transfer_exceeding_balance_sender_balance_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+
+    let before = capture_snapshot(&client, &creator, &sender);
+    let _ = client.try_transfer_keys(&creator, &sender, &recipient, &3);
+    let after = capture_snapshot(&client, &creator, &sender);
+
+    before.assert_unchanged(&after);
+}
+
+#[test]
+fn test_transfer_exceeding_balance_total_supply_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let _admin = set_pricing_and_fees(&env, &client, KEY_PRICE, 9000, 1000);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let _ = client.try_transfer_keys(&creator, &sender, &recipient, &5);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        supply_before, supply_after,
+        "total supply must be unchanged after failed transfer"
+    );
+}


### PR DESCRIPTION
## Summary

- **#463** — `transfer_keys_insufficient_balance.rs`: Verifies `transfer_keys` reverts with `InsufficientBalance` when sender tries to transfer more keys than held; confirms sender balance and total supply remain unchanged after the revert.
- **#464** — `dividend_total_claimable_cap.rs`: Verifies the sum of all claimable dividend amounts across holders with unequal balances never exceeds the distributed amount minus the protocol fee; includes a rounding-dust test with an indivisible amount.
- **#465** — `get_locked_allocation_none.rs`: Verifies `get_locked_allocation` returns `None` for a creator registered without a locked allocation, `Some` with correct data when one was set, and `None` for a non-existent creator.
- **#466** — `slippage_boundary_regression.rs`: Verifies buy succeeds when `max_price` equals the actual price exactly and reverts one stroop below; symmetric sell tests for `min_proceeds`.

Closes #463
Closes #464
Closes #465
Closes #466

## Test plan

- [x] All 12 new tests pass locally (`cargo test` per test binary)
- [x] No changes to contract logic — test-only additions
- [x] Existing tests unaffected (no shared state modifications)