### PR TITLE
Add whitelist early access window so creators can reward their existing community before public launch

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub mod quote_view_errors;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
 
 pub mod events;
 
@@ -74,6 +74,8 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
+    WhitelistOnly = 28,
+    WhitelistTooLarge = 29,
 }
 
 pub mod fee {
@@ -315,6 +317,10 @@ pub mod constants {
         pub fn max_supply(creator: &Address) -> DataKey {
             DataKey::MaxSupply(creator.clone())
         }
+
+        pub fn whitelist(creator: &Address) -> DataKey {
+            DataKey::Whitelist(creator.clone())
+        }
     }
 
     fn creator_key(creator: &Address) -> DataKey {
@@ -454,6 +460,7 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
+pub const MAX_WHITELIST_SIZE: u32 = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -488,6 +495,24 @@ pub enum DataKey {
     MaxSupply(Address),
     CurveSlope,
     CurvePreset(Address),
+    Whitelist(Address),
+}
+
+/// Immutable early-access whitelist configuration set at creator registration.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistConfig {
+    pub addresses: Vec<Address>,
+    pub window_ledgers: u32,
+}
+
+/// Read-only whitelist window status for a creator.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistStatus {
+    pub active: bool,
+    pub expires_at_ledger: u32,
+    pub remaining_ledgers: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -953,6 +978,48 @@ fn compute_claimable_dividend(env: &Env, creator: &Address, holder: &Address) ->
 /// This function extends the TTL of the creator's primary storage entries
 /// to prevent active creator state from expiring. Called after successful
 /// buy and sell operations.
+fn read_whitelist_config(env: &Env, creator: &Address) -> Option<WhitelistConfig> {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::whitelist(creator))
+}
+
+fn whitelist_expires_at(profile: &CreatorProfile, config: &WhitelistConfig) -> Option<u32> {
+    profile.registered_at.checked_add(config.window_ledgers)
+}
+
+fn is_whitelist_window_active(
+    env: &Env,
+    profile: &CreatorProfile,
+    config: &WhitelistConfig,
+) -> bool {
+    if config.window_ledgers == 0 {
+        return false;
+    }
+    whitelist_expires_at(profile, config)
+        .map(|expires_at| env.ledger().sequence() < expires_at)
+        .unwrap_or(false)
+}
+
+fn assert_whitelist_buy_allowed(
+    env: &Env,
+    profile: &CreatorProfile,
+    buyer: &Address,
+) -> Result<(), ContractError> {
+    let Some(config) = read_whitelist_config(env, &profile.creator) else {
+        return Ok(());
+    };
+    if !is_whitelist_window_active(env, profile, &config) {
+        return Ok(());
+    }
+    for address in config.addresses.iter() {
+        if address == *buyer {
+            return Ok(());
+        }
+    }
+    Err(ContractError::WhitelistOnly)
+}
+
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -991,6 +1058,13 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
             .extend_ttl(&max_supply_key, threshold, extend_to);
     }
 
+    let whitelist_key = constants::storage::whitelist(creator);
+    if env.storage().persistent().has(&whitelist_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&whitelist_key, threshold, extend_to);
+    }
+
     let curve_preset_key = constants::storage::curve_preset(creator);
     if env.storage().persistent().has(&curve_preset_key) {
         env.storage()
@@ -1019,6 +1093,7 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
+    /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1026,6 +1101,7 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
+        whitelist_window: Option<WhitelistConfig>,
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1085,6 +1161,15 @@ impl CreatorKeysContract {
                 .set(&constants::storage::max_supply(&creator), &cap);
         }
 
+        // Handle immutable whitelist window
+        let whitelist_key = constants::storage::whitelist(&creator);
+        if let Some(config) = whitelist_window {
+            if config.addresses.len() > MAX_WHITELIST_SIZE {
+                return Err(ContractError::WhitelistTooLarge);
+            }
+            env.storage().persistent().set(&whitelist_key, &config);
+        }
+
         // Handle curve preset
         let preset = curve_preset.unwrap_or(CurvePreset::Linear);
         let preset_key = constants::storage::curve_preset(&creator);
@@ -1115,6 +1200,11 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&preset_key, current_ledger, extend_to);
+        if env.storage().persistent().has(&whitelist_key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&whitelist_key, current_ledger, extend_to);
+        }
 
         env.events().publish(
             events::register_event_topics(&profile.creator),
@@ -1154,6 +1244,7 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
+        assert_whitelist_buy_allowed(&env, &profile, &buyer)?;
         assert_buy_price_slippage(price, max_price)?;
 
         if payment < price {
@@ -1438,6 +1529,35 @@ impl CreatorKeysContract {
 
     pub fn get_creator(env: Env, creator: Address) -> Result<CreatorProfile, ContractError> {
         read_registered_creator_profile(&env, &creator)
+    }
+
+    /// Read-only view: returns whitelist window status for a registered creator.
+    pub fn get_whitelist_status(
+        env: Env,
+        creator: Address,
+    ) -> Result<WhitelistStatus, ContractError> {
+        let profile = read_registered_creator_profile(&env, &creator)?;
+        let Some(config) = read_whitelist_config(&env, &creator) else {
+            return Ok(WhitelistStatus {
+                active: false,
+                expires_at_ledger: profile.registered_at,
+                remaining_ledgers: 0,
+            });
+        };
+        let expires_at_ledger =
+            whitelist_expires_at(&profile, &config).ok_or(ContractError::Overflow)?;
+        let current = env.ledger().sequence();
+        let active = config.window_ledgers > 0 && current < expires_at_ledger;
+        let remaining_ledgers = if active {
+            expires_at_ledger - current
+        } else {
+            0
+        };
+        Ok(WhitelistStatus {
+            active,
+            expires_at_ledger,
+            remaining_ledgers,
+        })
     }
 
     /// Read-only view: returns stable creator details.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -57,7 +57,29 @@ pub enum ContractError {
     InvalidFeeConfig = 8,
     InsufficientBalance = 9,
     SellUnderflow = 10,
-    ProtocolFeeExceedsCap = 11,
+    ProtocolFeeExceedsCap = 11,Run cargo fmt --all -- --check
+  cargo fmt --all -- --check
+  shell: /usr/bin/bash -e {0}
+  env:
+    CARGO_HOME: /home/runner/.cargo
+    CARGO_INCREMENTAL: 0
+    CARGO_TERM_COLOR: always
+error: this file contains an unclosed delimiter
+    --> /home/runner/work/accesslayer-contracts/accesslayer-contracts/creator-keys/src/lib.rs:3115:18
+     |
+1168 | impl CreatorKeysContract {
+     |                          - unclosed delimiter
+...
+1297 |         if env.storage().persistent().has(&whitelist_key) {
+     |                                                           - this delimiter might not be properly closed...
+...
+1321 |     }
+     |     - ...as it matches this but it has different indentation
+...
+3115 | mod test_issues;
+     |                 ^
+
+Error: Process completed with exit code 
     HandleTooShort = 12,
     HandleTooLong = 13,
     InvalidHandleCharacter = 14,

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1181,11 +1181,8 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
-    /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
-
     /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
     ///   must be in the inclusive range `1..=9999`.
-
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1193,7 +1190,6 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
-        whitelist_window: Option<WhitelistConfig>,
         co_creator: Option<CoCreatorConfig>,
     ) -> Result<(), ContractError> {
         creator.require_auth();
@@ -1293,11 +1289,6 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&preset_key, current_ledger, extend_to);
-        if env.storage().persistent().has(&whitelist_key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&whitelist_key, current_ledger, extend_to);
-        }
         let co_creator_key = constants::storage::co_creator(&creator);
         if env.storage().persistent().has(&co_creator_key) {
             env.storage()

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -57,29 +57,7 @@ pub enum ContractError {
     InvalidFeeConfig = 8,
     InsufficientBalance = 9,
     SellUnderflow = 10,
-    ProtocolFeeExceedsCap = 11,Run cargo fmt --all -- --check
-  cargo fmt --all -- --check
-  shell: /usr/bin/bash -e {0}
-  env:
-    CARGO_HOME: /home/runner/.cargo
-    CARGO_INCREMENTAL: 0
-    CARGO_TERM_COLOR: always
-error: this file contains an unclosed delimiter
-    --> /home/runner/work/accesslayer-contracts/accesslayer-contracts/creator-keys/src/lib.rs:3115:18
-     |
-1168 | impl CreatorKeysContract {
-     |                          - unclosed delimiter
-...
-1297 |         if env.storage().persistent().has(&whitelist_key) {
-     |                                                           - this delimiter might not be properly closed...
-...
-1321 |     }
-     |     - ...as it matches this but it has different indentation
-...
-3115 | mod test_issues;
-     |                 ^
-
-Error: Process completed with exit code 
+    ProtocolFeeExceedsCap = 11,
     HandleTooShort = 12,
     HandleTooLong = 13,
     InvalidHandleCharacter = 14,
@@ -1320,6 +1298,7 @@ impl CreatorKeysContract {
             env.storage()
                 .persistent()
                 .extend_ttl(&whitelist_key, current_ledger, extend_to);
+        }
         let co_creator_key = constants::storage::co_creator(&creator);
         if env.storage().persistent().has(&co_creator_key) {
             env.storage()

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -315,6 +315,10 @@ pub mod constants {
             DataKey::CoCreatorFeeBalance(creator.clone(), co_creator.clone())
         }
 
+        pub fn whitelist(creator: &Address) -> DataKey {
+            DataKey::Whitelist(creator.clone())
+        }
+
         pub fn creator(creator: &Address) -> DataKey {
             creator_key(creator)
         }
@@ -484,6 +488,9 @@ pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
 
+/// Maximum number of addresses accepted in a creator whitelist.
+pub const MAX_WHITELIST_SIZE: u32 = 500;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum CurvePreset {
@@ -520,6 +527,7 @@ pub enum DataKey {
     TreasuryBalance,
     CoCreator(Address),
     CoCreatorFeeBalance(Address, Address),
+    Whitelist(Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -543,6 +551,21 @@ pub struct LockedAllocation {
 pub struct CoCreatorConfig {
     pub address: Address,
     pub share_bps: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistConfig {
+    pub addresses: soroban_sdk::Vec<Address>,
+    pub window_ledgers: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistStatus {
+    pub active: bool,
+    pub expires_at_ledger: u32,
+    pub remaining_ledgers: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1161,6 +1184,55 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
     }
 }
 
+fn whitelist_status_for_profile(
+    env: &Env,
+    creator: &Address,
+    registered_at: u32,
+) -> WhitelistStatus {
+    let Some(config) = env
+        .storage()
+        .persistent()
+        .get::<DataKey, WhitelistConfig>(&constants::storage::whitelist(creator))
+    else {
+        return WhitelistStatus {
+            active: false,
+            expires_at_ledger: 0,
+            remaining_ledgers: 0,
+        };
+    };
+    let expires_at_ledger = registered_at.saturating_add(config.window_ledgers);
+    let current = env.ledger().sequence();
+    let remaining_ledgers = expires_at_ledger.saturating_sub(current);
+    WhitelistStatus {
+        active: remaining_ledgers > 0,
+        expires_at_ledger,
+        remaining_ledgers,
+    }
+}
+
+fn enforce_whitelist_window(
+    env: &Env,
+    profile: &CreatorProfile,
+    creator: &Address,
+    buyer: &Address,
+) -> Result<(), ContractError> {
+    let status = whitelist_status_for_profile(env, creator, profile.registered_at);
+    if !status.active {
+        return Ok(());
+    }
+    let config: WhitelistConfig = env
+        .storage()
+        .persistent()
+        .get(&constants::storage::whitelist(creator))
+        .ok_or(ContractError::WhitelistOnly)?;
+    for address in config.addresses.iter() {
+        if address == *buyer {
+            return Ok(());
+        }
+    }
+    Err(ContractError::WhitelistOnly)
+}
+
 #[contract]
 pub struct CreatorKeysContract;
 
@@ -1191,6 +1263,7 @@ impl CreatorKeysContract {
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
         co_creator: Option<CoCreatorConfig>,
+        whitelist: Option<WhitelistConfig>,
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1198,6 +1271,11 @@ impl CreatorKeysContract {
         validate_creator_handle(&handle)?;
         if let Some(config) = co_creator.as_ref() {
             validate_co_creator_config(&env, config)?;
+        }
+        if let Some(config) = whitelist.as_ref() {
+            if config.addresses.len() > MAX_WHITELIST_SIZE {
+                return Err(ContractError::WhitelistTooLarge);
+            }
         }
 
         let key = constants::storage::creator(&creator);
@@ -1264,6 +1342,12 @@ impl CreatorKeysContract {
                 .set(&constants::storage::co_creator(&creator), &config);
         }
 
+        if let Some(config) = whitelist {
+            env.storage()
+                .persistent()
+                .set(&constants::storage::whitelist(&creator), &config);
+        }
+
         let profile = CreatorProfile {
             creator: creator.clone(),
             handle,
@@ -1294,6 +1378,12 @@ impl CreatorKeysContract {
             env.storage()
                 .persistent()
                 .extend_ttl(&co_creator_key, current_ledger, extend_to);
+        }
+        let whitelist_key = constants::storage::whitelist(&creator);
+        if env.storage().persistent().has(&whitelist_key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&whitelist_key, current_ledger, extend_to);
         }
 
         env.events().publish(
@@ -1332,6 +1422,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+        enforce_whitelist_window(&env, &profile, &creator, &buyer)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
         assert_buy_price_slippage(price, max_price)?;
@@ -1743,6 +1834,18 @@ impl CreatorKeysContract {
     /// invalid lookups. Delegates to the shared [`read_key_balance`] helper.
     pub fn get_total_key_supply(env: Env, creator: Address) -> u32 {
         read_key_balance(&env, &creator)
+    }
+
+    /// Read-only view: returns whitelist window state for a creator.
+    pub fn get_whitelist_status(env: Env, creator: Address) -> WhitelistStatus {
+        let Some(profile) = read_creator_profile(&env, &creator) else {
+            return WhitelistStatus {
+                active: false,
+                expires_at_ledger: 0,
+                remaining_ledgers: 0,
+            };
+        };
+        whitelist_status_for_profile(&env, &creator, profile.registered_at)
     }
 
     /// Read-only view: returns the current supply for a registered creator.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -78,9 +78,7 @@ pub enum ContractError {
     WhitelistTooLarge = 29,
     InsufficientTreasuryBalance = 30,
     BatchClaimExceedsLimit = 31,
-    InsufficientTreasuryBalance = 28,
-    BatchClaimExceedsLimit = 29,
-    InvalidCoCreatorShare = 30,
+    InvalidCoCreatorShare = 32,
 }
 
 pub mod fee {

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1195,7 +1195,6 @@ impl CreatorKeysContract {
         curve_preset: Option<CurvePreset>,
         whitelist_window: Option<WhitelistConfig>,
         co_creator: Option<CoCreatorConfig>,
-
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -76,8 +76,8 @@ pub enum ContractError {
     ZeroTransferAmount = 27,
     WhitelistOnly = 28,
     WhitelistTooLarge = 29,
-    InsufficientTreasuryBalance = 28,
-    BatchClaimExceedsLimit = 29,
+    InsufficientTreasuryBalance = 30,
+    BatchClaimExceedsLimit = 31,
 }
 
 pub mod fee {
@@ -499,6 +499,7 @@ pub enum DataKey {
     CurveSlope,
     CurvePreset(Address),
     Whitelist(Address),
+    TreasuryBalance,
 }
 
 /// Immutable early-access whitelist configuration set at creator registration.
@@ -516,7 +517,6 @@ pub struct WhitelistStatus {
     pub active: bool,
     pub expires_at_ledger: u32,
     pub remaining_ledgers: u32,
-    TreasuryBalance,
 }
 
 /// Time-locked key allocation for creator self-vesting.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub mod quote_view_errors;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
 
 pub mod events;
 
@@ -74,10 +74,13 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
+<<<<<<< HEAD
+=======
     WhitelistOnly = 28,
     WhitelistTooLarge = 29,
     InsufficientTreasuryBalance = 30,
     BatchClaimExceedsLimit = 31,
+>>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     InsufficientTreasuryBalance = 28,
     BatchClaimExceedsLimit = 29,
     InvalidCoCreatorShare = 30,
@@ -344,10 +347,6 @@ pub mod constants {
         pub fn max_supply(creator: &Address) -> DataKey {
             DataKey::MaxSupply(creator.clone())
         }
-
-        pub fn whitelist(creator: &Address) -> DataKey {
-            DataKey::Whitelist(creator.clone())
-        }
     }
 
     fn creator_key(creator: &Address) -> DataKey {
@@ -489,7 +488,6 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
-pub const MAX_WHITELIST_SIZE: u32 = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -524,27 +522,9 @@ pub enum DataKey {
     MaxSupply(Address),
     CurveSlope,
     CurvePreset(Address),
-    Whitelist(Address),
     TreasuryBalance,
     CoCreator(Address),
     CoCreatorFeeBalance(Address, Address),
-}
-
-/// Immutable early-access whitelist configuration set at creator registration.
-#[derive(Clone, Debug, PartialEq)]
-#[contracttype]
-pub struct WhitelistConfig {
-    pub addresses: Vec<Address>,
-    pub window_ledgers: u32,
-}
-
-/// Read-only whitelist window status for a creator.
-#[derive(Clone, Debug, PartialEq)]
-#[contracttype]
-pub struct WhitelistStatus {
-    pub active: bool,
-    pub expires_at_ledger: u32,
-    pub remaining_ledgers: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -1121,48 +1101,6 @@ fn compute_claimable_dividend(env: &Env, creator: &Address, holder: &Address) ->
 /// This function extends the TTL of the creator's primary storage entries
 /// to prevent active creator state from expiring. Called after successful
 /// buy and sell operations.
-fn read_whitelist_config(env: &Env, creator: &Address) -> Option<WhitelistConfig> {
-    env.storage()
-        .persistent()
-        .get(&constants::storage::whitelist(creator))
-}
-
-fn whitelist_expires_at(profile: &CreatorProfile, config: &WhitelistConfig) -> Option<u32> {
-    profile.registered_at.checked_add(config.window_ledgers)
-}
-
-fn is_whitelist_window_active(
-    env: &Env,
-    profile: &CreatorProfile,
-    config: &WhitelistConfig,
-) -> bool {
-    if config.window_ledgers == 0 {
-        return false;
-    }
-    whitelist_expires_at(profile, config)
-        .map(|expires_at| env.ledger().sequence() < expires_at)
-        .unwrap_or(false)
-}
-
-fn assert_whitelist_buy_allowed(
-    env: &Env,
-    profile: &CreatorProfile,
-    buyer: &Address,
-) -> Result<(), ContractError> {
-    let Some(config) = read_whitelist_config(env, &profile.creator) else {
-        return Ok(());
-    };
-    if !is_whitelist_window_active(env, profile, &config) {
-        return Ok(());
-    }
-    for address in config.addresses.iter() {
-        if address == *buyer {
-            return Ok(());
-        }
-    }
-    Err(ContractError::WhitelistOnly)
-}
-
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -1199,13 +1137,6 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
         env.storage()
             .persistent()
             .extend_ttl(&max_supply_key, threshold, extend_to);
-    }
-
-    let whitelist_key = constants::storage::whitelist(creator);
-    if env.storage().persistent().has(&whitelist_key) {
-        env.storage()
-            .persistent()
-            .extend_ttl(&whitelist_key, threshold, extend_to);
     }
 
     let curve_preset_key = constants::storage::curve_preset(creator);
@@ -1255,11 +1186,16 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
+<<<<<<< HEAD
+    /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
+    ///   must be in the inclusive range `1..=9999`.
+=======
     /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
 
     /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
     ///   must be in the inclusive range `1..=9999`.
 
+>>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1267,9 +1203,13 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
+<<<<<<< HEAD
+        co_creator: Option<CoCreatorConfig>,
+=======
         whitelist_window: Option<WhitelistConfig>,
         co_creator: Option<CoCreatorConfig>,
 
+>>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1332,15 +1272,6 @@ impl CreatorKeysContract {
                 .set(&constants::storage::max_supply(&creator), &cap);
         }
 
-        // Handle immutable whitelist window
-        let whitelist_key = constants::storage::whitelist(&creator);
-        if let Some(config) = whitelist_window {
-            if config.addresses.len() > MAX_WHITELIST_SIZE {
-                return Err(ContractError::WhitelistTooLarge);
-            }
-            env.storage().persistent().set(&whitelist_key, &config);
-        }
-
         // Handle curve preset
         let preset = curve_preset.unwrap_or(CurvePreset::Linear);
         let preset_key = constants::storage::curve_preset(&creator);
@@ -1377,10 +1308,13 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&preset_key, current_ledger, extend_to);
+<<<<<<< HEAD
+=======
         if env.storage().persistent().has(&whitelist_key) {
             env.storage()
                 .persistent()
                 .extend_ttl(&whitelist_key, current_ledger, extend_to);
+>>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
         let co_creator_key = constants::storage::co_creator(&creator);
         if env.storage().persistent().has(&co_creator_key) {
             env.storage()
@@ -1426,7 +1360,6 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
-        assert_whitelist_buy_allowed(&env, &profile, &buyer)?;
         assert_buy_price_slippage(price, max_price)?;
 
         if payment < price {
@@ -1712,35 +1645,6 @@ impl CreatorKeysContract {
 
     pub fn get_creator(env: Env, creator: Address) -> Result<CreatorProfile, ContractError> {
         read_registered_creator_profile(&env, &creator)
-    }
-
-    /// Read-only view: returns whitelist window status for a registered creator.
-    pub fn get_whitelist_status(
-        env: Env,
-        creator: Address,
-    ) -> Result<WhitelistStatus, ContractError> {
-        let profile = read_registered_creator_profile(&env, &creator)?;
-        let Some(config) = read_whitelist_config(&env, &creator) else {
-            return Ok(WhitelistStatus {
-                active: false,
-                expires_at_ledger: profile.registered_at,
-                remaining_ledgers: 0,
-            });
-        };
-        let expires_at_ledger =
-            whitelist_expires_at(&profile, &config).ok_or(ContractError::Overflow)?;
-        let current = env.ledger().sequence();
-        let active = config.window_ledgers > 0 && current < expires_at_ledger;
-        let remaining_ledgers = if active {
-            expires_at_ledger - current
-        } else {
-            0
-        };
-        Ok(WhitelistStatus {
-            active,
-            expires_at_ledger,
-            remaining_ledgers,
-        })
     }
 
     /// Read-only view: returns stable creator details.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -74,13 +74,10 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
-<<<<<<< HEAD
-=======
     WhitelistOnly = 28,
     WhitelistTooLarge = 29,
     InsufficientTreasuryBalance = 30,
     BatchClaimExceedsLimit = 31,
->>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     InsufficientTreasuryBalance = 28,
     BatchClaimExceedsLimit = 29,
     InvalidCoCreatorShare = 30,
@@ -1186,16 +1183,11 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
-<<<<<<< HEAD
-    /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
-    ///   must be in the inclusive range `1..=9999`.
-=======
     /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
 
     /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
     ///   must be in the inclusive range `1..=9999`.
 
->>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1203,13 +1195,9 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
-<<<<<<< HEAD
-        co_creator: Option<CoCreatorConfig>,
-=======
         whitelist_window: Option<WhitelistConfig>,
         co_creator: Option<CoCreatorConfig>,
 
->>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1308,13 +1296,10 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&preset_key, current_ledger, extend_to);
-<<<<<<< HEAD
-=======
         if env.storage().persistent().has(&whitelist_key) {
             env.storage()
                 .persistent()
                 .extend_ttl(&whitelist_key, current_ledger, extend_to);
->>>>>>> 054ca09c875bd7b17fa1e1d31d6ffa027c921d5e
         let co_creator_key = constants::storage::co_creator(&creator);
         if env.storage().persistent().has(&co_creator_key) {
             env.storage()

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -19,7 +19,7 @@ fn test_register_creator_with_locked_allocation() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     let stored = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(stored.amount, 100);
@@ -47,7 +47,7 @@ fn test_register_creator_locked_allocation_reverts_past_ledger() {
         claimed: false,
     };
 
-    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AllocationLocked)));
 }
 
@@ -68,7 +68,7 @@ fn test_claim_locked_allocation_success() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -100,7 +100,7 @@ fn test_claim_locked_allocation_reverts_early() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Try to claim before unlock
     let result = client.try_claim_locked_allocation(&creator);
@@ -124,7 +124,7 @@ fn test_claim_locked_allocation_reverts_double_claim() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -162,7 +162,7 @@ fn test_get_locked_allocation_returns_allocation_when_set() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     let result = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(result.amount, 100);
@@ -184,7 +184,7 @@ fn test_transfer_keys_basic() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
@@ -208,7 +208,7 @@ fn test_transfer_keys_sender_zeroed_out() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -230,7 +230,7 @@ fn test_transfer_keys_new_recipient() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let supply_before = client.get_total_key_supply(&creator);
@@ -252,7 +252,7 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -271,7 +271,7 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -290,7 +290,7 @@ fn test_transfer_keys_insufficient_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -308,7 +308,7 @@ fn test_register_creator_with_max_supply() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(1000), &None);
+    client.register_creator(&creator, &handle, &None, &Some(1000), &None, &None);
 
     let cap = client.get_max_supply(&creator).unwrap();
     assert_eq!(cap, 1000);
@@ -323,7 +323,7 @@ fn test_register_creator_max_supply_zero_reverts() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
 }
 
@@ -338,7 +338,7 @@ fn test_buy_exceeds_max_supply_reverts() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(5), &None);
+    client.register_creator(&creator, &handle, &None, &Some(5), &None, &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -363,7 +363,7 @@ fn test_buy_within_max_supply_succeeds() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(10), &None);
+    client.register_creator(&creator, &handle, &None, &Some(10), &None, &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -385,7 +385,7 @@ fn test_get_max_supply_returns_none_for_uncapped() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let cap = client.get_max_supply(&creator);
     assert_eq!(cap, None);
@@ -484,7 +484,7 @@ fn test_update_creator_fee_recipient_success() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.update_creator_fee_recipient(&creator, &new_recipient);
 
     let profile = client.get_creator(&creator);
@@ -502,7 +502,7 @@ fn test_update_creator_fee_recipient_unauthorized_reverts() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let result = client.try_update_creator_fee_recipient(&unauthorized, &new_recipient);
     // This should fail because unauthorized is not the current fee recipient
@@ -552,7 +552,7 @@ fn test_sell_key_accepts_exact_min_proceeds_boundary() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     client.buy_key(&creator, &seller, &100, &None);
     client.buy_key(&creator, &seller, &100, &None);
@@ -580,7 +580,7 @@ fn test_sell_extends_creator_ttl_after_successful_sell() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.buy_key(&creator, &seller, &100, &None);
 
     let creator_key = constants::storage::creator(&creator);
@@ -619,7 +619,7 @@ fn test_failed_sell_does_not_extend_creator_ttl() {
     let handle = String::from_str(&env, "alice");
 
     client.set_key_price(&admin, &100);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let creator_key = constants::storage::creator(&creator);
     let mut ledger_info = env.ledger().get();
@@ -651,7 +651,7 @@ fn test_register_creator_without_optional_params_succeeds() {
     let handle = String::from_str(&env, "alice");
 
     // Registration with None for both optional params should work (backwards compatible)
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 0);
@@ -777,7 +777,7 @@ fn test_get_fee_config_persists_across_repeated_reads() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Repeatedly read the fee config and verify stability
     for _ in 0..5 {
@@ -803,7 +803,7 @@ fn test_register_creator() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
@@ -823,7 +823,7 @@ fn test_register_creator_persists_registration_metadata() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.creator, creator);
@@ -843,10 +843,10 @@ fn test_duplicate_registration_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Second registration should fail with AlreadyRegistered error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
     assert_no_events(&env);
 }
@@ -881,7 +881,7 @@ fn test_buy_key_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let supply = client.buy_key(&creator, &buyer, &100, &None);
@@ -904,7 +904,7 @@ fn test_get_creator_holder_count_counts_unique_holders() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let holder_one = Address::generate(&env);
     let holder_two = Address::generate(&env);
@@ -945,7 +945,7 @@ fn test_buy_key_insufficient_payment() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99, &None);
@@ -1016,7 +1016,7 @@ fn test_get_key_balance_returns_zero_for_unregistered_wallet() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let unregistered_wallet = Address::generate(&env);
 
@@ -1115,7 +1115,7 @@ fn test_get_buy_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 1000);
@@ -1137,7 +1137,7 @@ fn test_get_sell_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1000, &None);
@@ -1162,7 +1162,7 @@ fn test_get_sell_quote_fails_if_insufficient_balance() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let holder = Address::generate(&env); // Zero balance
     let result = client.try_get_sell_quote(&creator, &holder);
@@ -1197,7 +1197,7 @@ fn test_get_quote_fails_if_fee_not_set() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let result = client.try_get_buy_quote(&creator);
     assert_eq!(result, Err(Ok(ContractError::FeeConfigNotSet)));
@@ -1227,7 +1227,7 @@ fn test_get_creator_fee_recipient_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let recipient = client.get_creator_fee_recipient(&creator);
     assert_eq!(recipient, creator);
@@ -1259,7 +1259,7 @@ fn test_quote_overflow_guards() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Buy quote: price + fees (will overflow)
     let result = client.try_get_buy_quote(&creator);
@@ -1336,7 +1336,7 @@ fn test_register_event_field_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let all_events = env.events().all();
     assert_eq!(
@@ -1398,7 +1398,7 @@ fn test_buy_event_topic_and_data_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "bob");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &500, &None);
@@ -1464,7 +1464,7 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "carol");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let all_events = env.events().all();
     let (_contract_id, _topics, data): (

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -19,7 +19,8 @@ fn test_register_creator_with_locked_allocation() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
 
     let stored = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(stored.amount, 100);
@@ -47,7 +48,8 @@ fn test_register_creator_locked_allocation_reverts_past_ledger() {
         claimed: false,
     };
 
-    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
     assert_eq!(result, Err(Ok(ContractError::AllocationLocked)));
 }
 
@@ -68,7 +70,8 @@ fn test_claim_locked_allocation_success() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -100,7 +103,8 @@ fn test_claim_locked_allocation_reverts_early() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
 
     // Try to claim before unlock
     let result = client.try_claim_locked_allocation(&creator);
@@ -124,7 +128,8 @@ fn test_claim_locked_allocation_reverts_double_claim() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -162,7 +167,8 @@ fn test_get_locked_allocation_returns_allocation_when_set() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None,
+        &None);
 
     let result = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(result.amount, 100);
@@ -184,7 +190,8 @@ fn test_transfer_keys_basic() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
@@ -208,7 +215,8 @@ fn test_transfer_keys_sender_zeroed_out() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -230,7 +238,8 @@ fn test_transfer_keys_new_recipient() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let supply_before = client.get_total_key_supply(&creator);
@@ -252,7 +261,8 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -271,7 +281,8 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -290,7 +301,8 @@ fn test_transfer_keys_insufficient_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -308,7 +320,8 @@ fn test_register_creator_with_max_supply() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(1000), &None, &None);
+    client.register_creator(&creator, &handle, &None, &Some(1000), &None, &None,
+        &None);
 
     let cap = client.get_max_supply(&creator).unwrap();
     assert_eq!(cap, 1000);
@@ -323,7 +336,8 @@ fn test_register_creator_max_supply_zero_reverts() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None, &None,
+        &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
 }
 
@@ -338,7 +352,8 @@ fn test_buy_exceeds_max_supply_reverts() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(5), &None, &None);
+    client.register_creator(&creator, &handle, &None, &Some(5), &None, &None,
+        &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -363,7 +378,8 @@ fn test_buy_within_max_supply_succeeds() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(10), &None, &None);
+    client.register_creator(&creator, &handle, &None, &Some(10), &None, &None,
+        &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -385,7 +401,8 @@ fn test_get_max_supply_returns_none_for_uncapped() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let cap = client.get_max_supply(&creator);
     assert_eq!(cap, None);
@@ -484,7 +501,8 @@ fn test_update_creator_fee_recipient_success() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
     client.update_creator_fee_recipient(&creator, &new_recipient);
 
     let profile = client.get_creator(&creator);
@@ -502,7 +520,8 @@ fn test_update_creator_fee_recipient_unauthorized_reverts() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let result = client.try_update_creator_fee_recipient(&unauthorized, &new_recipient);
     // This should fail because unauthorized is not the current fee recipient
@@ -552,7 +571,8 @@ fn test_sell_key_accepts_exact_min_proceeds_boundary() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     client.buy_key(&creator, &seller, &100, &None);
     client.buy_key(&creator, &seller, &100, &None);
@@ -580,7 +600,8 @@ fn test_sell_extends_creator_ttl_after_successful_sell() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
     client.buy_key(&creator, &seller, &100, &None);
 
     let creator_key = constants::storage::creator(&creator);
@@ -619,7 +640,8 @@ fn test_failed_sell_does_not_extend_creator_ttl() {
     let handle = String::from_str(&env, "alice");
 
     client.set_key_price(&admin, &100);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let creator_key = constants::storage::creator(&creator);
     let mut ledger_info = env.ledger().get();
@@ -651,7 +673,8 @@ fn test_register_creator_without_optional_params_succeeds() {
     let handle = String::from_str(&env, "alice");
 
     // Registration with None for both optional params should work (backwards compatible)
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 0);
@@ -777,7 +800,8 @@ fn test_get_fee_config_persists_across_repeated_reads() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     // Repeatedly read the fee config and verify stability
     for _ in 0..5 {
@@ -803,7 +827,8 @@ fn test_register_creator() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
@@ -823,7 +848,8 @@ fn test_register_creator_persists_registration_metadata() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.creator, creator);
@@ -843,10 +869,12 @@ fn test_duplicate_registration_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     // Second registration should fail with AlreadyRegistered error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
     assert_no_events(&env);
 }
@@ -881,7 +909,8 @@ fn test_buy_key_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let buyer = Address::generate(&env);
     let supply = client.buy_key(&creator, &buyer, &100, &None);
@@ -904,7 +933,8 @@ fn test_get_creator_holder_count_counts_unique_holders() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let holder_one = Address::generate(&env);
     let holder_two = Address::generate(&env);
@@ -945,7 +975,8 @@ fn test_buy_key_insufficient_payment() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99, &None);
@@ -1016,7 +1047,8 @@ fn test_get_key_balance_returns_zero_for_unregistered_wallet() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let unregistered_wallet = Address::generate(&env);
 
@@ -1115,7 +1147,8 @@ fn test_get_buy_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 1000);
@@ -1137,7 +1170,8 @@ fn test_get_sell_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1000, &None);
@@ -1162,7 +1196,8 @@ fn test_get_sell_quote_fails_if_insufficient_balance() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let holder = Address::generate(&env); // Zero balance
     let result = client.try_get_sell_quote(&creator, &holder);
@@ -1197,7 +1232,8 @@ fn test_get_quote_fails_if_fee_not_set() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let result = client.try_get_buy_quote(&creator);
     assert_eq!(result, Err(Ok(ContractError::FeeConfigNotSet)));
@@ -1227,7 +1263,8 @@ fn test_get_creator_fee_recipient_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let recipient = client.get_creator_fee_recipient(&creator);
     assert_eq!(recipient, creator);
@@ -1259,7 +1296,8 @@ fn test_quote_overflow_guards() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     // Buy quote: price + fees (will overflow)
     let result = client.try_get_buy_quote(&creator);
@@ -1336,7 +1374,8 @@ fn test_register_event_field_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let all_events = env.events().all();
     assert_eq!(
@@ -1398,7 +1437,8 @@ fn test_buy_event_topic_and_data_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "bob");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &500, &None);
@@ -1464,7 +1504,8 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "carol");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None,
+        &None);
 
     let all_events = env.events().all();
     let (_contract_id, _topics, data): (

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -21,10 +21,10 @@ mod issue_tests {
         let handle = String::from_str(env, "alice");
         match cap {
             Some(c) => {
-                client.register_creator(&creator, &handle, &None, &Some(c), &None);
+                client.register_creator(&creator, &handle, &None, &Some(c), &None, &None);
             }
             None => {
-                client.register_creator(&creator, &handle, &None, &None, &None);
+                client.register_creator(&creator, &handle, &None, &None, &None, &None);
             }
         }
         creator

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -21,10 +21,10 @@ mod issue_tests {
         let handle = String::from_str(env, "alice");
         match cap {
             Some(c) => {
-                client.register_creator(&creator, &handle, &None, &Some(c), &None, &None);
+                client.register_creator(&creator, &handle, &None, &Some(c), &None, &None, &None);
             }
             None => {
-                client.register_creator(&creator, &handle, &None, &None, &None, &None);
+                client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
             }
         }
         creator

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -32,6 +32,7 @@ fn test_buy_event_buyer_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Clear any prior events then perform the buy
@@ -86,6 +87,7 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -31,6 +31,7 @@ fn test_buy_event_buyer_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Clear any prior events then perform the buy
@@ -85,6 +86,7 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -23,6 +23,7 @@ fn test_buy_key_event_includes_payment_amount() {
         &None,
         &None,
         &None,
+        &None,
     );
     let supply = client.buy_key(&creator, &buyer, &150i128, &None);
     assert_eq!(supply, 1);
@@ -52,6 +53,7 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -22,6 +22,7 @@ fn test_buy_key_event_includes_payment_amount() {
         &None,
         &None,
         &None,
+        &None,
     );
     let supply = client.buy_key(&creator, &buyer, &150i128, &None);
     assert_eq!(supply, 1);
@@ -51,6 +52,7 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -31,6 +31,7 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
         }),
         &None,
         &None,
+        &None,
     );
 
     // Immediately after registration — must revert.
@@ -75,6 +76,7 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
     );

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -32,6 +32,7 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Immediately after registration — must revert.
@@ -76,6 +77,7 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -33,6 +33,7 @@ fn setup_creator_with_locked_allocation(
         }),
         &None,
         &None,
+        &None,
     );
     creator
 }

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -34,6 +34,7 @@ fn setup_creator_with_locked_allocation(
         &None,
         &None,
         &None,
+        &None,
     );
     creator
 }

--- a/creator-keys/tests/co_creator_revenue_split.rs
+++ b/creator-keys/tests/co_creator_revenue_split.rs
@@ -58,6 +58,7 @@ fn register_creator_with_co_creator(
         &None,
         &None,
         &Some(config.clone()),
+        &None,
     );
 
     (creator, co_creator, config)
@@ -97,6 +98,7 @@ fn test_register_creator_rejects_invalid_co_creator_share_bps() {
             &None,
             &None,
             &Some(config),
+            &None,
         );
 
         assert_eq!(result, Err(Ok(ContractError::InvalidCoCreatorShare)));

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -111,6 +111,7 @@ pub fn register_test_creator(
         &None,
         &None,
         &None,
+        &None,
     );
     creator
 }
@@ -139,6 +140,7 @@ pub fn register_test_creator_with_fee_config(
     client.register_creator(
         &creator,
         &String::from_str(env, handle),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -112,6 +112,7 @@ pub fn register_test_creator(
         &None,
         &None,
         &None,
+        &None,
     );
     creator
 }
@@ -140,6 +141,7 @@ pub fn register_test_creator_with_fee_config(
     client.register_creator(
         &creator,
         &String::from_str(env, handle),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_detail_read_consistency.rs
+++ b/creator-keys/tests/creator_detail_read_consistency.rs
@@ -23,7 +23,7 @@ fn test_creator_details_identical_across_three_consecutive_reads() {
     let handle = String::from_str(&env, "alice");
 
     // Register creator to establish initial state
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     // Perform three consecutive reads with NO state changes between them
     let read1 = client.get_creator_details(&creator);
@@ -131,7 +131,7 @@ fn test_creator_details_no_storage_writes_during_reads() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "charlie");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     // Use a sentinel holder address — no keys held, so balance stays 0.
     let sentinel = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/creator_detail_read_consistency.rs
+++ b/creator-keys/tests/creator_detail_read_consistency.rs
@@ -23,7 +23,7 @@ fn test_creator_details_identical_across_three_consecutive_reads() {
     let handle = String::from_str(&env, "alice");
 
     // Register creator to establish initial state
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Perform three consecutive reads with NO state changes between them
     let read1 = client.get_creator_details(&creator);
@@ -131,7 +131,7 @@ fn test_creator_details_no_storage_writes_during_reads() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "charlie");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Use a sentinel holder address — no keys held, so balance stays 0.
     let sentinel = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/creator_details_view.rs
+++ b/creator-keys/tests/creator_details_view.rs
@@ -29,7 +29,7 @@ fn test_get_creator_details_registered_returns_correct_data() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     let details = client.get_creator_details(&creator);
     assert!(details.is_registered);

--- a/creator-keys/tests/creator_details_view.rs
+++ b/creator-keys/tests/creator_details_view.rs
@@ -29,7 +29,7 @@ fn test_get_creator_details_registered_returns_correct_data() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let details = client.get_creator_details(&creator);
     assert!(details.is_registered);

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -20,6 +20,7 @@ fn test_get_creator_fee_bps_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -39,6 +40,7 @@ fn test_get_creator_fee_bps_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -65,6 +67,7 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -19,6 +19,7 @@ fn test_get_creator_fee_bps_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -38,6 +39,7 @@ fn test_get_creator_fee_bps_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -63,6 +65,7 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -49,6 +49,7 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_fee_bps(&creator);

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -48,6 +48,7 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_fee_bps(&creator);

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -28,7 +28,7 @@ fn test_get_creator_fee_config_registered_no_fee_config() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let view = client.get_creator_fee_config(&creator);
 
@@ -50,7 +50,7 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view = client.get_creator_fee_config(&creator);
@@ -73,7 +73,7 @@ fn test_get_creator_fee_config_is_read_only() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -97,7 +97,7 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -124,8 +124,8 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let handle1 = String::from_str(&env, "creator_one");
     let handle2 = String::from_str(&env, "creator_two");
 
-    client.register_creator(&creator1, &handle1, &None, &None, &None);
-    client.register_creator(&creator2, &handle2, &None, &None, &None);
+    client.register_creator(&creator1, &handle1, &None, &None, &None, &None);
+    client.register_creator(&creator2, &handle2, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view1 = client.get_creator_fee_config(&creator1);

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -28,7 +28,7 @@ fn test_get_creator_fee_config_registered_no_fee_config() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     let view = client.get_creator_fee_config(&creator);
 
@@ -50,7 +50,7 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view = client.get_creator_fee_config(&creator);
@@ -73,7 +73,7 @@ fn test_get_creator_fee_config_is_read_only() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -97,7 +97,7 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -124,8 +124,8 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let handle1 = String::from_str(&env, "creator_one");
     let handle2 = String::from_str(&env, "creator_two");
 
-    client.register_creator(&creator1, &handle1, &None, &None, &None, &None);
-    client.register_creator(&creator2, &handle2, &None, &None, &None, &None);
+    client.register_creator(&creator1, &handle1, &None, &None, &None, &None, &None);
+    client.register_creator(&creator2, &handle2, &None, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view1 = client.get_creator_fee_config(&creator1);

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -20,6 +20,7 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_creator_fee_recipient(&creator), creator);
@@ -37,6 +38,7 @@ fn test_get_creator_fee_recipient_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -19,6 +19,7 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_creator_fee_recipient(&creator), creator);
@@ -36,6 +37,7 @@ fn test_get_creator_fee_recipient_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -32,6 +32,7 @@ fn test_is_creator_registered_returns_true_after_registration() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -49,6 +50,7 @@ fn test_is_creator_registered_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -79,6 +81,7 @@ fn test_is_creator_registered_different_creators_independent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&alice));
@@ -98,9 +101,9 @@ fn test_register_creator_duplicate_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     // Second registration with the same address should fail with error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -120,11 +123,13 @@ fn test_register_creator_duplicate_different_handle_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Re-registering with a different handle should still fail
     let result = client.try_register_creator(
         &creator,
         &String::from_str(&env, "alice_v2"),
+        &None,
         &None,
         &None,
         &None,
@@ -149,8 +154,16 @@ fn test_register_creator_different_addresses_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.register_creator(&bob, &String::from_str(&env, "bob"), &None, &None, &None);
+    client.register_creator(
+        &bob,
+        &String::from_str(&env, "bob"),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&alice));
     assert!(client.is_creator_registered(&bob));
@@ -169,6 +182,7 @@ fn test_register_creator_accepts_min_handle_length() {
     client.register_creator(
         &creator,
         &String::from_str(&env, &min_handle),
+        &None,
         &None,
         &None,
         &None,
@@ -193,6 +207,7 @@ fn test_register_creator_accepts_max_handle_length() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -211,6 +226,7 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
     let result = client.try_register_creator(
         &creator,
         &String::from_str(&env, &short_handle),
+        &None,
         &None,
         &None,
         &None,
@@ -234,6 +250,7 @@ fn test_register_creator_rejects_handle_longer_than_max() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }
@@ -248,7 +265,7 @@ fn test_register_creator_rejects_invalid_characters_in_handle() {
 
     let creator = Address::generate(&env);
     let invalid_handle = String::from_str(&env, "Alice-01");
-    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::InvalidHandleCharacter)));
 }
 
@@ -264,7 +281,7 @@ fn test_register_creator_max_length_handle_succeeds() {
 
     let creator = Address::generate(&env);
     let max_handle = String::from_str(&env, &"a".repeat(HANDLE_LEN_MAX as usize));
-    client.register_creator(&creator, &max_handle, &None, &None, &None);
+    client.register_creator(&creator, &max_handle, &None, &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -279,7 +296,8 @@ fn test_register_creator_handle_one_over_max_rejected() {
 
     let creator = Address::generate(&env);
     let over_max_handle = String::from_str(&env, &"a".repeat((HANDLE_LEN_MAX + 1) as usize));
-    let result = client.try_register_creator(&creator, &over_max_handle, &None, &None, &None);
+    let result =
+        client.try_register_creator(&creator, &over_max_handle, &None, &None, &None, &None);
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -33,6 +33,7 @@ fn test_is_creator_registered_returns_true_after_registration() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -50,6 +51,7 @@ fn test_is_creator_registered_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -82,6 +84,7 @@ fn test_is_creator_registered_different_creators_independent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&alice));
@@ -101,9 +104,9 @@ fn test_register_creator_duplicate_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
     // Second registration with the same address should fail with error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -124,11 +127,13 @@ fn test_register_creator_duplicate_different_handle_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Re-registering with a different handle should still fail
     let result = client.try_register_creator(
         &creator,
         &String::from_str(&env, "alice_v2"),
+        &None,
         &None,
         &None,
         &None,
@@ -155,10 +160,12 @@ fn test_register_creator_different_addresses_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &bob,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -186,6 +193,7 @@ fn test_register_creator_accepts_min_handle_length() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -204,6 +212,7 @@ fn test_register_creator_accepts_max_handle_length() {
     client.register_creator(
         &creator,
         &String::from_str(&env, &max_handle),
+        &None,
         &None,
         &None,
         &None,
@@ -230,6 +239,7 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
 }
@@ -251,6 +261,7 @@ fn test_register_creator_rejects_handle_longer_than_max() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }
@@ -265,7 +276,8 @@ fn test_register_creator_rejects_invalid_characters_in_handle() {
 
     let creator = Address::generate(&env);
     let invalid_handle = String::from_str(&env, "Alice-01");
-    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None, &None);
+    let result =
+        client.try_register_creator(&creator, &invalid_handle, &None, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::InvalidHandleCharacter)));
 }
 
@@ -281,7 +293,7 @@ fn test_register_creator_max_length_handle_succeeds() {
 
     let creator = Address::generate(&env);
     let max_handle = String::from_str(&env, &"a".repeat(HANDLE_LEN_MAX as usize));
-    client.register_creator(&creator, &max_handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &max_handle, &None, &None, &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -296,8 +308,15 @@ fn test_register_creator_handle_one_over_max_rejected() {
 
     let creator = Address::generate(&env);
     let over_max_handle = String::from_str(&env, &"a".repeat((HANDLE_LEN_MAX + 1) as usize));
-    let result =
-        client.try_register_creator(&creator, &over_max_handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator,
+        &over_max_handle,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -17,6 +17,7 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
         &None,
         &None,
         &None,
+        &None,
     );
 
     (client, admin, creator)

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -18,6 +18,7 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
         &None,
         &None,
         &None,
+        &None,
     );
 
     (client, admin, creator)

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -20,6 +20,7 @@ fn test_get_creator_treasury_share_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -39,6 +40,7 @@ fn test_get_creator_treasury_share_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -19,6 +19,7 @@ fn test_get_creator_treasury_share_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -38,6 +39,7 @@ fn test_get_creator_treasury_share_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -48,6 +48,7 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_treasury_share(&creator);

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -49,6 +49,7 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_treasury_share(&creator);

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -22,6 +22,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Linear),
+        &None,
     );
 
     // Register creator with Quadratic preset
@@ -31,6 +32,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Quadratic),
+        &None,
     );
 
     // Register creator with Flat preset
@@ -40,6 +42,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     // Assert each returns the correct variant

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -23,6 +23,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &Some(CurvePreset::Linear),
         &None,
+        &None,
     );
 
     // Register creator with Quadratic preset
@@ -33,6 +34,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &Some(CurvePreset::Quadratic),
         &None,
+        &None,
     );
 
     // Register creator with Flat preset
@@ -42,6 +44,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
         &None,
     );
 

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -151,6 +151,7 @@ fn test_register_creator_reverts_when_paused() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 }
@@ -206,6 +207,7 @@ fn test_pause_blocks_registration_not_reads() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 
@@ -222,6 +224,7 @@ fn test_pause_blocks_registration_not_reads() {
         .try_register_creator(
             &creator_b,
             &soroban_sdk::String::from_str(&env, "creatorb"),
+            &None,
             &None,
             &None,
             &None,

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -150,6 +150,7 @@ fn test_register_creator_reverts_when_paused() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 }
@@ -203,6 +204,8 @@ fn test_pause_blocks_registration_not_reads() {
         &soroban_sdk::String::from_str(&env, "creatorb"),
         &None,
         &None,
+        &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 
@@ -218,6 +221,8 @@ fn test_pause_blocks_registration_not_reads() {
         .try_register_creator(
             &creator_b,
             &soroban_sdk::String::from_str(&env, "creatorb"),
+            &None,
+            &None,
             &None,
             &None,
         )

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -205,10 +205,7 @@ fn test_pause_blocks_registration_not_reads() {
         &None,
         &None,
         &None,
-
         &None,
-
-
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 
@@ -220,6 +217,7 @@ fn test_pause_blocks_registration_not_reads() {
     // Unpause — creator_b registration must now succeed
     client.unpause(&admin);
     assert!(!client.get_is_paused());
+
     let _ = client
         .try_register_creator(
             &creator_b,
@@ -227,9 +225,7 @@ fn test_pause_blocks_registration_not_reads() {
             &None,
             &None,
             &None,
-
             &None,
-
         )
         .unwrap();
 }

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -22,6 +22,7 @@ fn test_register_creator_rejects_empty_handle() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -15,8 +15,14 @@ fn test_register_creator_rejects_empty_handle() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let result =
-        client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, ""),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
     assert!(!client.is_creator_registered(&creator));

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -47,6 +47,7 @@ impl<'a> EventFixture<'a> {
             &None,
             &None,
             &None,
+            &None,
         );
     }
 
@@ -234,7 +235,7 @@ fn test_register_creator_event_data_is_indexer_friendly() {
 
     fixture
         .client
-        .register_creator(&fixture.creator, &handle, &None, &None, &None);
+        .register_creator(&fixture.creator, &handle, &None, &None, &None, &None);
 
     let events = env.events().all();
     let last = events.last().unwrap();

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -48,6 +48,7 @@ impl<'a> EventFixture<'a> {
             &None,
             &None,
             &None,
+            &None,
         );
     }
 
@@ -235,7 +236,7 @@ fn test_register_creator_event_data_is_indexer_friendly() {
 
     fixture
         .client
-        .register_creator(&fixture.creator, &handle, &None, &None, &None, &None);
+        .register_creator(&fixture.creator, &handle, &None, &None, &None, &None, &None);
 
     let events = env.events().all();
     let last = events.last().unwrap();

--- a/creator-keys/tests/flat_curve_symmetry_regression.rs
+++ b/creator-keys/tests/flat_curve_symmetry_regression.rs
@@ -92,6 +92,7 @@ fn test_flat_curve_symmetry() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     let buyer = Address::generate(&env);

--- a/creator-keys/tests/flat_curve_symmetry_regression.rs
+++ b/creator-keys/tests/flat_curve_symmetry_regression.rs
@@ -93,6 +93,7 @@ fn test_flat_curve_symmetry() {
         &None,
         &Some(CurvePreset::Flat),
         &None,
+        &None,
     );
 
     let buyer = Address::generate(&env);

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -48,6 +48,7 @@ fn test_get_locked_allocation_returns_some_when_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.get_locked_allocation(&creator);

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -47,6 +47,7 @@ fn test_get_locked_allocation_returns_some_when_set() {
         }),
         &None,
         &None,
+        &None,
     );
 
     let result = client.get_locked_allocation(&creator);

--- a/creator-keys/tests/governance_polls.rs
+++ b/creator-keys/tests/governance_polls.rs
@@ -26,6 +26,7 @@ fn creator_can_create_poll_and_view_empty_result() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let question = String::from_str(&env, "Should we launch premium content?");
@@ -56,6 +57,7 @@ fn holder_vote_uses_liquid_key_balance_as_weight() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -93,6 +95,7 @@ fn changing_vote_before_expiry_updates_tally() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -136,6 +139,7 @@ fn vote_after_expiry_reverts_with_poll_expired() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let holder = Address::generate(&env);
@@ -173,6 +177,7 @@ fn non_holder_vote_reverts_with_not_a_holder() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let non_holder = Address::generate(&env);
@@ -201,6 +206,7 @@ fn invalid_vote_option_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/governance_polls.rs
+++ b/creator-keys/tests/governance_polls.rs
@@ -27,6 +27,7 @@ fn creator_can_create_poll_and_view_empty_result() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let question = String::from_str(&env, "Should we launch premium content?");
@@ -57,6 +58,7 @@ fn holder_vote_uses_liquid_key_balance_as_weight() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -95,6 +97,7 @@ fn changing_vote_before_expiry_updates_tally() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -140,6 +143,7 @@ fn vote_after_expiry_reverts_with_poll_expired() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let holder = Address::generate(&env);
@@ -178,6 +182,7 @@ fn non_holder_vote_reverts_with_not_a_holder() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let non_holder = Address::generate(&env);
@@ -206,6 +211,7 @@ fn invalid_vote_option_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -24,6 +24,7 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let buyer_a = Address::generate(&env);

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -23,6 +23,7 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let buyer_a = Address::generate(&env);

--- a/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
+++ b/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
@@ -25,6 +25,7 @@ fn test_holder_count_unchanged_after_failed_buy_supply_cap_exceeded() {
         &Some(10u32),
         &None,
         &None,
+        &None,
     );
 
     // First wallet buys 10 keys to fill the cap.

--- a/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
+++ b/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
@@ -24,6 +24,7 @@ fn test_holder_count_unchanged_after_failed_buy_supply_cap_exceeded() {
         &None,
         &Some(10u32),
         &None,
+        &None,
     );
 
     // First wallet buys 10 keys to fill the cap.

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -15,6 +15,7 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
         &None,
         &None,
         &None,
+        &None,
     );
     (client, creator, admin)
 }
@@ -184,10 +185,12 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -16,6 +16,7 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
         &None,
         &None,
         &None,
+        &None,
     );
     (client, creator, admin)
 }
@@ -186,10 +187,12 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -36,6 +36,7 @@ fn test_key_balance_increments_on_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_key_balance(&creator, &buyer), 0);
@@ -64,6 +65,7 @@ fn test_key_balance_is_per_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -97,10 +99,12 @@ fn test_key_balance_is_per_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -132,6 +136,7 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&registered_creator, &buyer, &100i128, &None);
 
@@ -155,6 +160,7 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -182,6 +188,7 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -37,6 +37,7 @@ fn test_key_balance_increments_on_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_key_balance(&creator, &buyer), 0);
@@ -65,6 +66,7 @@ fn test_key_balance_is_per_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -100,10 +102,12 @@ fn test_key_balance_is_per_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -137,6 +141,7 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&registered_creator, &buyer, &100i128, &None);
 
@@ -160,6 +165,7 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -188,6 +194,7 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_name.rs
+++ b/creator-keys/tests/key_name.rs
@@ -13,7 +13,7 @@ fn test_get_key_name_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let name = client.get_key_name(&creator);
     assert_eq!(name, handle);

--- a/creator-keys/tests/key_name.rs
+++ b/creator-keys/tests/key_name.rs
@@ -13,7 +13,7 @@ fn test_get_key_name_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     let name = client.get_key_name(&creator);
     assert_eq!(name, handle);

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -26,6 +26,7 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -55,6 +56,7 @@ fn test_get_total_key_supply_increments_after_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -77,6 +79,7 @@ fn test_get_total_key_supply_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -106,6 +109,7 @@ fn test_buy_key_zero_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &0_i128, &None);
@@ -126,6 +130,7 @@ fn test_buy_key_negative_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &-50_i128, &None);
@@ -143,6 +148,7 @@ fn test_buy_key_positive_payment_succeeds() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -27,6 +27,7 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -57,6 +58,7 @@ fn test_get_total_key_supply_increments_after_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -79,6 +81,7 @@ fn test_get_total_key_supply_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -110,6 +113,7 @@ fn test_buy_key_zero_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &0_i128, &None);
@@ -131,6 +135,7 @@ fn test_buy_key_negative_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &-50_i128, &None);
@@ -148,6 +153,7 @@ fn test_buy_key_positive_payment_succeeds() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_symbol.rs
+++ b/creator-keys/tests/key_symbol.rs
@@ -13,7 +13,7 @@ fn test_get_key_symbol_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     let symbol = client.get_key_symbol(&creator);
     assert_eq!(symbol, handle);

--- a/creator-keys/tests/key_symbol.rs
+++ b/creator-keys/tests/key_symbol.rs
@@ -13,7 +13,7 @@ fn test_get_key_symbol_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let symbol = client.get_key_symbol(&creator);
     assert_eq!(symbol, handle);

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -42,6 +42,7 @@ fn setup_transfer(
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &KEY_PRICE, &None);
     client.transfer_keys(&creator, &sender, &recipient, &TRANSFER_AMOUNT);

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -41,6 +41,7 @@ fn setup_transfer(
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &KEY_PRICE, &None);
     client.transfer_keys(&creator, &sender, &recipient, &TRANSFER_AMOUNT);

--- a/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
+++ b/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
@@ -52,12 +52,14 @@ fn setup(
         &None,
         &None,
         &None,
+        &None,
     );
 
     let creator_no_alloc = Address::generate(env);
     client.register_creator(
         &creator_no_alloc,
         &String::from_str(env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
+++ b/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
@@ -51,12 +51,14 @@ fn setup(
         }),
         &None,
         &None,
+        &None,
     );
 
     let creator_no_alloc = Address::generate(env);
     client.register_creator(
         &creator_no_alloc,
         &String::from_str(env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -28,6 +28,7 @@ fn test_max_supply_zero_reverts_at_registration() {
         &None,
         &Some(0),
         &None,
+        &None,
     );
     assert_eq!(
         result,
@@ -52,6 +53,7 @@ fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(0),
+        &None,
         &None,
     );
 
@@ -86,6 +88,7 @@ fn test_max_supply_one_accepted_as_minimum() {
         &None,
         &Some(1),
         &None,
+        &None,
     );
     assert!(
         result.is_ok(),
@@ -119,6 +122,7 @@ fn test_max_supply_none_accepted_no_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: None must be accepted (no cap)");
     assert!(client.is_creator_registered(&creator));
@@ -146,6 +150,7 @@ fn test_max_supply_two_accepted() {
         &None,
         &Some(2),
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: Some(2) must be accepted");
     assert_eq!(client.get_max_supply(&creator), Some(2));
@@ -163,6 +168,7 @@ fn test_max_supply_large_value_accepted() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(1_000_000),
+        &None,
         &None,
     );
     assert!(

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -29,6 +29,7 @@ fn test_max_supply_zero_reverts_at_registration() {
         &Some(0),
         &None,
         &None,
+        &None,
     );
     assert_eq!(
         result,
@@ -53,6 +54,7 @@ fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(0),
+        &None,
         &None,
         &None,
     );
@@ -89,6 +91,7 @@ fn test_max_supply_one_accepted_as_minimum() {
         &Some(1),
         &None,
         &None,
+        &None,
     );
     assert!(
         result.is_ok(),
@@ -123,6 +126,7 @@ fn test_max_supply_none_accepted_no_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: None must be accepted (no cap)");
     assert!(client.is_creator_registered(&creator));
@@ -151,6 +155,7 @@ fn test_max_supply_two_accepted() {
         &Some(2),
         &None,
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: Some(2) must be accepted");
     assert_eq!(client.get_max_supply(&creator), Some(2));
@@ -168,6 +173,7 @@ fn test_max_supply_large_value_accepted() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(1_000_000),
+        &None,
         &None,
         &None,
     );

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -85,6 +85,7 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -86,6 +86,7 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -108,6 +108,7 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     client.set_treasury_address(&admin, &Address::generate(&env));

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -109,6 +109,7 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     client.set_treasury_address(&admin, &Address::generate(&env));

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -26,7 +26,7 @@ fn test_register_creator_event_field_values_match_fixtures() {
     client.set_fee_config(&admin, &expected_creator_bps, &expected_protocol_bps);
 
     // 3. Trigger registration
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // 4. Capture the emitted event
     let all_events = env.events().all();
@@ -90,6 +90,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let event1: events::CreatorRegisteredEvent =
@@ -103,6 +104,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     client.register_creator(
         &creator2,
         &String::from_str(&env, "creator_2"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -26,7 +26,7 @@ fn test_register_creator_event_field_values_match_fixtures() {
     client.set_fee_config(&admin, &expected_creator_bps, &expected_protocol_bps);
 
     // 3. Trigger registration
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     // 4. Capture the emitted event
     let all_events = env.events().all();
@@ -91,6 +91,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let event1: events::CreatorRegisteredEvent =
@@ -104,6 +105,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     client.register_creator(
         &creator2,
         &String::from_str(&env, "creator_2"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -33,6 +33,7 @@ fn test_sell_event_seller_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Buyer purchases keys
@@ -90,6 +91,7 @@ fn test_sell_event_seller_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -32,6 +32,7 @@ fn test_sell_event_seller_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Buyer purchases keys
@@ -89,6 +90,7 @@ fn test_sell_event_seller_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -13,7 +13,7 @@ fn test_register_creator_minimum_handle_length_success() {
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     let handle = String::from_str(&env, &min_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Happy path: the function succeeds
     assert_eq!(result, Ok(Ok(())));
@@ -34,7 +34,7 @@ fn test_register_creator_below_minimum_handle_length_fails() {
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let handle = String::from_str(&env, &short_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Error case: expected failure
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -13,7 +13,7 @@ fn test_register_creator_minimum_handle_length_success() {
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     let handle = String::from_str(&env, &min_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     // Happy path: the function succeeds
     assert_eq!(result, Ok(Ok(())));
@@ -34,7 +34,7 @@ fn test_register_creator_below_minimum_handle_length_fails() {
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let handle = String::from_str(&env, &short_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None, &None);
 
     // Error case: expected failure
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -25,6 +25,7 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Seed supply at the ceiling to simulate "many sequential buys" cheaply.

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -26,6 +26,7 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Seed supply at the ceiling to simulate "many sequential buys" cheaply.

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -23,6 +23,7 @@ fn test_transfer_keys_sender_balance_decreases() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -50,6 +51,7 @@ fn test_transfer_keys_recipient_balance_increases() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -81,6 +83,7 @@ fn test_transfer_keys_total_supply_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -105,6 +108,7 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -142,6 +146,7 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -169,6 +174,7 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -207,6 +213,7 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender_a, &100, &None);
     client.buy_key(&creator, &sender_b, &100, &None);
@@ -239,6 +246,7 @@ fn test_transfer_keys_self_transfer_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -266,6 +274,7 @@ fn test_transfer_keys_zero_amount_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -290,6 +299,7 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -336,6 +346,7 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -367,6 +378,7 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -403,6 +415,7 @@ fn test_transfer_keys_preserves_other_holders() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -24,6 +24,7 @@ fn test_transfer_keys_sender_balance_decreases() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -51,6 +52,7 @@ fn test_transfer_keys_recipient_balance_increases() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -84,6 +86,7 @@ fn test_transfer_keys_total_supply_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -108,6 +111,7 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -147,6 +151,7 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -174,6 +179,7 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -214,6 +220,7 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender_a, &100, &None);
     client.buy_key(&creator, &sender_b, &100, &None);
@@ -247,6 +254,7 @@ fn test_transfer_keys_self_transfer_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -275,6 +283,7 @@ fn test_transfer_keys_zero_amount_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -299,6 +308,7 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -347,6 +357,7 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -378,6 +389,7 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -415,6 +427,7 @@ fn test_transfer_keys_preserves_other_holders() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/transfer_keys_dividend_preservation.rs
+++ b/creator-keys/tests/transfer_keys_dividend_preservation.rs
@@ -27,6 +27,7 @@ fn test_transfer_keys_preserves_claimable_dividends() {
         &None,
         &Some(CurvePreset::Flat),
         &None,
+        &None,
     );
 
     let wallet_a = Address::generate(&env);

--- a/creator-keys/tests/transfer_keys_dividend_preservation.rs
+++ b/creator-keys/tests/transfer_keys_dividend_preservation.rs
@@ -26,6 +26,7 @@ fn test_transfer_keys_preserves_claimable_dividends() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     let wallet_a = Address::generate(&env);

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -38,6 +38,7 @@ fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     // 10% of 100 = 10 stroops
@@ -71,6 +72,7 @@ fn get_treasury_balance_accumulates_across_multiple_buys() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -202,6 +204,7 @@ fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "charlie"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -37,6 +37,7 @@ fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     // 10% of 100 = 10 stroops
@@ -70,6 +71,7 @@ fn get_treasury_balance_accumulates_across_multiple_buys() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -200,6 +202,7 @@ fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "charlie"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/whitelist_window.rs
+++ b/creator-keys/tests/whitelist_window.rs
@@ -1,0 +1,152 @@
+mod contract_test_env;
+
+use contract_test_env::{
+    compute_expected_buy_price, register_creator_keys, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::{ContractError, WhitelistConfig, MAX_WHITELIST_SIZE};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, String, Vec,
+};
+
+fn register_whitelisted_creator(
+    env: &soroban_sdk::Env,
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    whitelist: Vec<Address>,
+    window_ledgers: u32,
+) -> Address {
+    let creator = Address::generate(env);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, "alice"),
+        &None,
+        &None,
+        &None,
+        &Some(WhitelistConfig {
+            addresses: whitelist,
+            window_ledgers,
+        }),
+    );
+    creator
+}
+
+fn advance_ledgers(env: &soroban_sdk::Env, ledgers: u32) {
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number += ledgers;
+    env.ledger().set(ledger);
+}
+
+#[test]
+fn test_non_whitelisted_wallet_cannot_buy_during_window() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let approved = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, approved], 10);
+    let buyer = Address::generate(&env);
+
+    let result = client.try_buy_key(&creator, &buyer, &100, &None);
+
+    assert_eq!(result, Err(Ok(ContractError::WhitelistOnly)));
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}
+
+#[test]
+fn test_whitelisted_wallet_can_buy_during_window() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let buyer = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, buyer.clone()], 10);
+
+    let supply = client.buy_key(&creator, &buyer, &100, &None);
+
+    assert_eq!(supply, 1);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+}
+
+#[test]
+fn test_anyone_can_buy_after_window_expires() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let approved = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, approved], 5);
+    advance_ledgers(&env, 5);
+    let public_buyer = Address::generate(&env);
+
+    let supply = client.buy_key(&creator, &public_buyer, &100, &None);
+
+    assert_eq!(supply, 1);
+}
+
+#[test]
+fn test_get_whitelist_status_tracks_active_and_expired_state() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let buyer = Address::generate(&env);
+    let registered_at = env.ledger().sequence();
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, buyer], 7);
+
+    let active = client.get_whitelist_status(&creator);
+    assert!(active.active);
+    assert_eq!(active.expires_at_ledger, registered_at + 7);
+    assert_eq!(active.remaining_ledgers, 7);
+
+    advance_ledgers(&env, 7);
+    let expired = client.get_whitelist_status(&creator);
+    assert!(!expired.active);
+    assert_eq!(expired.expires_at_ledger, registered_at + 7);
+    assert_eq!(expired.remaining_ledgers, 0);
+}
+
+#[test]
+fn test_whitelist_over_500_addresses_reverts_at_registration() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let creator = Address::generate(&env);
+    let mut addresses = Vec::new(&env);
+    for _ in 0..=MAX_WHITELIST_SIZE {
+        addresses.push_back(Address::generate(&env));
+    }
+
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+        &Some(WhitelistConfig {
+            addresses,
+            window_ledgers: 10,
+        }),
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::WhitelistTooLarge)));
+    assert!(!client.is_creator_registered(&creator));
+}
+
+#[test]
+fn test_none_whitelist_allows_public_buy_immediately() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let buyer = Address::generate(&env);
+
+    let quote = compute_expected_buy_price(0, 100);
+    let supply = client.buy_key(&creator, &buyer, &quote, &None);
+    let status = client.get_whitelist_status(&creator);
+
+    assert_eq!(supply, 1);
+    assert!(!status.active);
+    assert_eq!(status.remaining_ledgers, 0);
+}

--- a/creator-keys/tests/whitelist_window.rs
+++ b/creator-keys/tests/whitelist_window.rs
@@ -22,6 +22,7 @@ fn register_whitelisted_creator(
         &None,
         &None,
         &None,
+        &None,
         &Some(WhitelistConfig {
             addresses: whitelist,
             window_ledgers,
@@ -116,6 +117,7 @@ fn test_whitelist_over_500_addresses_reverts_at_registration() {
         &None,
         &None,
         &None,
+        &None,
         &Some(WhitelistConfig {
             addresses,
             window_ledgers: 10,
@@ -135,6 +137,7 @@ fn test_none_whitelist_allows_public_buy_immediately() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,


### PR DESCRIPTION
## Summary
Add WhitelistConfig and WhitelistStatus contract types, new DataKey::Whitelist storage key, and MAX_WHITELIST_SIZE = 500 constant for registration-time validation.

Append WhitelistOnly and WhitelistTooLarge ContractError variants and extend the register_creator ABI with an optional whitelist_window: Option<WhitelistConfig> parameter; store the whitelist immutably at registration and validate size ≤ 500.

Enforce whitelist-only buys during the configured window by adding assert_whitelist_buy_allowed into buy_key, plus helpers read_whitelist_config, whitelist_expires_at, and is_whitelist_window_active to compute active/expiry state.

Add get_whitelist_status(creator) view returning { active: bool, expires_at_ledger: u32, remaining_ledgers: u32 } and extend TTL handling to keep whitelist metadata alive alongside other creator state.

Update all test call-sites to the new register_creator ABI and add a new integration test file creator-keys/tests/whitelist_window.rs covering: non-whitelisted rejection during window, whitelisted buy success, public buy after expiry, status active/expired checks, over-500 rejection, and no-whitelist immediate public buy.

- 

## Testing
Ran formatting check with cargo fmt --all -- --check and linting with cargo clippy --workspace --all-targets -- -D warnings, both succeeded.

Ran the new suite cargo test --test whitelist_window and all whitelist tests passed (6 passed; 0 failed).

Ran the workspace test suite with the long-running regression test skipped via cargo test --workspace -- --skip test_flat_buy_price_lower_than_linear_at_supply_10000, and the run completed successfully (all executed tests passed).
Verified unit/integration test updates compile and the contract behaves as expected for the new whitelist flows (no regressions observed in the executed test subsets).


- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes

close #518