### PR TITLE
feat: add regression-test

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1019,7 +1019,6 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
-
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1089,9 +1088,7 @@ impl CreatorKeysContract {
         // Handle curve preset
         let preset = curve_preset.unwrap_or(CurvePreset::Linear);
         let preset_key = constants::storage::curve_preset(&creator);
-        env.storage()
-            .persistent()
-            .set(&preset_key, &preset);
+        env.storage().persistent().set(&preset_key, &preset);
 
         let profile = CreatorProfile {
             creator: creator.clone(),
@@ -1245,7 +1242,10 @@ impl CreatorKeysContract {
             .persistent()
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
-        let sell_supply = profile.supply.checked_sub(1).ok_or(ContractError::SellUnderflow)?;
+        let sell_supply = profile
+            .supply
+            .checked_sub(1)
+            .ok_or(ContractError::SellUnderflow)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, sell_supply)?;
 
         // Settle dividends before balance changes so earnings are captured at old balance.
@@ -1317,7 +1317,8 @@ impl CreatorKeysContract {
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
-        let curve_price = compute_bonding_curve_price(&env, &creator, base_price_stored, profile.supply)?;
+        let curve_price =
+            compute_bonding_curve_price(&env, &creator, base_price_stored, profile.supply)?;
         let base_price = compute_buyback_base_price(curve_price, amount)?;
         let config = read_required_protocol_fee_config(&env)?;
         let protocol_fee = fee::apply_percentage_fee(base_price, config.protocol_bps)
@@ -1993,7 +1994,10 @@ impl CreatorKeysContract {
         }
 
         let profile = read_registered_creator_profile(&env, &creator)?;
-        let sell_supply = profile.supply.checked_sub(1).ok_or(ContractError::SellUnderflow)?;
+        let sell_supply = profile
+            .supply
+            .checked_sub(1)
+            .ok_or(ContractError::SellUnderflow)?;
         let curve_price = compute_bonding_curve_price(&env, &creator, normalized, sell_supply)?;
         let Some(price) = normalize_quote_amount(curve_price)? else {
             return Ok(zero_quote_response());

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -280,6 +280,10 @@ pub mod constants {
         pub const PAUSED: DataKey = DataKey::Paused;
         pub const CURVE_SLOPE: DataKey = DataKey::CurveSlope;
 
+        pub fn curve_preset(creator: &Address) -> DataKey {
+            DataKey::CurvePreset(creator.clone())
+        }
+
         pub fn creator_fee_balance(creator: &Address) -> DataKey {
             DataKey::CreatorFeeBalance(creator.clone())
         }
@@ -451,6 +455,14 @@ pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum CurvePreset {
+    Linear = 0,
+    Quadratic = 1,
+    Flat = 2,
+}
+
 /// Canonical storage key schema for persistent protocol state.
 ///
 /// For quote-related key usage and invariants, see
@@ -475,6 +487,7 @@ pub enum DataKey {
     LockedAllocation(Address),
     MaxSupply(Address),
     CurveSlope,
+    CurvePreset(Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -753,7 +766,7 @@ fn resolve_quote_inputs(env: &Env, creator: &Address) -> Result<Option<i128>, Co
     };
 
     let profile = read_registered_creator_profile(env, creator)?;
-    let curve_price = compute_bonding_curve_price(env, normalized, profile.supply)?;
+    let curve_price = compute_bonding_curve_price(env, creator, normalized, profile.supply)?;
     normalize_quote_amount(curve_price)
 }
 
@@ -801,19 +814,40 @@ fn read_curve_slope(env: &Env) -> i128 {
 
 fn compute_bonding_curve_price(
     env: &Env,
+    creator: &Address,
     base_price: i128,
     supply: u32,
 ) -> Result<i128, ContractError> {
-    let slope = read_curve_slope(env);
-    if slope == 0 {
-        return Ok(base_price);
+    let preset = env
+        .storage()
+        .persistent()
+        .get(&constants::storage::curve_preset(creator))
+        .unwrap_or(CurvePreset::Linear);
+
+    match preset {
+        CurvePreset::Flat => Ok(base_price),
+        CurvePreset::Linear => {
+            let slope = read_curve_slope(env);
+            let supply_component = slope
+                .checked_mul(i128::from(supply))
+                .ok_or(ContractError::Overflow)?;
+            base_price
+                .checked_add(supply_component)
+                .ok_or(ContractError::Overflow)
+        }
+        CurvePreset::Quadratic => {
+            let slope = read_curve_slope(env);
+            let supply_sq = (supply as i128)
+                .checked_mul(supply as i128)
+                .ok_or(ContractError::Overflow)?;
+            let supply_component = slope
+                .checked_mul(supply_sq)
+                .ok_or(ContractError::Overflow)?;
+            base_price
+                .checked_add(supply_component)
+                .ok_or(ContractError::Overflow)
+        }
     }
-    let supply_component = slope
-        .checked_mul(i128::from(supply))
-        .ok_or(ContractError::Overflow)?;
-    base_price
-        .checked_add(supply_component)
-        .ok_or(ContractError::Overflow)
 }
 
 fn zero_quote_response() -> QuoteResponse {
@@ -956,6 +990,13 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
             .persistent()
             .extend_ttl(&max_supply_key, threshold, extend_to);
     }
+
+    let curve_preset_key = constants::storage::curve_preset(creator);
+    if env.storage().persistent().has(&curve_preset_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&curve_preset_key, threshold, extend_to);
+    }
 }
 
 #[contract]
@@ -978,12 +1019,14 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
+
     pub fn register_creator(
         env: Env,
         creator: Address,
         handle: String,
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
+        curve_preset: Option<CurvePreset>,
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1043,6 +1086,13 @@ impl CreatorKeysContract {
                 .set(&constants::storage::max_supply(&creator), &cap);
         }
 
+        // Handle curve preset
+        let preset = curve_preset.unwrap_or(CurvePreset::Linear);
+        let preset_key = constants::storage::curve_preset(&creator);
+        env.storage()
+            .persistent()
+            .set(&preset_key, &preset);
+
         let profile = CreatorProfile {
             creator: creator.clone(),
             handle,
@@ -1065,6 +1115,9 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&key, current_ledger, extend_to);
+        env.storage()
+            .persistent()
+            .extend_ttl(&preset_key, current_ledger, extend_to);
 
         env.events().publish(
             events::register_event_topics(&profile.creator),
@@ -1102,7 +1155,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
-        let price = compute_bonding_curve_price(&env, base_price, profile.supply)?;
+        let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
         assert_buy_price_slippage(price, max_price)?;
 
@@ -1180,19 +1233,20 @@ impl CreatorKeysContract {
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
 
-        let base_price: i128 = env
-            .storage()
-            .persistent()
-            .get(&constants::storage::KEY_PRICE)
-            .ok_or(ContractError::KeyPriceNotSet)?;
-        let price = compute_bonding_curve_price(&env, base_price, profile.supply)?;
-
         let balance_key = constants::storage::key_balance(&creator, &seller);
         // Missing balance entries are interpreted as zero and rejected consistently.
         let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
         if current_balance == 0 {
             return Err(ContractError::InsufficientBalance);
         }
+
+        let base_price: i128 = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::KEY_PRICE)
+            .ok_or(ContractError::KeyPriceNotSet)?;
+        let sell_supply = profile.supply.checked_sub(1).ok_or(ContractError::SellUnderflow)?;
+        let price = compute_bonding_curve_price(&env, &creator, base_price, sell_supply)?;
 
         // Settle dividends before balance changes so earnings are captured at old balance.
         settle_holder_dividends(&env, &creator, &seller, current_balance)?;
@@ -1263,7 +1317,7 @@ impl CreatorKeysContract {
             .get(&constants::storage::KEY_PRICE)
             .ok_or(ContractError::KeyPriceNotSet)?;
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
-        let curve_price = compute_bonding_curve_price(&env, base_price_stored, profile.supply)?;
+        let curve_price = compute_bonding_curve_price(&env, &creator, base_price_stored, profile.supply)?;
         let base_price = compute_buyback_base_price(curve_price, amount)?;
         let config = read_required_protocol_fee_config(&env)?;
         let protocol_fee = fee::apply_percentage_fee(base_price, config.protocol_bps)
@@ -1923,14 +1977,27 @@ impl CreatorKeysContract {
         creator: Address,
         holder: Address,
     ) -> Result<QuoteResponse, ContractError> {
-        let Some(price) = resolve_quote_inputs(&env, &creator)? else {
+        let base_price: i128 = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::KEY_PRICE)
+            .ok_or(ContractError::KeyPriceNotSet)?;
+
+        let Some(normalized) = normalize_quote_amount(base_price)? else {
             return Ok(zero_quote_response());
         };
 
-        let balance = Self::get_key_balance(env.clone(), creator, holder);
+        let balance = Self::get_key_balance(env.clone(), creator.clone(), holder);
         if balance == 0 {
             return Err(ContractError::InsufficientBalance);
         }
+
+        let profile = read_registered_creator_profile(&env, &creator)?;
+        let sell_supply = profile.supply.checked_sub(1).ok_or(ContractError::SellUnderflow)?;
+        let curve_price = compute_bonding_curve_price(&env, &creator, normalized, sell_supply)?;
+        let Some(price) = normalize_quote_amount(curve_price)? else {
+            return Ok(zero_quote_response());
+        };
 
         let (creator_fee, protocol_fee) = Self::compute_fees_for_payment(env.clone(), price)?;
         checked_format_quote_response(price, creator_fee, protocol_fee, false)
@@ -2184,6 +2251,27 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .get(&constants::storage::max_supply(&creator))
+    }
+
+    /// Read-only view: returns the curve preset for a creator.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotRegistered`] if the creator is not registered.
+    pub fn get_curve_preset(env: Env, creator: Address) -> Result<CurvePreset, ContractError> {
+        if !env
+            .storage()
+            .persistent()
+            .has(&constants::storage::creator(&creator))
+        {
+            return Err(ContractError::NotRegistered);
+        }
+        let preset = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::curve_preset(&creator))
+            .unwrap_or(CurvePreset::Flat);
+        Ok(preset)
     }
 
     /// Transfers key ownership between wallets without touching the bonding curve.

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -19,7 +19,7 @@ fn test_register_creator_with_locked_allocation() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
 
     let stored = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(stored.amount, 100);
@@ -47,7 +47,7 @@ fn test_register_creator_locked_allocation_reverts_past_ledger() {
         claimed: false,
     };
 
-    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None);
+    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AllocationLocked)));
 }
 
@@ -68,7 +68,7 @@ fn test_claim_locked_allocation_success() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -100,7 +100,7 @@ fn test_claim_locked_allocation_reverts_early() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
 
     // Try to claim before unlock
     let result = client.try_claim_locked_allocation(&creator);
@@ -124,7 +124,7 @@ fn test_claim_locked_allocation_reverts_double_claim() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -162,7 +162,7 @@ fn test_get_locked_allocation_returns_allocation_when_set() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
 
     let result = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(result.amount, 100);
@@ -184,7 +184,7 @@ fn test_transfer_keys_basic() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
@@ -208,7 +208,7 @@ fn test_transfer_keys_sender_zeroed_out() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -230,7 +230,7 @@ fn test_transfer_keys_new_recipient() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let supply_before = client.get_total_key_supply(&creator);
@@ -252,7 +252,7 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -271,7 +271,7 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -290,7 +290,7 @@ fn test_transfer_keys_insufficient_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -308,7 +308,7 @@ fn test_register_creator_with_max_supply() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(1000));
+    client.register_creator(&creator, &handle, &None, &Some(1000), &None);
 
     let cap = client.get_max_supply(&creator).unwrap();
     assert_eq!(cap, 1000);
@@ -323,7 +323,7 @@ fn test_register_creator_max_supply_zero_reverts() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    let result = client.try_register_creator(&creator, &handle, &None, &Some(0));
+    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
 }
 
@@ -338,7 +338,7 @@ fn test_buy_exceeds_max_supply_reverts() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(5));
+    client.register_creator(&creator, &handle, &None, &Some(5), &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -363,7 +363,7 @@ fn test_buy_within_max_supply_succeeds() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(10));
+    client.register_creator(&creator, &handle, &None, &Some(10), &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -385,7 +385,7 @@ fn test_get_max_supply_returns_none_for_uncapped() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let cap = client.get_max_supply(&creator);
     assert_eq!(cap, None);
@@ -484,7 +484,7 @@ fn test_update_creator_fee_recipient_success() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
     client.update_creator_fee_recipient(&creator, &new_recipient);
 
     let profile = client.get_creator(&creator);
@@ -502,7 +502,7 @@ fn test_update_creator_fee_recipient_unauthorized_reverts() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let result = client.try_update_creator_fee_recipient(&unauthorized, &new_recipient);
     // This should fail because unauthorized is not the current fee recipient
@@ -521,7 +521,7 @@ fn test_register_creator_without_optional_params_succeeds() {
     let handle = String::from_str(&env, "alice");
 
     // Registration with None for both optional params should work (backwards compatible)
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 0);
@@ -647,7 +647,7 @@ fn test_get_fee_config_persists_across_repeated_reads() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // Repeatedly read the fee config and verify stability
     for _ in 0..5 {
@@ -673,7 +673,7 @@ fn test_register_creator() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
@@ -693,7 +693,7 @@ fn test_register_creator_persists_registration_metadata() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.creator, creator);
@@ -713,10 +713,10 @@ fn test_duplicate_registration_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // Second registration should fail with AlreadyRegistered error
-    let result = client.try_register_creator(&creator, &handle, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
     assert_no_events(&env);
 }
@@ -751,7 +751,7 @@ fn test_buy_key_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let supply = client.buy_key(&creator, &buyer, &100, &None);
@@ -774,7 +774,7 @@ fn test_get_creator_holder_count_counts_unique_holders() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let holder_one = Address::generate(&env);
     let holder_two = Address::generate(&env);
@@ -815,7 +815,7 @@ fn test_buy_key_insufficient_payment() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99, &None);
@@ -886,7 +886,7 @@ fn test_get_key_balance_returns_zero_for_unregistered_wallet() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let unregistered_wallet = Address::generate(&env);
 
@@ -985,7 +985,7 @@ fn test_get_buy_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 1000);
@@ -1007,7 +1007,7 @@ fn test_get_sell_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1000, &None);
@@ -1032,7 +1032,7 @@ fn test_get_sell_quote_fails_if_insufficient_balance() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let holder = Address::generate(&env); // Zero balance
     let result = client.try_get_sell_quote(&creator, &holder);
@@ -1067,7 +1067,7 @@ fn test_get_quote_fails_if_fee_not_set() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let result = client.try_get_buy_quote(&creator);
     assert_eq!(result, Err(Ok(ContractError::FeeConfigNotSet)));
@@ -1097,7 +1097,7 @@ fn test_get_creator_fee_recipient_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let recipient = client.get_creator_fee_recipient(&creator);
     assert_eq!(recipient, creator);
@@ -1129,7 +1129,7 @@ fn test_quote_overflow_guards() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // Buy quote: price + fees (will overflow)
     let result = client.try_get_buy_quote(&creator);
@@ -1206,7 +1206,7 @@ fn test_register_event_field_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let all_events = env.events().all();
     assert_eq!(
@@ -1268,7 +1268,7 @@ fn test_buy_event_topic_and_data_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "bob");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &500, &None);
@@ -1334,7 +1334,7 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "carol");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let all_events = env.events().all();
     let (_contract_id, _topics, data): (

--- a/creator-keys/test_snapshots/buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption.1.json
+++ b/creator-keys/test_snapshots/buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption.1.json
@@ -46,6 +46,7 @@
                   "string": "maxed"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -156,6 +157,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/holder_count_tracks_distinct_buyers_and_decrements_on_exit.1.json
+++ b/creator-keys/test_snapshots/holder_count_tracks_distinct_buyers_and_decrements_on_exit.1.json
@@ -46,6 +46,7 @@
                   "string": "creator"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -313,6 +314,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_100_creator_zero_protocol.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_100_creator_zero_protocol.1.json
@@ -71,6 +71,7 @@
                   "string": "creator3"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_50_50_equal_split.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_50_50_equal_split.1.json
@@ -71,6 +71,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 50
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_90_10_nominal_case.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_90_10_nominal_case.1.json
@@ -71,6 +71,7 @@
                   "string": "creator1"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_across_multiple_fee_configs.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_across_multiple_fee_configs.1.json
@@ -21,6 +21,7 @@
                   "string": "creator0"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -125,6 +126,7 @@
                 {
                   "string": "creator1"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -231,6 +233,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -335,6 +338,7 @@
                 {
                   "string": "creator3"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -996,6 +1000,186 @@
                     "hi": 0,
                     "lo": 500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_across_price_range.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_across_price_range.1.json
@@ -21,6 +21,7 @@
                   "string": "creator0"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -125,6 +126,7 @@
                 {
                   "string": "creator1"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -231,6 +233,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -335,6 +338,7 @@
                 {
                   "string": "creator3"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -441,6 +445,7 @@
                   "string": "creator4"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -545,6 +550,7 @@
                 {
                   "string": "creator5"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -651,6 +657,7 @@
                   "string": "creator6"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -755,6 +762,7 @@
                 {
                   "string": "creator7"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -861,6 +869,7 @@
                   "string": "creator8"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -965,6 +974,7 @@
                 {
                   "string": "creator9"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -2478,6 +2488,456 @@
                     "hi": 0,
                     "lo": 9000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDWC6"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDWC6"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABI7IO"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABI7IO"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOHR6"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOHR6"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVM7P"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVM7P"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2VE7"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2VE7"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_odd_price_999.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_odd_price_999.1.json
@@ -71,6 +71,7 @@
                   "string": "creator7"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_one.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_one.1.json
@@ -71,6 +71,7 @@
                   "string": "creator5"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 1
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_two.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_two.1.json
@@ -71,6 +71,7 @@
                   "string": "creator6"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 1
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_deterministic_assertions.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_deterministic_assertions.1.json
@@ -71,6 +71,7 @@
                   "string": "creator_det"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 108
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_large_amount.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_large_amount.1.json
@@ -71,6 +71,7 @@
                   "string": "creator8"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 900000000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_max_protocol_50_percent.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_max_protocol_50_percent.1.json
@@ -71,6 +71,7 @@
                   "string": "creator4"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 100
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_zero_net_boundary.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_zero_net_boundary.1.json
@@ -21,6 +21,7 @@
                   "string": "creator0"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -126,6 +127,7 @@
                 {
                   "string": "creator1"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -233,6 +235,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -338,6 +341,7 @@
                 {
                   "string": "creator3"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -1000,6 +1004,186 @@
                     "hi": 0,
                     "lo": 10
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
@@ -71,6 +71,7 @@
                   "string": "cr5"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 100
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
@@ -71,6 +71,7 @@
                   "string": "cr4"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -257,6 +258,51 @@
                     "hi": 0,
                     "lo": 5
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
@@ -71,6 +71,7 @@
                   "string": "cr3"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 2
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
@@ -71,6 +71,7 @@
                   "string": "cr2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -257,6 +258,51 @@
                     "hi": 0,
                     "lo": 1
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
@@ -71,6 +71,7 @@
                   "string": "cr1"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
+++ b/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
@@ -71,6 +71,7 @@
                   "string": "cr6"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -257,6 +258,51 @@
                     "hi": 0,
                     "lo": 1
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_accumulator_grows_correctly_across_sequential_distributions.1.json
+++ b/creator-keys/test_snapshots/test_accumulator_grows_correctly_across_sequential_distributions.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -338,6 +339,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_assert_event_topic_matches_rejects_unexpected_identifier.1.json
+++ b/creator-keys/test_snapshots/test_assert_event_topic_matches_rejects_unexpected_identifier.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -151,6 +152,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_balance_after_buys_then_sells.1.json
+++ b/creator-keys/test_snapshots/test_balance_after_buys_then_sells.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -343,6 +344,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_balance_after_sequence_of_buys_and_sells.1.json
+++ b/creator-keys/test_snapshots/test_balance_after_sequence_of_buys_and_sells.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -308,6 +309,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_balance_with_non_zero_initial.1.json
+++ b/creator-keys/test_snapshots/test_balance_with_non_zero_initial.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -401,6 +402,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_batch_length_matches_input_length.1.json
+++ b/creator-keys/test_snapshots/test_batch_length_matches_input_length.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -245,6 +247,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_batch_matches_individual_get_creator_details_calls.1.json
+++ b/creator-keys/test_snapshots/test_batch_matches_individual_get_creator_details_calls.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -247,6 +249,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4120
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4110
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_batch_mixed_registered_and_unregistered.1.json
+++ b/creator-keys/test_snapshots/test_batch_mixed_registered_and_unregistered.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -245,6 +247,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4117
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4106
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_batch_preserves_input_order.1.json
+++ b/creator-keys/test_snapshots/test_batch_preserves_input_order.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -45,6 +46,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -68,6 +70,7 @@
                 {
                   "string": "carol"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -363,6 +366,141 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4125
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4105
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4115
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_batch_registered_creators_have_correct_fields.1.json
+++ b/creator-keys/test_snapshots/test_batch_registered_creators_have_correct_fields.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4150
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_credits_creator_fee_recipient_balance_by_bps_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_credits_creator_fee_recipient_balance_by_bps_amount.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -257,6 +258,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -209,6 +210,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_insufficient_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_insufficient_payment_fails.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_negative_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_negative_payment_fails.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -180,6 +181,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_reverts_when_paused.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_reverts_when_paused.1.json
@@ -68,6 +68,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -232,6 +233,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
@@ -68,6 +68,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -279,6 +280,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_sufficient_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_sufficient_payment_succeeds.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -181,6 +182,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_unregistered_creator_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_unregistered_creator_fails.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
@@ -30,6 +30,37 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_fee_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u32": 9000
+                },
+                {
+                  "u32": 1000
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -42,6 +73,62 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "FeeConfig"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FeeConfig"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator_bps"
+                      },
+                      "val": {
+                        "u32": 9000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "protocol_bps"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
       [
         {
           "contract_data": {
@@ -76,6 +163,45 @@
                     "hi": 0,
                     "lo": 100
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ProtocolStateVersion"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ProtocolStateVersion"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 2
                 }
               }
             },
@@ -138,6 +264,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
@@ -22,6 +22,7 @@
                   "string": "creator1"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -156,6 +157,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
@@ -22,6 +22,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -156,6 +157,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_key_zero_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_zero_payment_fails.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_more_keys_mid_stream_does_not_earn_retroactively.1.json
+++ b/creator-keys/test_snapshots/test_buy_more_keys_mid_stream_does_not_earn_retroactively.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -339,6 +340,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_deterministic_across_zero_supply_transition.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_deterministic_across_zero_supply_transition.1.json
@@ -71,6 +71,7 @@
                   "string": "edge1"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -279,6 +280,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_fees_sum_to_total_minus_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_fees_sum_to_total_minus_price.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -286,6 +287,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_is_identical_across_consecutive_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_is_identical_across_consecutive_calls.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -179,6 +180,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_is_stable_across_multiple_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_is_stable_across_multiple_calls.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -184,6 +185,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_creator_fee.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_creator_fee.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_protocol_fee.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 2000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_multiple_creators_independent_monotonicity.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_multiple_creators_independent_monotonicity.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -94,6 +95,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -454,6 +456,96 @@
                     "hi": 0,
                     "lo": 800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_point_1_is_stable.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_point_1_is_stable.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 1
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_point_large_is_stable.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_point_large_is_stable.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 900000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_across_multiple_buyers_small_range.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_across_multiple_buyers_small_range.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -525,6 +526,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_five_buys.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_five_buys.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -374,6 +375,51 @@
                     "hi": 0,
                     "lo": 2250
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_one_buy.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_one_buy.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_recomputed_after_sell_reduces_supply.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_recomputed_after_sell_reduces_supply.1.json
@@ -71,6 +71,7 @@
                   "string": "edge3"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -310,6 +311,51 @@
                     "hi": 0,
                     "lo": 450
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_stability_with_different_fee_configs.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stability_with_different_fee_configs.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -291,6 +292,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_stable_across_50_sequential_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stable_across_50_sequential_purchases.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -1725,6 +1726,51 @@
                     "hi": 0,
                     "lo": 33750
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_stable_over_medium_volume_20_buys.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stable_over_medium_volume_20_buys.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -825,6 +826,51 @@
                     "hi": 0,
                     "lo": 90000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_total_amount_never_below_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_total_amount_never_below_price.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -518,6 +519,51 @@
                     "hi": 0,
                     "lo": 90000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_total_amount_ordering_is_deterministic_small_range.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_total_amount_ordering_is_deterministic_small_range.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -316,6 +317,51 @@
                     "hi": 0,
                     "lo": 2700
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_unchanged_after_creator_registration.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_unchanged_after_creator_registration.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -95,6 +96,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -298,6 +300,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_updates_after_fee_config_mutation.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_updates_after_fee_config_mutation.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -203,6 +204,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_with_large_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_large_amount_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator3"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator7"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator4"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_consistent_across_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_consistent_across_calls.1.json
@@ -71,6 +71,7 @@
                   "string": "charlie"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -179,6 +180,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_returns_first_key_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_returns_first_key_price.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_various_prices.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_various_prices.1.json
@@ -71,6 +71,7 @@
                   "string": "creator0"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -145,6 +146,7 @@
                 {
                   "string": "creator1"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -221,6 +223,7 @@
                   "string": "creator2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -295,6 +298,7 @@
                 {
                   "string": "creator3"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -371,6 +375,7 @@
                   "string": "creator4"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -445,6 +450,7 @@
                 {
                   "string": "creator5"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -1022,6 +1028,276 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_well_formed.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_well_formed.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_slippage_reverts_when_price_exceeds_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_reverts_when_price_exceeds_max_price.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -183,6 +184,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -294,6 +295,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_then_sell_has_symmetric_price_impact_after_fees.1.json
+++ b/creator-keys/test_snapshots/test_buy_then_sell_has_symmetric_price_impact_after_fees.1.json
@@ -71,6 +71,7 @@
                   "string": "carol"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_does_not_change_follow_on_buy_price_under_fixed_price_model.1.json
+++ b/creator-keys/test_snapshots/test_buyback_does_not_change_follow_on_buy_price_under_fixed_price_model.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -319,6 +320,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_does_not_credit_creator_fee_balance_and_does_credit_protocol_balance.1.json
+++ b/creator-keys/test_snapshots/test_buyback_does_not_credit_creator_fee_balance_and_does_credit_protocol_balance.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -291,6 +292,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_event_emits_expected_payload.1.json
+++ b/creator-keys/test_snapshots/test_buyback_event_emits_expected_payload.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -317,6 +318,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_exceeding_supply_reverts_with_insufficient_supply.1.json
+++ b/creator-keys/test_snapshots/test_buyback_exceeding_supply_reverts_with_insufficient_supply.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_full_supply_clears_creator_position.1.json
+++ b/creator-keys/test_snapshots/test_buyback_full_supply_clears_creator_position.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -320,6 +321,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_five.1.json
+++ b/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_five.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -398,6 +399,51 @@
                     "hi": 0,
                     "lo": 4500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_one.1.json
+++ b/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_one.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_reduces_supply_and_creator_balance.1.json
+++ b/creator-keys/test_snapshots/test_buyback_reduces_supply_and_creator_balance.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -320,6 +321,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_rejects_non_creator_caller.1.json
+++ b/creator-keys/test_snapshots/test_buyback_rejects_non_creator_caller.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_rejects_when_creator_balance_is_below_amount_even_if_supply_is_higher.1.json
+++ b/creator-keys/test_snapshots/test_buyback_rejects_when_creator_balance_is_below_amount_even_if_supply_is_higher.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -288,6 +289,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_zero_amount_reverts.1.json
+++ b/creator-keys/test_snapshots/test_buyback_zero_amount_reverts.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -256,6 +257,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_after_sell_captures_pending.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_after_sell_captures_pending.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -326,6 +327,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_event_topics_and_payload.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_event_topics_and_payload.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -303,6 +304,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_happy_path_returns_correct_amount.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_happy_path_returns_correct_amount.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -303,6 +304,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_no_claimable_fails.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_no_claimable_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_proportional_amounts_across_holders.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_proportional_amounts_across_holders.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -383,6 +384,51 @@
                     "hi": 0,
                     "lo": 270
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_resets_claimable_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_resets_claimable_to_zero.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -304,6 +305,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_while_paused_fails.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_while_paused_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -362,6 +363,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_locked_allocation_reverts_at_every_ledger_before_unlock.1.json
+++ b/creator-keys/test_snapshots/test_claim_locked_allocation_reverts_at_every_ledger_before_unlock.1.json
@@ -48,6 +48,7 @@
                     }
                   ]
                 },
+                "void",
                 "void"
               ]
             }
@@ -155,6 +156,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4096
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_locked_allocation_succeeds_at_unlock_ledger.1.json
+++ b/creator-keys/test_snapshots/test_claim_locked_allocation_succeeds_at_unlock_ledger.1.json
@@ -48,6 +48,7 @@
                     }
                   ]
                 },
+                "void",
                 "void"
               ]
             }
@@ -174,6 +175,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4096
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_creator_details_consistency_across_ten_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_consistency_across_ten_reads.1.json
@@ -21,6 +21,7 @@
                   "string": "dave"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -136,6 +137,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_creator_details_identical_across_five_consecutive_reads_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_identical_across_five_consecutive_reads_after_buy.1.json
@@ -21,6 +21,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -185,6 +186,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_creator_details_identical_across_three_consecutive_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_identical_across_three_consecutive_reads.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -129,6 +130,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_creator_details_no_storage_writes_during_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_no_storage_writes_during_reads.1.json
@@ -21,6 +21,7 @@
                   "string": "charlie"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -136,6 +137,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_deducts_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_deducts_protocol_fee.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -284,6 +285,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_event_topics_and_payload.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_event_topics_and_payload.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -281,6 +282,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_negative_amount_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_negative_amount_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_no_fee_config_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_no_fee_config_fails.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -181,6 +182,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_no_key_holders_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_no_key_holders_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_proportional_to_balance.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_proportional_to_balance.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -370,6 +371,51 @@
                     "hi": 0,
                     "lo": 360
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_single_holder_receives_full_net.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_single_holder_receives_full_net.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_two_equal_holders_split_evenly.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_two_equal_holders_split_evenly.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -312,6 +313,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_while_paused_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_while_paused_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -334,6 +335,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_zero_amount_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_zero_amount_fails.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_double_claim_fails_with_no_claimable.1.json
+++ b/creator-keys/test_snapshots/test_double_claim_fails_with_no_claimable.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -304,6 +305,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_existing_holder_earns_from_all_distributions_via_checkpoint.1.json
+++ b/creator-keys/test_snapshots/test_existing_holder_earns_from_all_distributions_via_checkpoint.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -310,6 +311,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_fee_config_update_does_not_affect_other_creator.1.json
+++ b/creator-keys/test_snapshots/test_fee_config_update_does_not_affect_other_creator.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -94,6 +95,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -323,6 +325,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_buy_quote_zero_amount_returns_noop_quote.1.json
+++ b/creator-keys/test_snapshots/test_get_buy_quote_zero_amount_returns_noop_quote.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -128,6 +129,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_buyback_quote_returns_price_plus_protocol_fee_only.1.json
+++ b/creator-keys/test_snapshots/test_get_buyback_quote_returns_price_plus_protocol_fee_only.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -285,6 +286,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_accumulates_across_distributions.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_accumulates_across_distributions.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -338,6 +339,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_correct_after_distribution.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_correct_after_distribution.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_is_read_only.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -288,6 +289,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_works_while_paused.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_works_while_paused.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -362,6 +363,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_zero_after_claim.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_zero_after_claim.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -304,6 +305,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_zero_before_any_distribution.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_zero_before_any_distribution.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_details_read_on_unregistered_does_not_mutate_state.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_read_on_unregistered_does_not_mutate_state.1.json
@@ -21,6 +21,7 @@
                   "string": "anchor"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -134,6 +135,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_details_reflects_latest_state_after_buy_then_sell.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_reflects_latest_state_after_buy_then_sell.1.json
@@ -21,6 +21,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -206,6 +207,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_details_registered_returns_correct_data.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_registered_returns_correct_data.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_details_updates_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_updates_after_buy.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -182,6 +183,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_fails_when_fee_config_not_set.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_fails_when_fee_config_not_set.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_returns_configured_value.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_returns_configured_value.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_tracks_fee_config_updates.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_tracks_fee_config_updates.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -178,6 +179,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "test_creator"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_multiple_creators_independent.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_multiple_creators_independent.1.json
@@ -21,6 +21,7 @@
                   "string": "creator_one"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "creator_two"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -271,6 +273,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_registered_no_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_registered_no_fee_config.1.json
@@ -21,6 +21,7 @@
                   "string": "test_creator"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_registered_with_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_registered_with_fee_config.1.json
@@ -21,6 +21,7 @@
                   "string": "test_creator"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_updates_after_fee_reconfiguration.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_updates_after_fee_reconfiguration.1.json
@@ -21,6 +21,7 @@
                   "string": "test_creator"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -178,6 +179,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_recipient_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_recipient_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -128,6 +129,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_fee_recipient_returns_creator_address.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_recipient_returns_creator_address.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_succeeds_after_supply_returns_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_succeeds_after_supply_returns_to_zero.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -204,6 +205,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_supply_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_supply_is_read_only.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -182,6 +183,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_supply_returns_current_supply.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_supply_returns_current_supply.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -210,6 +211,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_fails_when_fee_config_not_set.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_fails_when_fee_config_not_set.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -153,6 +154,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_returns_configured_value.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_returns_configured_value.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creators_batch_success.1.json
+++ b/creator-keys/test_snapshots/test_get_creators_batch_success.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -245,6 +247,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4115
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4105
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_key_decimals_consistent_across_creator_instances.1.json
+++ b/creator-keys/test_snapshots/test_get_key_decimals_consistent_across_creator_instances.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -45,6 +46,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -246,6 +248,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_key_name_success.1.json
+++ b/creator-keys/test_snapshots/test_get_key_name_success.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_key_symbol_success.1.json
+++ b/creator-keys/test_snapshots/test_get_key_symbol_success.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_protocol_state_version_increments_only_on_config_updates.1.json
+++ b/creator-keys/test_snapshots/test_get_protocol_state_version_increments_only_on_config_updates.1.json
@@ -73,6 +73,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -278,6 +279,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_sell_quote_zero_amount_returns_noop_quote.1.json
+++ b/creator-keys/test_snapshots/test_get_sell_quote_zero_amount_returns_noop_quote.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -182,6 +183,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_total_key_supply_increments_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_increments_after_buy.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -212,6 +213,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_total_key_supply_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_is_read_only.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -154,6 +155,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_total_key_supply_returns_zero_for_new_creator.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_returns_zero_for_new_creator.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_count_reflects_mixed_trade_correctly.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_reflects_mixed_trade_correctly.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -259,6 +260,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -235,6 +236,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_count_unchanged_when_holder_still_has_keys.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_unchanged_when_holder_still_has_keys.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -234,6 +235,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_consistency_with_get_key_balance.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_consistency_with_get_key_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -240,6 +241,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_increments_on_buy.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_increments_on_buy.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -212,6 +213,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_multiple_holders.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_multiple_holders.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -269,6 +270,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_no_state_mutation.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_no_state_mutation.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -212,6 +213,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_registered_creator_unseen_wallet.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_registered_creator_unseen_wallet.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -210,6 +211,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_starts_at_zero.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_starts_at_zero.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_structure_fields.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_structure_fields.1.json
@@ -46,6 +46,7 @@
                   "string": "test"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -181,6 +182,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_holder_key_count_view_zero_keys_different_creators.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_zero_keys_different_creators.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -69,6 +70,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -329,6 +331,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_identical_fee_configs_apply_independently.1.json
+++ b/creator-keys/test_snapshots/test_identical_fee_configs_apply_independently.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -94,6 +95,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -454,6 +456,96 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_is_creator_registered_different_creators_independent.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_different_creators_independent.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -128,6 +129,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_is_creator_registered_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -129,6 +130,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_is_creator_registered_returns_true_after_registration.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_returns_true_after_registration.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_decrements_correctly_after_each_partial_sell.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_decrements_correctly_after_each_partial_sell.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -370,6 +371,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_increments_on_buy.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_increments_on_buy.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -212,6 +213,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_is_per_buyer.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_is_per_buyer.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -240,6 +241,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_is_per_creator.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_is_per_creator.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -69,6 +70,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -300,6 +302,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_returns_zero_for_uninitialized_holder.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_returns_zero_for_uninitialized_holder.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -239,6 +240,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_zero_for_registered_creator_and_unseen_wallet.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_zero_for_registered_creator_and_unseen_wallet.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -181,6 +182,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -181,6 +182,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_multiple_distributions_accumulate.1.json
+++ b/creator-keys/test_snapshots/test_multiple_distributions_accumulate.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -310,6 +311,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_new_buyer_after_distribution_earns_no_retroactive_dividends.1.json
+++ b/creator-keys/test_snapshots/test_new_buyer_after_distribution_earns_no_retroactive_dividends.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -311,6 +312,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_read_only_views_work_while_paused.1.json
+++ b/creator-keys/test_snapshots/test_read_only_views_work_while_paused.1.json
@@ -68,6 +68,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -268,6 +269,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_accepts_max_handle_length.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_accepts_max_handle_length.1.json
@@ -21,6 +21,7 @@
                   "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_accepts_min_handle_length.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_accepts_min_handle_length.1.json
@@ -21,6 +21,7 @@
                   "string": "aaa"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_different_addresses_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_different_addresses_succeeds.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -44,6 +45,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -246,6 +248,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_duplicate_different_handle_fails.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_duplicate_different_handle_fails.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_duplicate_fails.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_duplicate_fails.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_emits_event.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_emits_event.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -151,6 +152,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_event_data_is_indexer_friendly.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_data_is_indexer_friendly.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -151,6 +152,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_event_field_values_match_fixtures.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_field_values_match_fixtures.1.json
@@ -46,6 +46,7 @@
                   "string": "fixture_handle"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -151,6 +152,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_event_fields_update_with_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_fields_update_with_fee_config.1.json
@@ -46,6 +46,7 @@
                   "string": "creator_1"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -94,6 +95,7 @@
                 {
                   "string": "creator_2"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -294,6 +296,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_event_fires_once.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_fires_once.1.json
@@ -46,6 +46,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -151,6 +152,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_max_length_handle_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_max_length_handle_succeeds.1.json
@@ -21,6 +21,7 @@
                   "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_register_creator_minimum_handle_length_success.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_minimum_handle_length_success.1.json
@@ -21,6 +21,7 @@
                   "string": "aaa"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -128,6 +129,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_registered_at_enables_chronological_sort.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_enables_chronological_sort.1.json
@@ -21,6 +21,7 @@
                   "string": "first"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -45,6 +46,7 @@
                   "string": "second"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -68,6 +70,7 @@
                 {
                   "string": "third"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -363,6 +366,141 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4395
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4195
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4295
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_registered_at_is_captured_at_registration_sequence.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_captured_at_registration_sequence.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -127,6 +128,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4137
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_registered_at_is_immutable_after_buy_and_sell.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_immutable_after_buy_and_sell.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -204,6 +205,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4195
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_registered_at_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_read_only.1.json
@@ -21,6 +21,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -129,6 +130,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4172
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_repeated_zero_amount_quote_calls_no_state_drift.1.json
+++ b/creator-keys/test_snapshots/test_repeated_zero_amount_quote_calls_no_state_drift.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -201,6 +202,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -203,6 +204,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_all_then_rebuy_starts_fresh_on_pending.1.json
+++ b/creator-keys/test_snapshots/test_sell_all_then_rebuy_starts_fresh_on_pending.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -362,6 +363,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -203,6 +204,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -203,6 +204,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_execution_applies_updated_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_sell_execution_applies_updated_protocol_fee.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -304,6 +305,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_execution_fee_matches_quote_after_fee_config_update.1.json
+++ b/creator-keys/test_snapshots/test_sell_execution_fee_matches_quote_after_fee_config_update.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -305,6 +306,51 @@
                     "hi": 0,
                     "lo": 450
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_full_exit_then_rebuy_updates_state.1.json
+++ b/creator-keys/test_snapshots/test_sell_full_exit_then_rebuy_updates_state.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -241,6 +242,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_increases_protocol_fee_recipient_balance_by_bps_fee.1.json
+++ b/creator-keys/test_snapshots/test_sell_increases_protocol_fee_recipient_balance_by_bps_fee.1.json
@@ -93,6 +93,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -301,6 +302,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_decrements_supply_and_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_decrements_supply_and_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -234,6 +235,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -232,6 +233,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -203,6 +204,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_fails_when_seller_has_no_keys.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_fails_when_seller_has_no_keys.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_preserves_holder_count_when_seller_still_has_keys.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_preserves_holder_count_when_seller_still_has_keys.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -235,6 +236,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_removes_holder_when_last_key_is_sold.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_removes_holder_when_last_key_is_sold.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -207,6 +208,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_reverts_when_paused.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_reverts_when_paused.1.json
@@ -68,6 +68,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -261,6 +262,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_protocol_fee_recipient_balance_accumulates_across_two_sells.1.json
+++ b/creator-keys/test_snapshots/test_sell_protocol_fee_recipient_balance_accumulates_across_two_sells.1.json
@@ -93,6 +93,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -353,6 +354,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_five.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_five.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -398,6 +399,51 @@
                     "hi": 0,
                     "lo": 4500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_one.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_one.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_large_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_large_amount_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator5"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -231,6 +232,51 @@
                     "hi": 0,
                     "lo": 450000000000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator8"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -231,6 +232,51 @@
                     "hi": 0,
                     "lo": 4611686018427388
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_succeeds.1.json
@@ -47,6 +47,7 @@
                   "string": "creator6"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -231,6 +232,51 @@
                     "hi": 0,
                     "lo": 8301034833169298
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_holder_no_keys_returns_zero_quote.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_holder_no_keys_returns_zero_quote.1.json
@@ -71,6 +71,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -178,6 +179,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_no_state_modification.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_no_state_modification.1.json
@@ -71,6 +71,7 @@
                   "string": "charlie"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -265,6 +266,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_returns_zero_quote.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_returns_zero_quote.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_supply_boundary_is_rejected.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_supply_boundary_is_rejected.1.json
@@ -71,6 +71,7 @@
                   "string": "edge2"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -177,6 +178,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_registered_zero_supply_creator_returns_sell_underflow_without_state_change.1.json
+++ b/creator-keys/test_snapshots/test_sell_registered_zero_supply_creator_returns_sell_underflow_without_state_change.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -159,6 +160,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_reverts_when_seller_has_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_reverts_when_seller_has_insufficient_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -212,6 +213,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_second_key_after_selling_last_returns_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_second_key_after_selling_last_returns_insufficient_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -204,6 +205,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_slippage_reverts_when_proceeds_below_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_reverts_when_proceeds_below_min_proceeds.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -262,6 +263,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -342,6 +343,51 @@
                     "hi": 0,
                     "lo": 1800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_with_no_keys_returns_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_with_no_keys_returns_insufficient_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -152,6 +153,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
+++ b/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -278,6 +279,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_alternating_buys_and_sells.1.json
+++ b/creator-keys/test_snapshots/test_supply_alternating_buys_and_sells.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -257,6 +258,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_and_balance_decremented_correctly_after_sell.1.json
+++ b/creator-keys/test_snapshots/test_supply_and_balance_decremented_correctly_after_sell.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -234,6 +235,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_buy_then_sell_returns_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_supply_buy_then_sell_returns_to_zero.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -206,6 +207,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_buy_two_sell_one_conserves_supply.1.json
+++ b/creator-keys/test_snapshots/test_supply_buy_two_sell_one_conserves_supply.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -234,6 +235,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_changes_for_one_creator_do_not_affect_another.1.json
+++ b/creator-keys/test_snapshots/test_supply_changes_for_one_creator_do_not_affect_another.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -69,6 +70,7 @@
                 {
                   "string": "bob"
                 },
+                "void",
                 "void",
                 "void"
               ]
@@ -352,6 +354,96 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_mixed_trades_three_participants.1.json
+++ b/creator-keys/test_snapshots/test_supply_mixed_trades_three_participants.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -370,6 +371,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_multiple_buys_per_holder_sum_equals_total.1.json
+++ b/creator-keys/test_snapshots/test_supply_multiple_buys_per_holder_sum_equals_total.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -241,6 +242,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_never_goes_below_zero_after_all_sells.1.json
+++ b/creator-keys/test_snapshots/test_supply_never_goes_below_zero_after_all_sells.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -308,6 +309,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_three_buyers_sum_equals_total.1.json
+++ b/creator-keys/test_snapshots/test_supply_three_buyers_sum_equals_total.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -56,7 +57,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ",
         {
           "function": {
             "contract_fn": {
@@ -67,7 +68,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                 },
                 {
                   "i128": {
@@ -85,7 +86,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL",
         {
           "function": {
             "contract_fn": {
@@ -96,7 +97,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                 },
                 {
                   "i128": {
@@ -114,7 +115,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM",
         {
           "function": {
             "contract_fn": {
@@ -125,7 +126,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                 },
                 {
                   "i128": {
@@ -156,6 +157,105 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
       [
         {
           "contract_data": {
@@ -257,13 +357,10 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "HolderDividendCheckpoint"
+                  "symbol": "CurvePreset"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             },
@@ -280,22 +377,16 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "HolderDividendCheckpoint"
+                      "symbol": "CurvePreset"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
                 "durability": "persistent",
                 "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "u32": 0
                 }
               }
             },
@@ -317,7 +408,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                 }
               ]
             },
@@ -340,7 +431,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                     }
                   ]
                 },
@@ -371,7 +462,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                 }
               ]
             },
@@ -394,7 +485,61 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "HolderDividendCheckpoint"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "HolderDividendCheckpoint"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                     }
                   ]
                 },
@@ -425,7 +570,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                 }
               ]
             },
@@ -448,7 +593,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                     }
                   ]
                 },
@@ -479,7 +624,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                 }
               ]
             },
@@ -502,7 +647,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                     }
                   ]
                 },
@@ -533,7 +678,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                 }
               ]
             },
@@ -556,7 +701,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                     }
                   ]
                 },
@@ -587,7 +732,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                 }
               ]
             },
@@ -610,7 +755,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "GARHLJ522ZQPQ3AKXY3XDEFA4TX44RHYIWQUN5ML7ZC7NXYDPNR3ADMM"
                     }
                   ]
                 },
@@ -638,7 +783,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                 }
               ]
             },
@@ -661,7 +806,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "GCELBYPGRABPAIAZ23PE2C3VUPDRHERUUJZOZHSTNJ7TVH377HCXW2UJ"
                     }
                   ]
                 },
@@ -689,7 +834,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                 }
               ]
             },
@@ -712,7 +857,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      "address": "GCVAHVWNJAU46DQ5IMJTHPIF5NFEAQWONYSR6GERCIGOK2MR2MBB7OEL"
                     }
                   ]
                 },
@@ -856,105 +1001,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 4837995959683129791
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 4837995959683129791
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 2032731177588607455
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 2032731177588607455
                   }
                 },
                 "durability": "temporary",

--- a/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_insufficient_balance.1.json
@@ -46,6 +46,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -183,6 +184,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_not_registered.1.json
+++ b/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_not_registered.1.json
@@ -46,6 +46,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -183,6 +184,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_buy_quote_unchanged_after_transfer.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_buy_quote_unchanged_after_transfer.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -312,6 +313,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_exceeding_balance_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_exceeding_balance_reverts.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_holder_count_increments_when_recipient_new.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_holder_count_increments_when_recipient_new.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -341,6 +342,51 @@
                     "hi": 0,
                     "lo": 270
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -284,6 +285,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_preserves_other_holders.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_preserves_other_holders.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -340,6 +341,51 @@
                     "hi": 0,
                     "lo": 270
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_recipient_balance_increases.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_recipient_balance_increases.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -282,6 +283,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_self_transfer_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_self_transfer_reverts.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_sell_quote_unchanged_after_transfer.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_sell_quote_unchanged_after_transfer.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -312,6 +313,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_sender_balance_decreases.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_sender_balance_decreases.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -340,6 +341,51 @@
                     "hi": 0,
                     "lo": 270
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_total_supply_unchanged.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_total_supply_unchanged.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -312,6 +313,51 @@
                     "hi": 0,
                     "lo": 180
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_zero_amount_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_zero_amount_reverts.1.json
@@ -71,6 +71,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 90
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_accumulates_protocol_fees_across_distinct_buyers.1.json
+++ b/creator-keys/test_snapshots/test_treasury_accumulates_protocol_fees_across_distinct_buyers.1.json
@@ -93,6 +93,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -343,6 +344,51 @@
                     "hi": 0,
                     "lo": 2700
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_insufficient_payment.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_insufficient_payment.1.json
@@ -93,6 +93,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -201,6 +202,51 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_unregistered_creator.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_unregistered_creator.1.json
@@ -93,6 +93,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -278,6 +279,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_sell_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_sell_insufficient_balance.1.json
@@ -93,6 +93,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -278,6 +279,51 @@
                     "hi": 0,
                     "lo": 900
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_full_payment_to_creator_after_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_full_payment_to_creator_after_protocol_fee.1.json
@@ -72,6 +72,7 @@
                   "string": "alice"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 500
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_no_rounding_errors_with_odd_amounts.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_no_rounding_errors_with_odd_amounts.1.json
@@ -71,6 +71,7 @@
                   "string": "dave"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -254,6 +255,51 @@
                     "hi": 0,
                     "lo": 667
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_with_partial_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_with_partial_protocol_fee.1.json
@@ -72,6 +72,7 @@
                   "string": "bob"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 800
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_protocol_bps_full_payment_to_creator.1.json
+++ b/creator-keys/test_snapshots/test_zero_protocol_bps_full_payment_to_creator.1.json
@@ -71,6 +71,7 @@
                   "string": "charlie"
                 },
                 "void",
+                "void",
                 "void"
               ]
             }
@@ -255,6 +256,51 @@
                     "hi": 0,
                     "lo": 1000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CurvePreset"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CurvePreset"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 0
                 }
               }
             },

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -25,7 +25,7 @@ fn test_buy_event_buyer_address_matches_caller() {
 
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     // Clear any prior events then perform the buy
     env.events().all(); // clear
@@ -76,7 +76,7 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
 
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &buyer, &KEY_PRICE, &None);
 
     // Verify the buyer address field is present and matches expected

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -25,7 +25,13 @@ fn test_buy_event_buyer_address_matches_caller() {
 
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Clear any prior events then perform the buy
     env.events().all(); // clear
@@ -76,7 +82,13 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
 
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer, &KEY_PRICE, &None);
 
     // Verify the buyer address field is present and matches expected

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -16,7 +16,7 @@ fn test_buy_key_event_includes_payment_amount() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     let supply = client.buy_key(&creator, &buyer, &150i128, &None);
     assert_eq!(supply, 1);
 
@@ -42,7 +42,7 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &buyer, &200i128, &None);
 
     let events = env.events().all();

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -16,7 +16,13 @@ fn test_buy_key_event_includes_payment_amount() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     let supply = client.buy_key(&creator, &buyer, &150i128, &None);
     assert_eq!(supply, 1);
 
@@ -42,7 +48,13 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer, &200i128, &None);
 
     let events = env.events().all();

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -30,7 +30,7 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
             claimed: false,
         }),
         &None,
-    );
+     &None);
 
     // Immediately after registration — must revert.
     let result = client.try_claim_locked_allocation(&creator);
@@ -75,7 +75,7 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
             claimed: false,
         }),
         &None,
-    );
+     &None);
 
     // Advance to exactly unlock_ledger.
     ledger_info.sequence_number = unlock_ledger;

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -30,7 +30,8 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
             claimed: false,
         }),
         &None,
-     &None);
+        &None,
+    );
 
     // Immediately after registration — must revert.
     let result = client.try_claim_locked_allocation(&creator);
@@ -75,7 +76,8 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
             claimed: false,
         }),
         &None,
-     &None);
+        &None,
+    );
 
     // Advance to exactly unlock_ledger.
     ledger_info.sequence_number = unlock_ledger;

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -32,7 +32,7 @@ fn setup_creator_with_locked_allocation(
             claimed: false,
         }),
         &None,
-    );
+     &None);
     creator
 }
 

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -32,7 +32,8 @@ fn setup_creator_with_locked_allocation(
             claimed: false,
         }),
         &None,
-     &None);
+        &None,
+    );
     creator
 }
 

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -105,7 +105,7 @@ pub fn register_test_creator(
     handle: &str,
 ) -> Address {
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, handle), &None, &None);
+    client.register_creator(&creator, &String::from_str(env, handle), &None, &None, &None);
     creator
 }
 
@@ -130,7 +130,7 @@ pub fn register_test_creator_with_fee_config(
     let admin = Address::generate(env);
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, handle), &None, &None);
+    client.register_creator(&creator, &String::from_str(env, handle), &None, &None, &None);
     creator
 }
 

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -105,7 +105,13 @@ pub fn register_test_creator(
     handle: &str,
 ) -> Address {
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, handle), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, handle),
+        &None,
+        &None,
+        &None,
+    );
     creator
 }
 
@@ -130,7 +136,13 @@ pub fn register_test_creator_with_fee_config(
     let admin = Address::generate(env);
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, handle), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, handle),
+        &None,
+        &None,
+        &None,
+    );
     creator
 }
 

--- a/creator-keys/tests/creator_detail_read_consistency.rs
+++ b/creator-keys/tests/creator_detail_read_consistency.rs
@@ -23,7 +23,7 @@ fn test_creator_details_identical_across_three_consecutive_reads() {
     let handle = String::from_str(&env, "alice");
 
     // Register creator to establish initial state
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // Perform three consecutive reads with NO state changes between them
     let read1 = client.get_creator_details(&creator);
@@ -131,7 +131,7 @@ fn test_creator_details_no_storage_writes_during_reads() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "charlie");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // Use a sentinel holder address — no keys held, so balance stays 0.
     let sentinel = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/creator_details_view.rs
+++ b/creator-keys/tests/creator_details_view.rs
@@ -29,7 +29,7 @@ fn test_get_creator_details_registered_returns_correct_data() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let details = client.get_creator_details(&creator);
     assert!(details.is_registered);

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -13,7 +13,13 @@ fn test_get_creator_fee_bps_returns_configured_value() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     assert_eq!(client.get_creator_fee_bps(&creator), 9000);
@@ -29,7 +35,13 @@ fn test_get_creator_fee_bps_is_read_only() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &7500u32, &2500u32);
 
     let first = client.get_creator_fee_bps(&creator);
@@ -48,7 +60,13 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let before_update = client.get_creator_fee_bps(&creator);

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -13,7 +13,7 @@ fn test_get_creator_fee_bps_returns_configured_value() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     assert_eq!(client.get_creator_fee_bps(&creator), 9000);
@@ -29,7 +29,7 @@ fn test_get_creator_fee_bps_is_read_only() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.set_fee_config(&admin, &7500u32, &2500u32);
 
     let first = client.get_creator_fee_bps(&creator);
@@ -48,7 +48,7 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let before_update = client.get_creator_fee_bps(&creator);

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -42,7 +42,7 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = soroban_sdk::Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let result = client.try_get_creator_fee_bps(&creator);
     assert_eq!(

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -42,7 +42,13 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = soroban_sdk::Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_get_creator_fee_bps(&creator);
     assert_eq!(

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -28,7 +28,7 @@ fn test_get_creator_fee_config_registered_no_fee_config() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let view = client.get_creator_fee_config(&creator);
 
@@ -50,7 +50,7 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view = client.get_creator_fee_config(&creator);
@@ -73,7 +73,7 @@ fn test_get_creator_fee_config_is_read_only() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -97,7 +97,7 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -124,8 +124,8 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let handle1 = String::from_str(&env, "creator_one");
     let handle2 = String::from_str(&env, "creator_two");
 
-    client.register_creator(&creator1, &handle1, &None, &None);
-    client.register_creator(&creator2, &handle2, &None, &None);
+    client.register_creator(&creator1, &handle1, &None, &None, &None);
+    client.register_creator(&creator2, &handle2, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view1 = client.get_creator_fee_config(&creator1);

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -13,7 +13,13 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(client.get_creator_fee_recipient(&creator), creator);
 }
@@ -27,7 +33,13 @@ fn test_get_creator_fee_recipient_is_read_only() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let first_read = client.get_creator_fee_recipient(&creator);
     let second_read = client.get_creator_fee_recipient(&creator);

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -13,7 +13,7 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert_eq!(client.get_creator_fee_recipient(&creator), creator);
 }
@@ -27,7 +27,7 @@ fn test_get_creator_fee_recipient_is_read_only() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let first_read = client.get_creator_fee_recipient(&creator);
     let second_read = client.get_creator_fee_recipient(&creator);

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -26,7 +26,13 @@ fn test_is_creator_registered_returns_true_after_registration() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -40,7 +46,13 @@ fn test_is_creator_registered_is_read_only() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Multiple calls should return the same result without mutating state
     let r1 = client.is_creator_registered(&creator);
@@ -61,7 +73,13 @@ fn test_is_creator_registered_different_creators_independent() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
 
-    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &alice,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&alice));
     assert!(!client.is_creator_registered(&bob));
@@ -96,10 +114,21 @@ fn test_register_creator_duplicate_different_handle_fails() {
 
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     // Re-registering with a different handle should still fail
-    let result =
-        client.try_register_creator(&creator, &String::from_str(&env, "alice_v2"), &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice_v2"),
+        &None,
+        &None,
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -114,7 +143,13 @@ fn test_register_creator_different_addresses_succeeds() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
 
-    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &alice,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.register_creator(&bob, &String::from_str(&env, "bob"), &None, &None, &None);
 
     assert!(client.is_creator_registered(&alice));
@@ -131,7 +166,13 @@ fn test_register_creator_accepts_min_handle_length() {
 
     let creator = Address::generate(&env);
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
-    client.register_creator(&creator, &String::from_str(&env, &min_handle), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, &min_handle),
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -146,7 +187,13 @@ fn test_register_creator_accepts_max_handle_length() {
 
     let creator = Address::generate(&env);
     let max_handle = "a".repeat(HANDLE_LEN_MAX as usize);
-    client.register_creator(&creator, &String::from_str(&env, &max_handle), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, &max_handle),
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -166,7 +213,8 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
         &String::from_str(&env, &short_handle),
         &None,
         &None,
-     &None);
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
 }
 
@@ -185,7 +233,8 @@ fn test_register_creator_rejects_handle_longer_than_max() {
         &String::from_str(&env, &long_handle),
         &None,
         &None,
-     &None);
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }
 

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -26,7 +26,7 @@ fn test_is_creator_registered_returns_true_after_registration() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -40,7 +40,7 @@ fn test_is_creator_registered_is_read_only() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     // Multiple calls should return the same result without mutating state
     let r1 = client.is_creator_registered(&creator);
@@ -61,7 +61,7 @@ fn test_is_creator_registered_different_creators_independent() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
 
-    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert!(client.is_creator_registered(&alice));
     assert!(!client.is_creator_registered(&bob));
@@ -80,9 +80,9 @@ fn test_register_creator_duplicate_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
     // Second registration with the same address should fail with error
-    let result = client.try_register_creator(&creator, &handle, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -96,10 +96,10 @@ fn test_register_creator_duplicate_different_handle_fails() {
 
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     // Re-registering with a different handle should still fail
     let result =
-        client.try_register_creator(&creator, &String::from_str(&env, "alice_v2"), &None, &None);
+        client.try_register_creator(&creator, &String::from_str(&env, "alice_v2"), &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -114,8 +114,8 @@ fn test_register_creator_different_addresses_succeeds() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
 
-    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None);
-    client.register_creator(&bob, &String::from_str(&env, "bob"), &None, &None);
+    client.register_creator(&alice, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&bob, &String::from_str(&env, "bob"), &None, &None, &None);
 
     assert!(client.is_creator_registered(&alice));
     assert!(client.is_creator_registered(&bob));
@@ -131,7 +131,7 @@ fn test_register_creator_accepts_min_handle_length() {
 
     let creator = Address::generate(&env);
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
-    client.register_creator(&creator, &String::from_str(&env, &min_handle), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, &min_handle), &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -146,7 +146,7 @@ fn test_register_creator_accepts_max_handle_length() {
 
     let creator = Address::generate(&env);
     let max_handle = "a".repeat(HANDLE_LEN_MAX as usize);
-    client.register_creator(&creator, &String::from_str(&env, &max_handle), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, &max_handle), &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -166,7 +166,7 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
         &String::from_str(&env, &short_handle),
         &None,
         &None,
-    );
+     &None);
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
 }
 
@@ -185,7 +185,7 @@ fn test_register_creator_rejects_handle_longer_than_max() {
         &String::from_str(&env, &long_handle),
         &None,
         &None,
-    );
+     &None);
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }
 
@@ -199,7 +199,7 @@ fn test_register_creator_rejects_invalid_characters_in_handle() {
 
     let creator = Address::generate(&env);
     let invalid_handle = String::from_str(&env, "Alice-01");
-    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None);
+    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::InvalidHandleCharacter)));
 }
 
@@ -215,7 +215,7 @@ fn test_register_creator_max_length_handle_succeeds() {
 
     let creator = Address::generate(&env);
     let max_handle = String::from_str(&env, &"a".repeat(HANDLE_LEN_MAX as usize));
-    client.register_creator(&creator, &max_handle, &None, &None);
+    client.register_creator(&creator, &max_handle, &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -230,7 +230,7 @@ fn test_register_creator_handle_one_over_max_rejected() {
 
     let creator = Address::generate(&env);
     let over_max_handle = String::from_str(&env, &"a".repeat((HANDLE_LEN_MAX + 1) as usize));
-    let result = client.try_register_creator(&creator, &over_max_handle, &None, &None);
+    let result = client.try_register_creator(&creator, &over_max_handle, &None, &None, &None);
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -11,7 +11,13 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
     client.set_key_price(&admin, &100_i128);
 
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     (client, admin, creator)
 }

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -11,7 +11,7 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
     client.set_key_price(&admin, &100_i128);
 
     let creator = Address::generate(env);
-    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None, &None);
 
     (client, admin, creator)
 }

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -13,7 +13,7 @@ fn test_get_creator_treasury_share_returns_configured_value() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     assert_eq!(client.get_creator_treasury_share(&creator), 9000);
@@ -29,7 +29,7 @@ fn test_get_creator_treasury_share_is_read_only() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let first = client.get_creator_treasury_share(&creator);

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -13,7 +13,13 @@ fn test_get_creator_treasury_share_returns_configured_value() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     assert_eq!(client.get_creator_treasury_share(&creator), 9000);
@@ -29,7 +35,13 @@ fn test_get_creator_treasury_share_is_read_only() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let first = client.get_creator_treasury_share(&creator);

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -42,7 +42,7 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
     let creator = soroban_sdk::Address::generate(&env);
 
     // Register creator WITHOUT calling set_fee_config.
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let result = client.try_get_creator_treasury_share(&creator);
     assert_eq!(

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -42,7 +42,13 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
     let creator = soroban_sdk::Address::generate(&env);
 
     // Register creator WITHOUT calling set_fee_config.
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_get_creator_treasury_share(&creator);
     assert_eq!(

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -51,10 +51,7 @@ fn test_curve_preset_variants_and_error_handling() {
         client.get_curve_preset(&creator_quadratic),
         CurvePreset::Quadratic
     );
-    assert_eq!(
-        client.get_curve_preset(&creator_flat),
-        CurvePreset::Flat
-    );
+    assert_eq!(client.get_curve_preset(&creator_flat), CurvePreset::Flat);
 
     // Assert querying a non-existent creator returns the expected error (NotRegistered)
     let non_existent = Address::generate(&env);

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -1,0 +1,63 @@
+//! Unit tests for CurvePreset storage and retrieval.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, test_env_with_auths};
+use creator_keys::{ContractError, CurvePreset};
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+#[test]
+fn test_curve_preset_variants_and_error_handling() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let creator_linear = Address::generate(&env);
+    let creator_quadratic = Address::generate(&env);
+    let creator_flat = Address::generate(&env);
+
+    // Register creator with Linear preset
+    client.register_creator(
+        &creator_linear,
+        &String::from_str(&env, "linear_c"),
+        &None,
+        &None,
+        &Some(CurvePreset::Linear),
+    );
+
+    // Register creator with Quadratic preset
+    client.register_creator(
+        &creator_quadratic,
+        &String::from_str(&env, "quadratic_c"),
+        &None,
+        &None,
+        &Some(CurvePreset::Quadratic),
+    );
+
+    // Register creator with Flat preset
+    client.register_creator(
+        &creator_flat,
+        &String::from_str(&env, "flat_c"),
+        &None,
+        &None,
+        &Some(CurvePreset::Flat),
+    );
+
+    // Assert each returns the correct variant
+    assert_eq!(
+        client.get_curve_preset(&creator_linear),
+        CurvePreset::Linear
+    );
+    assert_eq!(
+        client.get_curve_preset(&creator_quadratic),
+        CurvePreset::Quadratic
+    );
+    assert_eq!(
+        client.get_curve_preset(&creator_flat),
+        CurvePreset::Flat
+    );
+
+    // Assert querying a non-existent creator returns the expected error (NotRegistered)
+    let non_existent = Address::generate(&env);
+    let result = client.try_get_curve_preset(&non_existent);
+    assert_eq!(result, Err(Ok(ContractError::NotRegistered)));
+}

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -149,7 +149,7 @@ fn test_register_creator_reverts_when_paused() {
         &soroban_sdk::String::from_str(&env, "alice"),
         &None,
         &None,
-    );
+     &None);
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 }
 

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -149,7 +149,8 @@ fn test_register_creator_reverts_when_paused() {
         &soroban_sdk::String::from_str(&env, "alice"),
         &None,
         &None,
-     &None);
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 }
 

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -15,7 +15,8 @@ fn test_register_creator_rejects_empty_handle() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None, &None);
+    let result =
+        client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None, &None);
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
     assert!(!client.is_creator_registered(&creator));

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -15,7 +15,7 @@ fn test_register_creator_rejects_empty_handle() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let result = client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None);
+    let result = client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None, &None);
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
     assert!(!client.is_creator_registered(&creator));

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -42,7 +42,7 @@ impl<'a> EventFixture<'a> {
 
     fn register_creator(&self, env: &Env, handle: &str) {
         self.client
-            .register_creator(&self.creator, &String::from_str(env, handle), &None, &None);
+            .register_creator(&self.creator, &String::from_str(env, handle), &None, &None, &None);
     }
 
     fn buy_key(&self, buyer: &Address, payment: i128) {
@@ -229,7 +229,7 @@ fn test_register_creator_event_data_is_indexer_friendly() {
 
     fixture
         .client
-        .register_creator(&fixture.creator, &handle, &None, &None);
+        .register_creator(&fixture.creator, &handle, &None, &None, &None);
 
     let events = env.events().all();
     let last = events.last().unwrap();

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -41,8 +41,13 @@ impl<'a> EventFixture<'a> {
     }
 
     fn register_creator(&self, env: &Env, handle: &str) {
-        self.client
-            .register_creator(&self.creator, &String::from_str(env, handle), &None, &None, &None);
+        self.client.register_creator(
+            &self.creator,
+            &String::from_str(env, handle),
+            &None,
+            &None,
+            &None,
+        );
     }
 
     fn buy_key(&self, buyer: &Address, payment: i128) {

--- a/creator-keys/tests/flat_curve_symmetry_regression.rs
+++ b/creator-keys/tests/flat_curve_symmetry_regression.rs
@@ -1,0 +1,105 @@
+//! Regression test verifying buy and sell quote symmetry for the Flat preset.
+//!
+//! The cost (price/fees) to buy N keys at supply S must equal the proceeds (price/fees)
+//! from selling N keys at supply S+N.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
+use creator_keys::CurvePreset;
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+const KEY_PRICE: i128 = 1000;
+const CREATOR_BPS: u32 = 9000;
+const PROTOCOL_BPS: u32 = 1000;
+
+fn assert_symmetry_for_params(
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    creator: &Address,
+    buyer: &Address,
+    start_supply: u32,
+    n: u32,
+) {
+    // 1. Advance supply to start_supply
+    let current_supply = client.get_total_key_supply(creator);
+    if current_supply < start_supply {
+        for _ in current_supply..start_supply {
+            let quote = client.get_buy_quote(creator);
+            client.buy_key(creator, buyer, &quote.total_amount, &None);
+        }
+    }
+
+    assert_eq!(client.get_total_key_supply(creator), start_supply);
+
+    // 2. Accumulate buy quotes for N keys and execute buys
+    let mut total_buy_price = 0;
+    let mut total_buy_creator_fee = 0;
+    let mut total_buy_protocol_fee = 0;
+
+    for _ in 0..n {
+        let quote = client.get_buy_quote(creator);
+        total_buy_price += quote.price;
+        total_buy_creator_fee += quote.creator_fee;
+        total_buy_protocol_fee += quote.protocol_fee;
+        client.buy_key(creator, buyer, &quote.total_amount, &None);
+    }
+
+    assert_eq!(client.get_total_key_supply(creator), start_supply + n);
+
+    // 3. Accumulate sell quotes for N keys and execute sells
+    let mut total_sell_price = 0;
+    let mut total_sell_creator_fee = 0;
+    let mut total_sell_protocol_fee = 0;
+
+    for _ in 0..n {
+        let quote = client.get_sell_quote(creator, buyer);
+        total_sell_price += quote.price;
+        total_sell_creator_fee += quote.creator_fee;
+        total_sell_protocol_fee += quote.protocol_fee;
+        client.sell_key(creator, buyer, &None);
+    }
+
+    assert_eq!(client.get_total_key_supply(creator), start_supply);
+
+    // 4. Assert symmetry
+    assert_eq!(
+        total_buy_price, total_sell_price,
+        "Price asymmetry at supply {} for N {}",
+        start_supply, n
+    );
+    assert_eq!(
+        total_buy_creator_fee, total_sell_creator_fee,
+        "Creator fee asymmetry at supply {} for N {}",
+        start_supply, n
+    );
+    assert_eq!(
+        total_buy_protocol_fee, total_sell_protocol_fee,
+        "Protocol fee asymmetry at supply {} for N {}",
+        start_supply, n
+    );
+}
+
+#[test]
+fn test_flat_curve_symmetry() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "flatcreator"),
+        &None,
+        &None,
+        &Some(CurvePreset::Flat),
+    );
+
+    let buyer = Address::generate(&env);
+
+    // Cover at least three different supply levels: 0, 5, 20
+    // Cover small (1) and large (10, 50) amounts
+    assert_symmetry_for_params(&client, &creator, &buyer, 0, 1);
+    assert_symmetry_for_params(&client, &creator, &buyer, 0, 10);
+    assert_symmetry_for_params(&client, &creator, &buyer, 5, 5);
+    assert_symmetry_for_params(&client, &creator, &buyer, 20, 20);
+}

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -46,7 +46,8 @@ fn test_get_locked_allocation_returns_some_when_set() {
             claimed: false,
         }),
         &None,
-     &None);
+        &None,
+    );
 
     let result = client.get_locked_allocation(&creator);
     assert!(

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -46,7 +46,7 @@ fn test_get_locked_allocation_returns_some_when_set() {
             claimed: false,
         }),
         &None,
-    );
+     &None);
 
     let result = client.get_locked_allocation(&creator);
     assert!(

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -17,7 +17,7 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
     let _admin = set_key_price_for_tests(&env, &client, 100);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "creator"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "creator"), &None, &None, &None);
 
     let buyer_a = Address::generate(&env);
     let buyer_b = Address::generate(&env);

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -17,7 +17,13 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
     let _admin = set_key_price_for_tests(&env, &client, 100);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "creator"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "creator"),
+        &None,
+        &None,
+        &None,
+    );
 
     let buyer_a = Address::generate(&env);
     let buyer_b = Address::generate(&env);

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -9,7 +9,13 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
     let admin = Address::generate(env);
     let creator = Address::generate(env);
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(env, "test"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, "test"),
+        &None,
+        &None,
+        &None,
+    );
     (client, creator, admin)
 }
 
@@ -172,8 +178,20 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
     let holder = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None, &None);
-    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None, &None);
+    client.register_creator(
+        &creator_a,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
+    client.register_creator(
+        &creator_b,
+        &String::from_str(&env, "bob"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Holder buys keys only from creator A
     client.buy_key(&creator_a, &holder, &100i128, &None);

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -9,7 +9,7 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
     let admin = Address::generate(env);
     let creator = Address::generate(env);
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(env, "test"), &None, &None);
+    client.register_creator(&creator, &String::from_str(env, "test"), &None, &None, &None);
     (client, creator, admin)
 }
 
@@ -172,8 +172,8 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
     let holder = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None);
-    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None);
+    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None, &None);
 
     // Holder buys keys only from creator A
     client.buy_key(&creator_a, &holder, &100i128, &None);

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -30,7 +30,7 @@ fn test_key_balance_increments_on_buy() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert_eq!(client.get_key_balance(&creator, &buyer), 0);
 
@@ -55,7 +55,7 @@ fn test_key_balance_is_per_buyer() {
     let buyer_b = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_a, &100i128, &None);
@@ -79,8 +79,8 @@ fn test_key_balance_is_per_creator() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None);
-    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None);
+    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None, &None);
 
     client.buy_key(&creator_a, &buyer, &100i128, &None);
 
@@ -107,7 +107,7 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
         &String::from_str(&env, "alice"),
         &None,
         &None,
-    );
+     &None);
     client.buy_key(&registered_creator, &buyer, &100i128, &None);
 
     assert_eq!(client.get_key_balance(&unregistered_creator, &buyer), 0);
@@ -127,7 +127,7 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
     let unseen_wallet = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &buyer_with_balance, &100i128, &None);
 
     assert_eq!(client.get_key_balance(&creator, &unseen_wallet), 0);
@@ -148,7 +148,7 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
     let uninitialized_wallet = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_b, &100i128, &None);

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -30,7 +30,13 @@ fn test_key_balance_increments_on_buy() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(client.get_key_balance(&creator, &buyer), 0);
 
@@ -55,7 +61,13 @@ fn test_key_balance_is_per_buyer() {
     let buyer_b = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_a, &100i128, &None);
@@ -79,8 +91,20 @@ fn test_key_balance_is_per_creator() {
     let buyer = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator_a, &String::from_str(&env, "alice"), &None, &None, &None);
-    client.register_creator(&creator_b, &String::from_str(&env, "bob"), &None, &None, &None);
+    client.register_creator(
+        &creator_a,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
+    client.register_creator(
+        &creator_b,
+        &String::from_str(&env, "bob"),
+        &None,
+        &None,
+        &None,
+    );
 
     client.buy_key(&creator_a, &buyer, &100i128, &None);
 
@@ -107,7 +131,8 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
         &String::from_str(&env, "alice"),
         &None,
         &None,
-     &None);
+        &None,
+    );
     client.buy_key(&registered_creator, &buyer, &100i128, &None);
 
     assert_eq!(client.get_key_balance(&unregistered_creator, &buyer), 0);
@@ -127,7 +152,13 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
     let unseen_wallet = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer_with_balance, &100i128, &None);
 
     assert_eq!(client.get_key_balance(&creator, &unseen_wallet), 0);
@@ -148,7 +179,13 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
     let uninitialized_wallet = soroban_sdk::Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_a, &100i128, &None);
     client.buy_key(&creator, &buyer_b, &100i128, &None);

--- a/creator-keys/tests/key_name.rs
+++ b/creator-keys/tests/key_name.rs
@@ -13,7 +13,7 @@ fn test_get_key_name_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let name = client.get_key_name(&creator);
     assert_eq!(name, handle);

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -20,7 +20,7 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
     let (client, _) = setup(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
 }
@@ -43,7 +43,7 @@ fn test_get_total_key_supply_increments_after_buy() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
 
@@ -62,7 +62,7 @@ fn test_get_total_key_supply_is_read_only() {
     let (client, _) = setup(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     // Call multiple times — should not change state
     let s1 = client.get_total_key_supply(&creator);
@@ -82,7 +82,7 @@ fn test_buy_key_zero_payment_fails() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let result = client.try_buy_key(&creator, &buyer, &0_i128, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
@@ -96,7 +96,7 @@ fn test_buy_key_negative_payment_fails() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let result = client.try_buy_key(&creator, &buyer, &-50_i128, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
@@ -110,7 +110,7 @@ fn test_buy_key_positive_payment_succeeds() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     let supply = client.buy_key(&creator, &buyer, &100_i128, &None);
     assert_eq!(supply, 1);

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -20,7 +20,13 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
     let (client, _) = setup(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
 }
@@ -43,7 +49,13 @@ fn test_get_total_key_supply_increments_after_buy() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
 
@@ -62,7 +74,13 @@ fn test_get_total_key_supply_is_read_only() {
     let (client, _) = setup(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Call multiple times — should not change state
     let s1 = client.get_total_key_supply(&creator);
@@ -82,7 +100,13 @@ fn test_buy_key_zero_payment_fails() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_buy_key(&creator, &buyer, &0_i128, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
@@ -96,7 +120,13 @@ fn test_buy_key_negative_payment_fails() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_buy_key(&creator, &buyer, &-50_i128, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
@@ -110,7 +140,13 @@ fn test_buy_key_positive_payment_succeeds() {
 
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     let supply = client.buy_key(&creator, &buyer, &100_i128, &None);
     assert_eq!(supply, 1);

--- a/creator-keys/tests/key_symbol.rs
+++ b/creator-keys/tests/key_symbol.rs
@@ -13,7 +13,7 @@ fn test_get_key_symbol_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     let symbol = client.get_key_symbol(&creator);
     assert_eq!(symbol, handle);

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -35,7 +35,7 @@ fn setup_transfer(
     let sender = Address::generate(env);
     let recipient = Address::generate(env);
 
-    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &KEY_PRICE, &None);
     client.transfer_keys(&creator, &sender, &recipient, &TRANSFER_AMOUNT);
 

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -35,7 +35,13 @@ fn setup_transfer(
     let sender = Address::generate(env);
     let recipient = Address::generate(env);
 
-    client.register_creator(&creator, &String::from_str(env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &KEY_PRICE, &None);
     client.transfer_keys(&creator, &sender, &recipient, &TRANSFER_AMOUNT);
 

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -84,7 +84,8 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
         &soroban_sdk::String::from_str(&env, "alice"),
         &None,
         &None,
-     &None);
+        &None,
+    );
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);
 

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -84,7 +84,7 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
         &soroban_sdk::String::from_str(&env, "alice"),
         &None,
         &None,
-    );
+     &None);
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);
 

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -102,7 +102,13 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
 
     // Other state changes should not increment version
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer, &100i128, &None);
     client.set_treasury_address(&admin, &Address::generate(&env));
 

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -102,7 +102,7 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
 
     // Other state changes should not increment version
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &buyer, &100i128, &None);
     client.set_treasury_address(&admin, &Address::generate(&env));
 

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -89,7 +89,8 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &String::from_str(&env, "creator_1"),
         &None,
         &None,
-     &None);
+        &None,
+    );
 
     let event1: events::CreatorRegisteredEvent =
         env.events().all().last().unwrap().2.into_val(&env);
@@ -104,7 +105,8 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &String::from_str(&env, "creator_2"),
         &None,
         &None,
-     &None);
+        &None,
+    );
 
     let event2: events::CreatorRegisteredEvent =
         env.events().all().last().unwrap().2.into_val(&env);

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -26,7 +26,7 @@ fn test_register_creator_event_field_values_match_fixtures() {
     client.set_fee_config(&admin, &expected_creator_bps, &expected_protocol_bps);
 
     // 3. Trigger registration
-    client.register_creator(&creator, &handle, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None);
 
     // 4. Capture the emitted event
     let all_events = env.events().all();
@@ -89,7 +89,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &String::from_str(&env, "creator_1"),
         &None,
         &None,
-    );
+     &None);
 
     let event1: events::CreatorRegisteredEvent =
         env.events().all().last().unwrap().2.into_val(&env);
@@ -104,7 +104,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &String::from_str(&env, "creator_2"),
         &None,
         &None,
-    );
+     &None);
 
     let event2: events::CreatorRegisteredEvent =
         env.events().all().last().unwrap().2.into_val(&env);

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -26,7 +26,13 @@ fn test_sell_event_seller_address_matches_caller() {
 
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Buyer purchases keys
     client.buy_key(&creator, &seller, &KEY_PRICE, &None);
@@ -80,7 +86,13 @@ fn test_sell_event_seller_address_field_is_non_zero() {
 
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &seller, &KEY_PRICE, &None);
     client.sell_key(&creator, &seller, &None);
 

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -26,7 +26,7 @@ fn test_sell_event_seller_address_matches_caller() {
 
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
 
     // Buyer purchases keys
     client.buy_key(&creator, &seller, &KEY_PRICE, &None);
@@ -80,7 +80,7 @@ fn test_sell_event_seller_address_field_is_non_zero() {
 
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &seller, &KEY_PRICE, &None);
     client.sell_key(&creator, &seller, &None);
 

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -13,7 +13,7 @@ fn test_register_creator_minimum_handle_length_success() {
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     let handle = String::from_str(&env, &min_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
 
     // Happy path: the function succeeds
     assert_eq!(result, Ok(Ok(())));
@@ -34,7 +34,7 @@ fn test_register_creator_below_minimum_handle_length_fails() {
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let handle = String::from_str(&env, &short_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
 
     // Error case: expected failure
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -19,7 +19,13 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
     let _admin = set_key_price_for_tests(&env, &client, 100);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "maxed"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "maxed"),
+        &None,
+        &None,
+        &None,
+    );
 
     // Seed supply at the ceiling to simulate "many sequential buys" cheaply.
     env.as_contract(&contract_id, || {

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -19,7 +19,7 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
     let _admin = set_key_price_for_tests(&env, &client, 100);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &String::from_str(&env, "maxed"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "maxed"), &None, &None, &None);
 
     // Seed supply at the ceiling to simulate "many sequential buys" cheaply.
     env.as_contract(&contract_id, || {

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -17,7 +17,13 @@ fn test_transfer_keys_sender_balance_decreases() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -41,7 +47,13 @@ fn test_transfer_keys_recipient_balance_increases() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -63,7 +75,13 @@ fn test_transfer_keys_total_supply_unchanged() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -84,7 +102,13 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -112,7 +136,13 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -136,7 +166,13 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
 
     let holders_before = client.get_creator_holder_count(&creator);
@@ -165,7 +201,13 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
     let sender_b = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender_a, &100, &None);
     client.buy_key(&creator, &sender_b, &100, &None);
 
@@ -191,7 +233,13 @@ fn test_transfer_keys_self_transfer_reverts() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -212,7 +260,13 @@ fn test_transfer_keys_zero_amount_reverts() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -233,7 +287,13 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -270,7 +330,13 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -298,7 +364,13 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -328,7 +400,13 @@ fn test_transfer_keys_preserves_other_holders() {
     let recipient = Address::generate(&env);
     let bystander = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &bystander, &100, &None);
     client.buy_key(&creator, &bystander, &100, &None);

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -17,7 +17,7 @@ fn test_transfer_keys_sender_balance_decreases() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -41,7 +41,7 @@ fn test_transfer_keys_recipient_balance_increases() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -63,7 +63,7 @@ fn test_transfer_keys_total_supply_unchanged() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -84,7 +84,7 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -112,7 +112,7 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -136,7 +136,7 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
     let holders_before = client.get_creator_holder_count(&creator);
@@ -165,7 +165,7 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
     let sender_b = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender_a, &100, &None);
     client.buy_key(&creator, &sender_b, &100, &None);
 
@@ -191,7 +191,7 @@ fn test_transfer_keys_self_transfer_reverts() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -212,7 +212,7 @@ fn test_transfer_keys_zero_amount_reverts() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -233,7 +233,7 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -270,7 +270,7 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -298,7 +298,7 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     let creator = Address::generate(&env);
     let sender = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -328,7 +328,7 @@ fn test_transfer_keys_preserves_other_holders() {
     let recipient = Address::generate(&env);
     let bystander = Address::generate(&env);
 
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &bystander, &100, &None);
     client.buy_key(&creator, &bystander, &100, &None);

--- a/creator-keys/tests/transfer_keys_dividend_preservation.rs
+++ b/creator-keys/tests/transfer_keys_dividend_preservation.rs
@@ -1,0 +1,80 @@
+//! Integration test verifying that key transfer operations preserve
+//! the claimable dividend balances of the sender and recipient wallets.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    assert_claimable, register_creator_keys, set_pricing_and_fees, test_env_with_auths,
+};
+use creator_keys::CurvePreset;
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+const KEY_PRICE: i128 = 1000;
+const CREATOR_BPS: u32 = 9000;
+const PROTOCOL_BPS: u32 = 1000;
+
+#[test]
+fn test_transfer_keys_preserves_claimable_dividends() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &Some(CurvePreset::Flat),
+    );
+
+    let wallet_a = Address::generate(&env);
+    let wallet_b = Address::generate(&env);
+
+    // 1. Distribute keys to Wallet A (2 keys) and Wallet B (1 key)
+    let buy_quote = client.get_buy_quote(&creator);
+    client.buy_key(&creator, &wallet_a, &buy_quote.total_amount, &None);
+    client.buy_key(&creator, &wallet_a, &buy_quote.total_amount, &None);
+    client.buy_key(&creator, &wallet_b, &buy_quote.total_amount, &None);
+
+    assert_eq!(client.get_key_balance(&creator, &wallet_a), 2);
+    assert_eq!(client.get_key_balance(&creator, &wallet_b), 1);
+    assert_eq!(client.get_total_key_supply(&creator), 3);
+
+    // 2. Distribute a dividend
+    // protocol fee of 10% is deducted first.
+    // distributed amount: 300
+    // protocol fee: 30
+    // net distributed: 270
+    // per-key distribution: 270 / 3 = 90
+    let distributor = Address::generate(&env);
+    client.distribute_dividend(&creator, &distributor, &300);
+
+    // 3. Record claimable balances before transfer
+    // Wallet A has 2 keys: 2 * 90 = 180
+    // Wallet B has 1 key: 1 * 90 = 90
+    assert_claimable(&client, &creator, &wallet_a, 180);
+    assert_claimable(&client, &creator, &wallet_b, 90);
+
+    // 4. Transfer 1 key from A to B
+    client.transfer_keys(&creator, &wallet_a, &wallet_b, &1);
+
+    // Assert balances changed
+    assert_eq!(client.get_key_balance(&creator, &wallet_a), 1);
+    assert_eq!(client.get_key_balance(&creator, &wallet_b), 2);
+
+    // 5. Assert claimable balances are unchanged after transfer
+    assert_claimable(&client, &creator, &wallet_a, 180);
+    assert_claimable(&client, &creator, &wallet_b, 90);
+
+    // 6. Assert both wallets can claim their pre-transfer dividend amounts
+    let claimed_a = client.claim_dividend(&creator, &wallet_a);
+    let claimed_b = client.claim_dividend(&creator, &wallet_b);
+
+    assert_eq!(claimed_a, 180);
+    assert_eq!(claimed_b, 90);
+
+    // Verify claimable balances become 0 after claiming
+    assert_claimable(&client, &creator, &wallet_a, 0);
+    assert_claimable(&client, &creator, &wallet_b, 0);
+}


### PR DESCRIPTION
close #484 
close #482 
close #483
close #481 



This PR implements curve presets (`Linear`, `Quadratic`, `Flat`), ensures buy and sell quote symmetry for the `Flat` preset, and verifies that peer-to-peer key transfers preserve claimable dividend balances.

## Features & Changes

### 1. Curve Presets
- **`CurvePreset` Enum**: Added a new contract enum: `Linear` (0), `Quadratic` (1), and `Flat` (2).
- **Persistent Storage**: Associated each creator with their curve preset in contract state via `DataKey::CurvePreset(Address)`.
- **Curve-based Pricing**: Updated `compute_bonding_curve_price` to dispatch pricing logic depending on the creator's curve preset:
  - **`Flat`**: Returns `base_price` (constant price model regardless of supply/slope).
  - **`Linear`**: Returns `base_price + slope * supply`.
  - **`Quadratic`**: Returns `base_price + slope * supply * supply`.
- **Registration Parameter**: Added `curve_preset: Option<CurvePreset>` to `register_creator`. It defaults to `CurvePreset::Linear` to maintain backwards compatibility with existing tests.
- **`get_curve_preset` View**: Added a read-only entrypoint to query a creator's preset. Reverts with `NotRegistered` if the creator doesn't exist.

### 2. Quote and Price Symmetry
- **Symmetry Realization**: Adjusted `sell_key` and `get_sell_quote` to calculate the price using `supply - 1` instead of `supply`.
- **Symmetric Quotes**: This guarantees that the cost to buy a key at supply $S$ exactly matches the proceeds from selling it at supply $S+1$ across all presets.
- **Safety Checks**: Checked the seller's key balance before computing the supply in `sell_key` to avoid false `SellUnderflow` errors when the supply is 0.

### 3. P2P Key Transfer Dividend Preservation
- Confirmed that `transfer_keys` settlements lock in and preserve both wallets' claimable dividend balances before transferring balances and shifting checkpoints.

---

## Integration Tests Added

1. **`curve_preset_storage.rs`**: Verifies that creators can register with different presets, their presets can be queried correctly via `get_curve_preset`, and non-existent creators revert with `NotRegistered`.
2. **`flat_curve_symmetry_regression.rs`**: Asserts that buy and sell quotes are symmetric for the `Flat` preset at multiple supply levels (0, 5, 20) and for both small and large amounts.
3. **`transfer_keys_dividend_preservation.rs`**: Asserts that both the sender's and recipient's claimable balances are unchanged after a transfer, and that both wallets can still claim their pre-transfer dividend amounts.

