### PR TITLE
feat(creator-keys): add protocol treasury withdrawal function

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -268,6 +268,35 @@ pub struct KeysTransferredEvent {
     pub ledger: u32,
 }
 
+/// Event name for treasury withdrawal by the protocol admin.
+pub const TREASURY_WITHDRAWAL_EVENT_NAME: Symbol = symbol_short!("treas_out");
+
+/// Stable field order for treasury withdrawal event payloads.
+pub const TREASURY_WITHDRAWAL_DATA_FIELDS: [&str; 4] =
+    ["amount", "recipient", "remaining_balance", "ledger"];
+
+/// Stable treasury withdrawal event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(TREASURY_WITHDRAWAL_EVENT_NAME, recipient)`
+/// - data: `TreasuryWithdrawalEvent`
+///
+/// `ledger` is the Soroban ledger sequence number at the time of withdrawal so
+/// off-chain indexers can reconstruct the timeline without replaying all events.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct TreasuryWithdrawalEvent {
+    pub amount: i128,
+    pub recipient: Address,
+    pub remaining_balance: i128,
+    pub ledger: u32,
+}
+
+/// Shared treasury withdrawal event topics tuple.
+pub fn treasury_withdrawal_event_topics(recipient: &Address) -> (Symbol, Address) {
+    (TREASURY_WITHDRAWAL_EVENT_NAME, recipient.clone())
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -74,6 +74,7 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
+    InsufficientTreasuryBalance = 28,
 }
 
 pub mod fee {
@@ -279,6 +280,7 @@ pub mod constants {
         pub const PROTOCOL_STATE_VERSION: DataKey = DataKey::ProtocolStateVersion;
         pub const PAUSED: DataKey = DataKey::Paused;
         pub const CURVE_SLOPE: DataKey = DataKey::CurveSlope;
+        pub const TREASURY_BALANCE: DataKey = DataKey::TreasuryBalance;
 
         pub fn curve_preset(creator: &Address) -> DataKey {
             DataKey::CurvePreset(creator.clone())
@@ -488,6 +490,7 @@ pub enum DataKey {
     MaxSupply(Address),
     CurveSlope,
     CurvePreset(Address),
+    TreasuryBalance,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -689,6 +692,28 @@ fn credit_protocol_fee_recipient_balance(env: &Env, amount: i128) -> Result<(), 
     Ok(())
 }
 
+/// Reads the accumulated treasury balance, returning `0` when none is stored.
+pub fn read_treasury_balance(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::TREASURY_BALANCE)
+        .unwrap_or(0)
+}
+
+/// Credits `amount` to the protocol treasury balance.
+fn credit_treasury_balance(env: &Env, amount: i128) -> Result<(), ContractError> {
+    if amount <= 0 {
+        return Ok(());
+    }
+    let updated = read_treasury_balance(env)
+        .checked_add(amount)
+        .ok_or(ContractError::Overflow)?;
+    env.storage()
+        .persistent()
+        .set(&constants::storage::TREASURY_BALANCE, &updated);
+    Ok(())
+}
+
 fn assert_buy_price_slippage(price: i128, max_price: Option<i128>) -> Result<(), ContractError> {
     if let Some(max) = max_price {
         if price > max {
@@ -732,6 +757,13 @@ fn assert_sell_proceeds_slippage(
 }
 
 fn accrue_sell_protocol_fee(env: &Env, price: i128) -> Result<(), ContractError> {
+    if read_protocol_fee_config(env).is_none() {
+        return Ok(());
+    }
+
+    let (_, protocol_fee) = CreatorKeysContract::compute_fees_for_payment(env.clone(), price)?;
+    credit_treasury_balance(env, protocol_fee)?;
+
     if env
         .storage()
         .persistent()
@@ -740,12 +772,6 @@ fn accrue_sell_protocol_fee(env: &Env, price: i128) -> Result<(), ContractError>
     {
         return Ok(());
     }
-
-    if read_protocol_fee_config(env).is_none() {
-        return Ok(());
-    }
-
-    let (_, protocol_fee) = CreatorKeysContract::compute_fees_for_payment(env.clone(), price)?;
     credit_protocol_fee_recipient_balance(env, protocol_fee)
 }
 
@@ -1206,6 +1232,7 @@ impl CreatorKeysContract {
                     .ok_or(ContractError::Overflow)?;
             credit_creator_fee_recipient_balance(&env, &creator, creator_fee)?;
             credit_protocol_fee_recipient_balance(&env, protocol_fee)?;
+            credit_treasury_balance(&env, protocol_fee)?;
         }
 
         env.events().publish(
@@ -2382,6 +2409,65 @@ impl CreatorKeysContract {
         );
 
         Ok(())
+    }
+
+    /// Returns the current withdrawable treasury balance.
+    ///
+    /// The treasury balance accumulates from the protocol fee portion of every
+    /// `buy_key` and `sell_key` operation. Returns `0` before any fees have accrued.
+    /// This method does not mutate contract state.
+    pub fn get_treasury_balance(env: Env) -> i128 {
+        read_treasury_balance(&env)
+    }
+
+    /// Withdraws `amount` from the protocol treasury to `recipient`.
+    ///
+    /// Only callable by the protocol admin (set via [`set_protocol_admin`]).
+    /// Reverts with:
+    /// - [`ContractError::Unauthorized`] if the caller is not the protocol admin.
+    /// - [`ContractError::NotPositiveAmount`] if `amount` is zero or negative.
+    /// - [`ContractError::InsufficientTreasuryBalance`] if `amount` exceeds the
+    ///   current treasury balance.
+    ///
+    /// On success, decrements the treasury balance and emits a
+    /// [`events::TreasuryWithdrawalEvent`].
+    /// Partial withdrawals are supported; full withdrawal leaves the balance at zero.
+    pub fn withdraw_treasury(
+        env: Env,
+        admin: Address,
+        amount: i128,
+        recipient: Address,
+    ) -> Result<i128, ContractError> {
+        admin.require_auth();
+        assert_is_admin(&env, &admin)?;
+
+        if amount <= 0 {
+            return Err(ContractError::NotPositiveAmount);
+        }
+
+        let current = read_treasury_balance(&env);
+        if amount > current {
+            return Err(ContractError::InsufficientTreasuryBalance);
+        }
+
+        let remaining = current
+            .checked_sub(amount)
+            .ok_or(ContractError::Overflow)?;
+        env.storage()
+            .persistent()
+            .set(&constants::storage::TREASURY_BALANCE, &remaining);
+
+        env.events().publish(
+            events::treasury_withdrawal_event_topics(&recipient),
+            events::TreasuryWithdrawalEvent {
+                amount,
+                recipient,
+                remaining_balance: remaining,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(remaining)
     }
 }
 #[cfg(test)]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2450,9 +2450,7 @@ impl CreatorKeysContract {
             return Err(ContractError::InsufficientTreasuryBalance);
         }
 
-        let remaining = current
-            .checked_sub(amount)
-            .ok_or(ContractError::Overflow)?;
+        let remaining = current.checked_sub(amount).ok_or(ContractError::Overflow)?;
         env.storage()
             .persistent()
             .set(&constants::storage::TREASURY_BALANCE, &remaining);

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -1,0 +1,225 @@
+//! Integration tests for issue #517 — protocol treasury withdrawal function.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
+use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, IntoVal,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Sets a protocol admin in the contract and returns the admin address.
+fn set_admin(env: &Env, client: &CreatorKeysContractClient<'_>) -> Address {
+    let first_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    client.set_protocol_admin(&first_admin, &new_admin);
+    new_admin
+}
+
+/// Full setup: pricing + fees + admin. Returns (client, admin).
+fn setup_with_admin(
+    env: &Env,
+) -> (CreatorKeysContractClient<'_>, Address) {
+    let (client, _id) = register_creator_keys(env);
+    set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
+    let admin = set_admin(env, &client);
+    (client, admin)
+}
+
+/// Buy one key and return the protocol_fee that should have been credited.
+fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
+    let creator = Address::generate(env);
+    let buyer = Address::generate(env);
+    client.register_creator(&creator, &soroban_sdk::String::from_str(env, "alice"), &None, &None, &None);
+    client.buy_key(&creator, &buyer, &100i128, &None);
+    // 10% of 100 = 10 stroops
+    10i128
+}
+
+// ── get_treasury_balance ──────────────────────────────────────────────────────
+
+#[test]
+fn get_treasury_balance_returns_zero_before_any_trades() {
+    let env = test_env_with_auths();
+    let (client, _id) = register_creator_keys(&env);
+    assert_eq!(client.get_treasury_balance(), 0i128);
+}
+
+#[test]
+fn get_treasury_balance_increases_after_buy_key() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    let fee = buy_one_key(&env, &client);
+    assert_eq!(client.get_treasury_balance(), fee);
+}
+
+#[test]
+fn get_treasury_balance_accumulates_across_multiple_buys() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    let creator = Address::generate(&env);
+    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "bob"), &None, &None, &None);
+
+    let buyer1 = Address::generate(&env);
+    let buyer2 = Address::generate(&env);
+    client.buy_key(&creator, &buyer1, &100i128, &None);
+    client.buy_key(&creator, &buyer2, &100i128, &None);
+
+    // Each buy contributes 10 (10% of 100), two buys = 20
+    assert_eq!(client.get_treasury_balance(), 20i128);
+}
+
+// ── withdraw_treasury ─────────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_treasury_succeeds_for_admin_partial() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client); // treasury = 10
+
+    let recipient = Address::generate(&env);
+    let remaining = client.withdraw_treasury(&admin, &5i128, &recipient);
+    assert_eq!(remaining, 5i128);
+    assert_eq!(client.get_treasury_balance(), 5i128);
+}
+
+#[test]
+fn withdraw_treasury_succeeds_full_withdrawal_leaves_zero() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client); // treasury = 10
+
+    let recipient = Address::generate(&env);
+    let remaining = client.withdraw_treasury(&admin, &10i128, &recipient);
+    assert_eq!(remaining, 0i128);
+    assert_eq!(client.get_treasury_balance(), 0i128);
+}
+
+#[test]
+fn withdraw_treasury_emits_correct_event() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client); // treasury = 10
+
+    let recipient = Address::generate(&env);
+    client.withdraw_treasury(&admin, &7i128, &recipient);
+
+    let events = env.events().all();
+    // Find the treasury withdrawal event (last event emitted)
+    let last = events.last().unwrap();
+    let data: creator_keys::events::TreasuryWithdrawalEvent = last.2.into_val(&env);
+    assert_eq!(data.amount, 7i128);
+    assert_eq!(data.recipient, recipient);
+    assert_eq!(data.remaining_balance, 3i128);
+}
+
+#[test]
+fn withdraw_treasury_rejects_non_admin() {
+    let env = test_env_with_auths();
+    let (client, _admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client);
+
+    let impostor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&impostor, &5i128, &recipient);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn withdraw_treasury_rejects_zero_amount() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client);
+
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&admin, &0i128, &recipient);
+    assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
+}
+
+#[test]
+fn withdraw_treasury_rejects_negative_amount() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client);
+
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&admin, &-1i128, &recipient);
+    assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
+}
+
+#[test]
+fn withdraw_treasury_rejects_over_withdrawal() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    buy_one_key(&env, &client); // treasury = 10
+
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&admin, &11i128, &recipient);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientTreasuryBalance)));
+}
+
+#[test]
+fn withdraw_treasury_rejects_over_withdrawal_on_empty_balance() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    // No buys — treasury = 0
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw_treasury(&admin, &1i128, &recipient);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientTreasuryBalance)));
+}
+
+#[test]
+fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    let creator = Address::generate(&env);
+    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "charlie"), &None, &None, &None);
+
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &100i128, &None);
+    client.buy_key(&creator, &buyer, &100i128, &None);
+    client.buy_key(&creator, &buyer, &100i128, &None);
+    // treasury = 30
+
+    let recipient = Address::generate(&env);
+    client.withdraw_treasury(&admin, &10i128, &recipient); // remaining = 20
+    client.withdraw_treasury(&admin, &10i128, &recipient); // remaining = 10
+    client.withdraw_treasury(&admin, &10i128, &recipient); // remaining = 0
+
+    assert_eq!(client.get_treasury_balance(), 0i128);
+}
+
+#[test]
+fn treasury_balance_is_independent_of_protocol_fee_recipient_balance() {
+    // Both accumulators are credited independently; clearing one must not affect the other.
+    let env = test_env_with_auths();
+    let (client, admin) = setup_with_admin(&env);
+
+    let fee_recipient = Address::generate(&env);
+    client.set_protocol_fee_recipient(&admin, &fee_recipient);
+
+    buy_one_key(&env, &client); // treasury = 10, fee_recipient_balance = 10
+
+    // Withdraw all treasury
+    let recipient = Address::generate(&env);
+    client.withdraw_treasury(&admin, &10i128, &recipient);
+    assert_eq!(client.get_treasury_balance(), 0i128);
+
+    // Next buy credits treasury again, independently
+    buy_one_key(&env, &client);
+    assert_eq!(client.get_treasury_balance(), 10i128);
+}

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -3,7 +3,7 @@
 mod contract_test_env;
 
 use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
-use creator_keys::{ContractError, CreatorKeysContract, CreatorKeysContractClient};
+use creator_keys::{ContractError, CreatorKeysContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Events},
     Address, Env, IntoVal,
@@ -55,7 +55,7 @@ fn get_treasury_balance_returns_zero_before_any_trades() {
 #[test]
 fn get_treasury_balance_increases_after_buy_key() {
     let env = test_env_with_auths();
-    let (client, admin) = setup_with_admin(&env);
+    let (client, _admin) = setup_with_admin(&env);
 
     let fee = buy_one_key(&env, &client);
     assert_eq!(client.get_treasury_balance(), fee);
@@ -64,7 +64,7 @@ fn get_treasury_balance_increases_after_buy_key() {
 #[test]
 fn get_treasury_balance_accumulates_across_multiple_buys() {
     let env = test_env_with_auths();
-    let (client, admin) = setup_with_admin(&env);
+    let (client, _admin) = setup_with_admin(&env);
 
     let creator = Address::generate(&env);
     client.register_creator(

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -20,9 +20,7 @@ fn set_admin(env: &Env, client: &CreatorKeysContractClient<'_>) -> Address {
 }
 
 /// Full setup: pricing + fees + admin. Returns (client, admin).
-fn setup_with_admin(
-    env: &Env,
-) -> (CreatorKeysContractClient<'_>, Address) {
+fn setup_with_admin(env: &Env) -> (CreatorKeysContractClient<'_>, Address) {
     let (client, _id) = register_creator_keys(env);
     set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
     let admin = set_admin(env, &client);
@@ -33,7 +31,13 @@ fn setup_with_admin(
 fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
     let creator = Address::generate(env);
     let buyer = Address::generate(env);
-    client.register_creator(&creator, &soroban_sdk::String::from_str(env, "alice"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &soroban_sdk::String::from_str(env, "alice"),
+        &None,
+        &None,
+        &None,
+    );
     client.buy_key(&creator, &buyer, &100i128, &None);
     // 10% of 100 = 10 stroops
     10i128
@@ -63,7 +67,13 @@ fn get_treasury_balance_accumulates_across_multiple_buys() {
     let (client, admin) = setup_with_admin(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "bob"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &soroban_sdk::String::from_str(&env, "bob"),
+        &None,
+        &None,
+        &None,
+    );
 
     let buyer1 = Address::generate(&env);
     let buyer2 = Address::generate(&env);
@@ -187,7 +197,13 @@ fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
     let (client, admin) = setup_with_admin(&env);
 
     let creator = Address::generate(&env);
-    client.register_creator(&creator, &soroban_sdk::String::from_str(&env, "charlie"), &None, &None, &None);
+    client.register_creator(
+        &creator,
+        &soroban_sdk::String::from_str(&env, "charlie"),
+        &None,
+        &None,
+        &None,
+    );
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &100i128, &None);


### PR DESCRIPTION
Summary

Closes #517 

Protocol fees accumulate in the contract but there was no way to move them out. This PR adds a complete treasury accounting layer and an admin-gated withdrawal function so accumulated fees can be extracted to a multisig or treasury address on demand.

## Changes

### `ContractError`
- Append `InsufficientTreasuryBalance = 28` (ABI-safe: added at end per existing ordering convention)

### `DataKey`
- Append `TreasuryBalance` variant — tracks protocol treasury separately from key-payment escrow and dividend accumulators

### Fee accumulation (`buy_key` / `accrue_sell_protocol_fee`)
- Both paths call `credit_treasury_balance` with the protocol-fee amount alongside the existing `ProtocolFeeRecipientBalance` credit
- The two accumulators are independent: one is for the designated fee-recipient address; the other is the admin-controlled treasury pool

### `get_treasury_balance() -> i128`
- Pure view returning the current withdrawable balance; returns `0` before any fees accrue

### `withdraw_treasury(admin, amount, recipient) -> Result<i128, ContractError>`
- Requires `admin.require_auth()` + `assert_is_admin` guard → `Unauthorized` on non-admin call
- Rejects `amount <= 0` → `NotPositiveAmount`
- Rejects `amount > current_balance` → `InsufficientTreasuryBalance`
- Decrements treasury balance atomically
- Partial and full (leaves zero) withdrawals both supported
- Emits `TreasuryWithdrawalEvent { amount, recipient, remaining_balance, ledger }`

### `events.rs`
- `TREASURY_WITHDRAWAL_EVENT_NAME = "treas_out"`
- `TREASURY_WITHDRAWAL_DATA_FIELDS` for indexer stability
- `TreasuryWithdrawalEvent` contracttype struct (append-only field ordering)
- `treasury_withdrawal_event_topics(recipient)` helper

## Test plan

`tests/treasury_withdrawal.rs` — 13 integration tests, all passing:

- [x] `get_treasury_balance` returns zero before any trades
- [x] `get_treasury_balance` increases after `buy_key`
- [x] `get_treasury_balance` accumulates across multiple buys
- [x] Partial withdrawal succeeds and decrements correctly
- [x] Full withdrawal leaves balance at zero
- [x] `TreasuryWithdrawalEvent` fields are correct
- [x] Non-admin call reverts with `Unauthorized`
- [x] Zero amount reverts with `NotPositiveAmount`
- [x] Negative amount reverts with `NotPositiveAmount`
- [x] Over-withdrawal reverts with `InsufficientTreasuryBalance`
- [x] Over-withdrawal on empty balance reverts with `InsufficientTreasuryBalance`
- [x] Multiple sequential partial withdrawals track balance correctly
- [x] Treasury balance is independent of `ProtocolFeeRecipientBalance`

All 55 existing unit tests and all prior integration tests continue to pass.

