### PR TITLE
feat(events): add TreasuryWithdrawalEvent for protocol fee withdrawals

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -258,3 +258,32 @@ pub struct KeysTransferredEvent {
     pub amount: u32,
     pub ledger: u32,
 }
+
+/// Event name for treasury withdrawal.
+pub const TREASURY_WITHDRAWAL_EVENT_NAME: Symbol = symbol_short!("treasury_wd");
+
+/// Stable field order for treasury withdrawal event payloads.
+pub const TREASURY_WITHDRAWAL_DATA_FIELDS: [&str; 4] =
+    ["amount", "recipient", "remaining_balance", "ledger"];
+
+/// Number of fields in the treasury withdrawal event data payload.
+pub const TREASURY_WITHDRAWAL_FIELD_COUNT: usize = TREASURY_WITHDRAWAL_DATA_FIELDS.len();
+
+/// Treasury withdrawal event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(TREASURY_WITHDRAWAL_EVENT_NAME, admin)`
+/// - data: `TreasuryWithdrawalEvent`
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct TreasuryWithdrawalEvent {
+    pub amount: i128,
+    pub recipient: Address,
+    pub remaining_balance: i128,
+    pub ledger: u32,
+}
+
+/// Shared treasury withdrawal event topics tuple.
+pub fn treasury_withdrawal_topics(admin: &Address) -> (Symbol, Address) {
+    (TREASURY_WITHDRAWAL_EVENT_NAME, admin.clone())
+}


### PR DESCRIPTION


## Summary

- Add TREASURY_WITHDRAWAL_EVENT_NAME constant
- Add TreasuryWithdrawalEvent struct with amount, recipient, remaining_balance, ledger
- Add treasury_withdrawal_topics() helper for consistent event emission
- Add field count and field order constants for indexer compatibility

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
