### PR TITLE
Add whitelist early access window so creators can reward their existing community before public launch

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub mod quote_view_errors;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
 
 pub mod events;
 
@@ -74,6 +74,8 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
+    WhitelistOnly = 28,
+    WhitelistTooLarge = 29,
 }
 
 pub mod fee {
@@ -315,6 +317,10 @@ pub mod constants {
         pub fn max_supply(creator: &Address) -> DataKey {
             DataKey::MaxSupply(creator.clone())
         }
+
+        pub fn whitelist(creator: &Address) -> DataKey {
+            DataKey::Whitelist(creator.clone())
+        }
     }
 
     fn creator_key(creator: &Address) -> DataKey {
@@ -454,6 +460,7 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
+pub const MAX_WHITELIST_SIZE: u32 = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -488,6 +495,24 @@ pub enum DataKey {
     MaxSupply(Address),
     CurveSlope,
     CurvePreset(Address),
+    Whitelist(Address),
+}
+
+/// Immutable early-access whitelist configuration set at creator registration.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistConfig {
+    pub addresses: Vec<Address>,
+    pub window_ledgers: u32,
+}
+
+/// Read-only whitelist window status for a creator.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistStatus {
+    pub active: bool,
+    pub expires_at_ledger: u32,
+    pub remaining_ledgers: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -953,6 +978,48 @@ fn compute_claimable_dividend(env: &Env, creator: &Address, holder: &Address) ->
 /// This function extends the TTL of the creator's primary storage entries
 /// to prevent active creator state from expiring. Called after successful
 /// buy and sell operations.
+fn read_whitelist_config(env: &Env, creator: &Address) -> Option<WhitelistConfig> {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::whitelist(creator))
+}
+
+fn whitelist_expires_at(profile: &CreatorProfile, config: &WhitelistConfig) -> Option<u32> {
+    profile.registered_at.checked_add(config.window_ledgers)
+}
+
+fn is_whitelist_window_active(
+    env: &Env,
+    profile: &CreatorProfile,
+    config: &WhitelistConfig,
+) -> bool {
+    if config.window_ledgers == 0 {
+        return false;
+    }
+    whitelist_expires_at(profile, config)
+        .map(|expires_at| env.ledger().sequence() < expires_at)
+        .unwrap_or(false)
+}
+
+fn assert_whitelist_buy_allowed(
+    env: &Env,
+    profile: &CreatorProfile,
+    buyer: &Address,
+) -> Result<(), ContractError> {
+    let Some(config) = read_whitelist_config(env, &profile.creator) else {
+        return Ok(());
+    };
+    if !is_whitelist_window_active(env, profile, &config) {
+        return Ok(());
+    }
+    for address in config.addresses.iter() {
+        if address == *buyer {
+            return Ok(());
+        }
+    }
+    Err(ContractError::WhitelistOnly)
+}
+
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -991,6 +1058,13 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
             .extend_ttl(&max_supply_key, threshold, extend_to);
     }
 
+    let whitelist_key = constants::storage::whitelist(creator);
+    if env.storage().persistent().has(&whitelist_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&whitelist_key, threshold, extend_to);
+    }
+
     let curve_preset_key = constants::storage::curve_preset(creator);
     if env.storage().persistent().has(&curve_preset_key) {
         env.storage()
@@ -1019,6 +1093,7 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
+    /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
     pub fn register_creator(
         env: Env,
         creator: Address,
@@ -1026,6 +1101,7 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
+        whitelist_window: Option<WhitelistConfig>,
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1085,6 +1161,15 @@ impl CreatorKeysContract {
                 .set(&constants::storage::max_supply(&creator), &cap);
         }
 
+        // Handle immutable whitelist window
+        let whitelist_key = constants::storage::whitelist(&creator);
+        if let Some(config) = whitelist_window {
+            if config.addresses.len() > MAX_WHITELIST_SIZE {
+                return Err(ContractError::WhitelistTooLarge);
+            }
+            env.storage().persistent().set(&whitelist_key, &config);
+        }
+
         // Handle curve preset
         let preset = curve_preset.unwrap_or(CurvePreset::Linear);
         let preset_key = constants::storage::curve_preset(&creator);
@@ -1115,6 +1200,11 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .extend_ttl(&preset_key, current_ledger, extend_to);
+        if env.storage().persistent().has(&whitelist_key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&whitelist_key, current_ledger, extend_to);
+        }
 
         env.events().publish(
             events::register_event_topics(&profile.creator),
@@ -1154,6 +1244,7 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
+        assert_whitelist_buy_allowed(&env, &profile, &buyer)?;
         assert_buy_price_slippage(price, max_price)?;
 
         if payment < price {
@@ -1438,6 +1529,35 @@ impl CreatorKeysContract {
 
     pub fn get_creator(env: Env, creator: Address) -> Result<CreatorProfile, ContractError> {
         read_registered_creator_profile(&env, &creator)
+    }
+
+    /// Read-only view: returns whitelist window status for a registered creator.
+    pub fn get_whitelist_status(
+        env: Env,
+        creator: Address,
+    ) -> Result<WhitelistStatus, ContractError> {
+        let profile = read_registered_creator_profile(&env, &creator)?;
+        let Some(config) = read_whitelist_config(&env, &creator) else {
+            return Ok(WhitelistStatus {
+                active: false,
+                expires_at_ledger: profile.registered_at,
+                remaining_ledgers: 0,
+            });
+        };
+        let expires_at_ledger =
+            whitelist_expires_at(&profile, &config).ok_or(ContractError::Overflow)?;
+        let current = env.ledger().sequence();
+        let active = config.window_ledgers > 0 && current < expires_at_ledger;
+        let remaining_ledgers = if active {
+            expires_at_ledger - current
+        } else {
+            0
+        };
+        Ok(WhitelistStatus {
+            active,
+            expires_at_ledger,
+            remaining_ledgers,
+        })
     }
 
     /// Read-only view: returns stable creator details.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub mod quote_view_errors;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
 
 pub mod events;
 
@@ -77,6 +77,8 @@ pub enum ContractError {
     InsufficientTreasuryBalance = 28,
     BatchClaimExceedsLimit = 29,
     InvalidCoCreatorShare = 30,
+    WhitelistOnly = 31,
+    WhitelistTooLarge = 32,
 }
 
 pub mod fee {
@@ -313,6 +315,10 @@ pub mod constants {
             DataKey::CoCreatorFeeBalance(creator.clone(), co_creator.clone())
         }
 
+        pub fn whitelist(creator: &Address) -> DataKey {
+            DataKey::Whitelist(creator.clone())
+        }
+
         pub fn creator(creator: &Address) -> DataKey {
             creator_key(creator)
         }
@@ -481,6 +487,7 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
+pub const MAX_WHITELIST_SIZE: u32 = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -518,6 +525,7 @@ pub enum DataKey {
     TreasuryBalance,
     CoCreator(Address),
     CoCreatorFeeBalance(Address, Address),
+    Whitelist(Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -543,6 +551,35 @@ pub struct CoCreatorConfig {
     pub share_bps: u32,
 }
 
+/// Required creator identity fields for registration.
+///
+/// Grouping these fields keeps the public contract entrypoint under Clippy's
+/// argument-count threshold without changing validation or storage behavior for
+/// any registration option.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RegisterCreatorParams {
+    pub creator: Address,
+    pub handle: String,
+}
+
+/// Optional whitelist window configured at creator registration.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WhitelistConfig {
+    pub addresses: Vec<Address>,
+    pub window_ledgers: u32,
+}
+
+/// Read-only status for a creator's whitelist window.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct WhitelistStatus {
+    pub active: bool,
+    pub expires_at_ledger: u32,
+    pub remaining_ledgers: u32,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
 pub struct CreatorProfile {
@@ -564,6 +601,57 @@ pub struct CreatorProfile {
 pub struct ClaimResult {
     pub creator: Address,
     pub amount_claimed: i128,
+}
+
+fn validate_whitelist_config(config: &WhitelistConfig) -> Result<(), ContractError> {
+    if config.addresses.len() > MAX_WHITELIST_SIZE {
+        return Err(ContractError::WhitelistTooLarge);
+    }
+    Ok(())
+}
+
+fn read_whitelist_config(env: &Env, creator: &Address) -> Option<WhitelistConfig> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, WhitelistConfig>(&constants::storage::whitelist(creator))
+}
+
+fn whitelist_status(env: &Env, profile: &CreatorProfile) -> WhitelistStatus {
+    let Some(config) = read_whitelist_config(env, &profile.creator) else {
+        return WhitelistStatus {
+            active: false,
+            expires_at_ledger: 0,
+            remaining_ledgers: 0,
+        };
+    };
+    let expires_at_ledger = profile.registered_at.saturating_add(config.window_ledgers);
+    let current_ledger = env.ledger().sequence();
+    let remaining_ledgers = expires_at_ledger.saturating_sub(current_ledger);
+    WhitelistStatus {
+        active: remaining_ledgers > 0,
+        expires_at_ledger,
+        remaining_ledgers,
+    }
+}
+
+fn assert_whitelist_allows_buy(
+    env: &Env,
+    profile: &CreatorProfile,
+    buyer: &Address,
+) -> Result<(), ContractError> {
+    let status = whitelist_status(env, profile);
+    if !status.active {
+        return Ok(());
+    }
+    let Some(config) = read_whitelist_config(env, &profile.creator) else {
+        return Ok(());
+    };
+    for address in config.addresses.iter() {
+        if address == *buyer {
+            return Ok(());
+        }
+    }
+    Err(ContractError::WhitelistOnly)
 }
 
 /// Reads a creator profile from storage, returning `None` for unregistered creators.
@@ -1183,19 +1271,24 @@ impl CreatorKeysContract {
     ///   must be in the inclusive range `1..=9999`.
     pub fn register_creator(
         env: Env,
-        creator: Address,
-        handle: String,
+        params: RegisterCreatorParams,
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
         co_creator: Option<CoCreatorConfig>,
+        whitelist: Option<WhitelistConfig>,
     ) -> Result<(), ContractError> {
+        let RegisterCreatorParams { creator, handle } = params;
+
         creator.require_auth();
         assert_not_paused(&env)?;
 
         validate_creator_handle(&handle)?;
         if let Some(config) = co_creator.as_ref() {
             validate_co_creator_config(&env, config)?;
+        }
+        if let Some(config) = whitelist.as_ref() {
+            validate_whitelist_config(config)?;
         }
 
         let key = constants::storage::creator(&creator);
@@ -1262,6 +1355,12 @@ impl CreatorKeysContract {
                 .set(&constants::storage::co_creator(&creator), &config);
         }
 
+        if let Some(config) = whitelist {
+            env.storage()
+                .persistent()
+                .set(&constants::storage::whitelist(&creator), &config);
+        }
+
         let profile = CreatorProfile {
             creator: creator.clone(),
             handle,
@@ -1292,6 +1391,12 @@ impl CreatorKeysContract {
             env.storage()
                 .persistent()
                 .extend_ttl(&co_creator_key, current_ledger, extend_to);
+        }
+        let whitelist_key = constants::storage::whitelist(&creator);
+        if env.storage().persistent().has(&whitelist_key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&whitelist_key, current_ledger, extend_to);
         }
 
         env.events().publish(
@@ -1330,6 +1435,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::KeyPriceNotSet)?;
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+        assert_whitelist_allows_buy(&env, &profile, &buyer)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
         assert_buy_price_slippage(price, max_price)?;
@@ -1761,10 +1867,21 @@ impl CreatorKeysContract {
             .unwrap_or(0)
     }
 
-    /// Read-only view: returns whether a creator is registered in the contract.
+    /// Read-only view: returns a creator's whitelist window status.
     ///
-    /// Returns `true` if a [`CreatorProfile`] exists for the given address,
-    /// `false` otherwise. Does not mutate state.
+    /// Returns inactive defaults for unregistered creators or creators without
+    /// a configured whitelist. Does not mutate state.
+    pub fn get_whitelist_status(env: Env, creator: Address) -> WhitelistStatus {
+        let Some(profile) = read_creator_profile(&env, &creator) else {
+            return WhitelistStatus {
+                active: false,
+                expires_at_ledger: 0,
+                remaining_ledgers: 0,
+            };
+        };
+        whitelist_status(&env, &profile)
+    }
+
     pub fn is_creator_registered(env: Env, creator: Address) -> bool {
         read_creator_profile(&env, &creator).is_some()
     }

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -76,8 +76,8 @@ pub enum ContractError {
     ZeroTransferAmount = 27,
     WhitelistOnly = 28,
     WhitelistTooLarge = 29,
-    InsufficientTreasuryBalance = 28,
-    BatchClaimExceedsLimit = 29,
+    InsufficientTreasuryBalance = 30,
+    BatchClaimExceedsLimit = 31,
 }
 
 pub mod fee {
@@ -499,6 +499,7 @@ pub enum DataKey {
     CurveSlope,
     CurvePreset(Address),
     Whitelist(Address),
+    TreasuryBalance,
 }
 
 /// Immutable early-access whitelist configuration set at creator registration.
@@ -516,7 +517,6 @@ pub struct WhitelistStatus {
     pub active: bool,
     pub expires_at_ledger: u32,
     pub remaining_ledgers: u32,
-    TreasuryBalance,
 }
 
 /// Time-locked key allocation for creator self-vesting.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1054,6 +1054,27 @@ fn assert_whitelist_buy_allowed(
     Err(ContractError::WhitelistOnly)
 }
 
+fn extend_creator_registration_ttl(
+    env: &Env,
+    creator_key: &DataKey,
+    preset_key: &DataKey,
+    whitelist_key: &DataKey,
+    current_ledger: u32,
+) {
+    let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
+    env.storage()
+        .persistent()
+        .extend_ttl(creator_key, current_ledger, extend_to);
+    env.storage()
+        .persistent()
+        .extend_ttl(preset_key, current_ledger, extend_to);
+    if env.storage().persistent().has(whitelist_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(whitelist_key, current_ledger, extend_to);
+    }
+}
+
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -1225,23 +1246,8 @@ impl CreatorKeysContract {
 
         // Persist profile before event publication so indexers reading contract state
         // after this tx observe the same registration payload that was emitted.
-        // Keep the registration TTL and event emission in this block so merge conflict
-        // resolutions do not accidentally splice registration state writes into trading flows
-        // or leave the `register_creator` implementation with an unclosed delimiter.
         env.storage().persistent().set(&key, &profile);
-        // Set initial TTL for creator storage
-        let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, current_ledger, extend_to);
-        env.storage()
-            .persistent()
-            .extend_ttl(&preset_key, current_ledger, extend_to);
-        if env.storage().persistent().has(&whitelist_key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&whitelist_key, current_ledger, extend_to);
-        }
+        extend_creator_registration_ttl(&env, &key, &preset_key, &whitelist_key, current_ledger);
 
         env.events().publish(
             events::register_event_topics(&profile.creator),

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1225,6 +1225,8 @@ impl CreatorKeysContract {
 
         // Persist profile before event publication so indexers reading contract state
         // after this tx observe the same registration payload that was emitted.
+        // Keep the registration TTL and event emission in this block so merge conflict
+        // resolutions do not accidentally splice registration state writes into trading flows.
         env.storage().persistent().set(&key, &profile);
         // Set initial TTL for creator storage
         let extend_to = current_ledger + CREATOR_TTL_LEDGERS;

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1054,6 +1054,32 @@ fn assert_whitelist_buy_allowed(
     Err(ContractError::WhitelistOnly)
 }
 
+/// Extends all storage entries written during creator registration in one place.
+///
+/// Keeping this outside `register_creator` avoids another nested storage block in
+/// the registration method, which makes delimiter issues easier to spot during
+/// merge conflict resolution and keeps `cargo fmt --all -- --check` reliable.
+fn extend_creator_registration_ttl(
+    env: &Env,
+    creator_key: &DataKey,
+    preset_key: &DataKey,
+    whitelist_key: &DataKey,
+    current_ledger: u32,
+) {
+    let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
+    env.storage()
+        .persistent()
+        .extend_ttl(creator_key, current_ledger, extend_to);
+    env.storage()
+        .persistent()
+        .extend_ttl(preset_key, current_ledger, extend_to);
+    if env.storage().persistent().has(whitelist_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(whitelist_key, current_ledger, extend_to);
+    }
+}
+
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -1225,23 +1251,8 @@ impl CreatorKeysContract {
 
         // Persist profile before event publication so indexers reading contract state
         // after this tx observe the same registration payload that was emitted.
-        // Keep the registration TTL and event emission in this block so merge conflict
-        // resolutions do not accidentally splice registration state writes into trading flows
-        // or leave the `register_creator` implementation with an unclosed delimiter.
         env.storage().persistent().set(&key, &profile);
-        // Set initial TTL for creator storage
-        let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, current_ledger, extend_to);
-        env.storage()
-            .persistent()
-            .extend_ttl(&preset_key, current_ledger, extend_to);
-        if env.storage().persistent().has(&whitelist_key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&whitelist_key, current_ledger, extend_to);
-        }
+        extend_creator_registration_ttl(&env, &key, &preset_key, &whitelist_key, current_ledger);
 
         env.events().publish(
             events::register_event_topics(&profile.creator),

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1226,7 +1226,8 @@ impl CreatorKeysContract {
         // Persist profile before event publication so indexers reading contract state
         // after this tx observe the same registration payload that was emitted.
         // Keep the registration TTL and event emission in this block so merge conflict
-        // resolutions do not accidentally splice registration state writes into trading flows.
+        // resolutions do not accidentally splice registration state writes into trading flows
+        // or leave the `register_creator` implementation with an unclosed delimiter.
         env.storage().persistent().set(&key, &profile);
         // Set initial TTL for creator storage
         let extend_to = current_ledger + CREATOR_TTL_LEDGERS;

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub mod quote_view_errors;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
 
 pub mod events;
 
@@ -74,14 +74,9 @@ pub enum ContractError {
     InsufficientSupply = 25,
     SelfTransfer = 26,
     ZeroTransferAmount = 27,
-    WhitelistOnly = 28,
-    WhitelistTooLarge = 29,
-    InsufficientTreasuryBalance = 30,
-    BatchClaimExceedsLimit = 31,
     InsufficientTreasuryBalance = 28,
     BatchClaimExceedsLimit = 29,
     InvalidCoCreatorShare = 30,
-
 }
 
 pub mod fee {
@@ -345,10 +340,6 @@ pub mod constants {
         pub fn max_supply(creator: &Address) -> DataKey {
             DataKey::MaxSupply(creator.clone())
         }
-
-        pub fn whitelist(creator: &Address) -> DataKey {
-            DataKey::Whitelist(creator.clone())
-        }
     }
 
     fn creator_key(creator: &Address) -> DataKey {
@@ -490,7 +481,6 @@ pub const KEY_DECIMALS: u32 = 7;
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
-pub const MAX_WHITELIST_SIZE: u32 = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -525,27 +515,9 @@ pub enum DataKey {
     MaxSupply(Address),
     CurveSlope,
     CurvePreset(Address),
-    Whitelist(Address),
     TreasuryBalance,
     CoCreator(Address),
     CoCreatorFeeBalance(Address, Address),
-}
-
-/// Immutable early-access whitelist configuration set at creator registration.
-#[derive(Clone, Debug, PartialEq)]
-#[contracttype]
-pub struct WhitelistConfig {
-    pub addresses: Vec<Address>,
-    pub window_ledgers: u32,
-}
-
-/// Read-only whitelist window status for a creator.
-#[derive(Clone, Debug, PartialEq)]
-#[contracttype]
-pub struct WhitelistStatus {
-    pub active: bool,
-    pub expires_at_ledger: u32,
-    pub remaining_ledgers: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -1122,69 +1094,6 @@ fn compute_claimable_dividend(env: &Env, creator: &Address, holder: &Address) ->
 /// This function extends the TTL of the creator's primary storage entries
 /// to prevent active creator state from expiring. Called after successful
 /// buy and sell operations.
-fn read_whitelist_config(env: &Env, creator: &Address) -> Option<WhitelistConfig> {
-    env.storage()
-        .persistent()
-        .get(&constants::storage::whitelist(creator))
-}
-
-fn whitelist_expires_at(profile: &CreatorProfile, config: &WhitelistConfig) -> Option<u32> {
-    profile.registered_at.checked_add(config.window_ledgers)
-}
-
-fn is_whitelist_window_active(
-    env: &Env,
-    profile: &CreatorProfile,
-    config: &WhitelistConfig,
-) -> bool {
-    if config.window_ledgers == 0 {
-        return false;
-    }
-    whitelist_expires_at(profile, config)
-        .map(|expires_at| env.ledger().sequence() < expires_at)
-        .unwrap_or(false)
-}
-
-fn assert_whitelist_buy_allowed(
-    env: &Env,
-    profile: &CreatorProfile,
-    buyer: &Address,
-) -> Result<(), ContractError> {
-    let Some(config) = read_whitelist_config(env, &profile.creator) else {
-        return Ok(());
-    };
-    if !is_whitelist_window_active(env, profile, &config) {
-        return Ok(());
-    }
-    for address in config.addresses.iter() {
-        if address == *buyer {
-            return Ok(());
-        }
-    }
-    Err(ContractError::WhitelistOnly)
-}
-
-fn extend_creator_registration_ttl(
-    env: &Env,
-    creator_key: &DataKey,
-    preset_key: &DataKey,
-    whitelist_key: &DataKey,
-    current_ledger: u32,
-) {
-    let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
-    env.storage()
-        .persistent()
-        .extend_ttl(creator_key, current_ledger, extend_to);
-    env.storage()
-        .persistent()
-        .extend_ttl(preset_key, current_ledger, extend_to);
-    if env.storage().persistent().has(whitelist_key) {
-        env.storage()
-            .persistent()
-            .extend_ttl(whitelist_key, current_ledger, extend_to);
-    }
-}
-
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -1221,13 +1130,6 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
         env.storage()
             .persistent()
             .extend_ttl(&max_supply_key, threshold, extend_to);
-    }
-
-    let whitelist_key = constants::storage::whitelist(creator);
-    if env.storage().persistent().has(&whitelist_key) {
-        env.storage()
-            .persistent()
-            .extend_ttl(&whitelist_key, threshold, extend_to);
     }
 
     let curve_preset_key = constants::storage::curve_preset(creator);
@@ -1277,7 +1179,6 @@ impl CreatorKeysContract {
     /// - `locked_allocation`: optional time-locked key allocation for creator self-vesting.
     ///   If provided, `unlock_ledger` must be strictly greater than current ledger.
     /// - `max_supply`: optional maximum supply cap. If provided, must be greater than zero.
-    /// - `whitelist_window`: optional immutable early-access address list and ledger duration.
     /// - `co_creator`: optional immutable collaborator split. If provided, `share_bps`
     ///   must be in the inclusive range `1..=9999`.
     pub fn register_creator(
@@ -1287,9 +1188,7 @@ impl CreatorKeysContract {
         locked_allocation: Option<LockedAllocation>,
         max_supply: Option<u32>,
         curve_preset: Option<CurvePreset>,
-        whitelist_window: Option<WhitelistConfig>,
         co_creator: Option<CoCreatorConfig>,
-
     ) -> Result<(), ContractError> {
         creator.require_auth();
         assert_not_paused(&env)?;
@@ -1352,15 +1251,6 @@ impl CreatorKeysContract {
                 .set(&constants::storage::max_supply(&creator), &cap);
         }
 
-        // Handle immutable whitelist window
-        let whitelist_key = constants::storage::whitelist(&creator);
-        if let Some(config) = whitelist_window {
-            if config.addresses.len() > MAX_WHITELIST_SIZE {
-                return Err(ContractError::WhitelistTooLarge);
-            }
-            env.storage().persistent().set(&whitelist_key, &config);
-        }
-
         // Handle curve preset
         let preset = curve_preset.unwrap_or(CurvePreset::Linear);
         let preset_key = constants::storage::curve_preset(&creator);
@@ -1389,8 +1279,6 @@ impl CreatorKeysContract {
         // Persist profile before event publication so indexers reading contract state
         // after this tx observe the same registration payload that was emitted.
         env.storage().persistent().set(&key, &profile);
-        extend_creator_registration_ttl(&env, &key, &preset_key, &whitelist_key, current_ledger);
-
         // Set initial TTL for creator storage
         let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
         env.storage()
@@ -1405,8 +1293,6 @@ impl CreatorKeysContract {
                 .persistent()
                 .extend_ttl(&co_creator_key, current_ledger, extend_to);
         }
-
-
 
         env.events().publish(
             events::register_event_topics(&profile.creator),
@@ -1446,7 +1332,6 @@ impl CreatorKeysContract {
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         let price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
-        assert_whitelist_buy_allowed(&env, &profile, &buyer)?;
         assert_buy_price_slippage(price, max_price)?;
 
         if payment < price {
@@ -1732,35 +1617,6 @@ impl CreatorKeysContract {
 
     pub fn get_creator(env: Env, creator: Address) -> Result<CreatorProfile, ContractError> {
         read_registered_creator_profile(&env, &creator)
-    }
-
-    /// Read-only view: returns whitelist window status for a registered creator.
-    pub fn get_whitelist_status(
-        env: Env,
-        creator: Address,
-    ) -> Result<WhitelistStatus, ContractError> {
-        let profile = read_registered_creator_profile(&env, &creator)?;
-        let Some(config) = read_whitelist_config(&env, &creator) else {
-            return Ok(WhitelistStatus {
-                active: false,
-                expires_at_ledger: profile.registered_at,
-                remaining_ledgers: 0,
-            });
-        };
-        let expires_at_ledger =
-            whitelist_expires_at(&profile, &config).ok_or(ContractError::Overflow)?;
-        let current = env.ledger().sequence();
-        let active = config.window_ledgers > 0 && current < expires_at_ledger;
-        let remaining_ledgers = if active {
-            expires_at_ledger - current
-        } else {
-            0
-        };
-        Ok(WhitelistStatus {
-            active,
-            expires_at_ledger,
-            remaining_ledgers,
-        })
     }
 
     /// Read-only view: returns stable creator details.

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -19,7 +19,7 @@ fn test_register_creator_with_locked_allocation() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     let stored = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(stored.amount, 100);
@@ -47,7 +47,7 @@ fn test_register_creator_locked_allocation_reverts_past_ledger() {
         claimed: false,
     };
 
-    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AllocationLocked)));
 }
 
@@ -68,7 +68,7 @@ fn test_claim_locked_allocation_success() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -100,7 +100,7 @@ fn test_claim_locked_allocation_reverts_early() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Try to claim before unlock
     let result = client.try_claim_locked_allocation(&creator);
@@ -124,7 +124,7 @@ fn test_claim_locked_allocation_reverts_double_claim() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -162,7 +162,7 @@ fn test_get_locked_allocation_returns_allocation_when_set() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None);
+    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
 
     let result = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(result.amount, 100);
@@ -184,7 +184,7 @@ fn test_transfer_keys_basic() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
@@ -208,7 +208,7 @@ fn test_transfer_keys_sender_zeroed_out() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -230,7 +230,7 @@ fn test_transfer_keys_new_recipient() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let supply_before = client.get_total_key_supply(&creator);
@@ -252,7 +252,7 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -271,7 +271,7 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -290,7 +290,7 @@ fn test_transfer_keys_insufficient_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None);
+    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -308,7 +308,7 @@ fn test_register_creator_with_max_supply() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(1000), &None);
+    client.register_creator(&creator, &handle, &None, &Some(1000), &None, &None);
 
     let cap = client.get_max_supply(&creator).unwrap();
     assert_eq!(cap, 1000);
@@ -323,7 +323,7 @@ fn test_register_creator_max_supply_zero_reverts() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None, &None);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
 }
 
@@ -338,7 +338,7 @@ fn test_buy_exceeds_max_supply_reverts() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(5), &None);
+    client.register_creator(&creator, &handle, &None, &Some(5), &None, &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -363,7 +363,7 @@ fn test_buy_within_max_supply_succeeds() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(10), &None);
+    client.register_creator(&creator, &handle, &None, &Some(10), &None, &None);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -385,7 +385,7 @@ fn test_get_max_supply_returns_none_for_uncapped() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let cap = client.get_max_supply(&creator);
     assert_eq!(cap, None);
@@ -484,7 +484,7 @@ fn test_update_creator_fee_recipient_success() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.update_creator_fee_recipient(&creator, &new_recipient);
 
     let profile = client.get_creator(&creator);
@@ -502,7 +502,7 @@ fn test_update_creator_fee_recipient_unauthorized_reverts() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let result = client.try_update_creator_fee_recipient(&unauthorized, &new_recipient);
     // This should fail because unauthorized is not the current fee recipient
@@ -552,7 +552,7 @@ fn test_sell_key_accepts_exact_min_proceeds_boundary() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     client.buy_key(&creator, &seller, &100, &None);
     client.buy_key(&creator, &seller, &100, &None);
@@ -580,7 +580,7 @@ fn test_sell_extends_creator_ttl_after_successful_sell() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.buy_key(&creator, &seller, &100, &None);
 
     let creator_key = constants::storage::creator(&creator);
@@ -619,7 +619,7 @@ fn test_failed_sell_does_not_extend_creator_ttl() {
     let handle = String::from_str(&env, "alice");
 
     client.set_key_price(&admin, &100);
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let creator_key = constants::storage::creator(&creator);
     let mut ledger_info = env.ledger().get();
@@ -651,7 +651,7 @@ fn test_register_creator_without_optional_params_succeeds() {
     let handle = String::from_str(&env, "alice");
 
     // Registration with None for both optional params should work (backwards compatible)
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 0);
@@ -777,7 +777,7 @@ fn test_get_fee_config_persists_across_repeated_reads() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Repeatedly read the fee config and verify stability
     for _ in 0..5 {
@@ -803,7 +803,7 @@ fn test_register_creator() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
@@ -823,7 +823,7 @@ fn test_register_creator_persists_registration_metadata() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.creator, creator);
@@ -843,10 +843,10 @@ fn test_duplicate_registration_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Second registration should fail with AlreadyRegistered error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
     assert_no_events(&env);
 }
@@ -881,7 +881,7 @@ fn test_buy_key_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let supply = client.buy_key(&creator, &buyer, &100, &None);
@@ -904,7 +904,7 @@ fn test_get_creator_holder_count_counts_unique_holders() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let holder_one = Address::generate(&env);
     let holder_two = Address::generate(&env);
@@ -945,7 +945,7 @@ fn test_buy_key_insufficient_payment() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99, &None);
@@ -1016,7 +1016,7 @@ fn test_get_key_balance_returns_zero_for_unregistered_wallet() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let unregistered_wallet = Address::generate(&env);
 
@@ -1115,7 +1115,7 @@ fn test_get_buy_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 1000);
@@ -1137,7 +1137,7 @@ fn test_get_sell_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1000, &None);
@@ -1162,7 +1162,7 @@ fn test_get_sell_quote_fails_if_insufficient_balance() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let holder = Address::generate(&env); // Zero balance
     let result = client.try_get_sell_quote(&creator, &holder);
@@ -1197,7 +1197,7 @@ fn test_get_quote_fails_if_fee_not_set() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let result = client.try_get_buy_quote(&creator);
     assert_eq!(result, Err(Ok(ContractError::FeeConfigNotSet)));
@@ -1227,7 +1227,7 @@ fn test_get_creator_fee_recipient_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let recipient = client.get_creator_fee_recipient(&creator);
     assert_eq!(recipient, creator);
@@ -1259,7 +1259,7 @@ fn test_quote_overflow_guards() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Buy quote: price + fees (will overflow)
     let result = client.try_get_buy_quote(&creator);
@@ -1336,7 +1336,7 @@ fn test_register_event_field_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let all_events = env.events().all();
     assert_eq!(
@@ -1398,7 +1398,7 @@ fn test_buy_event_topic_and_data_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "bob");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &500, &None);
@@ -1464,7 +1464,7 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "carol");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let all_events = env.events().all();
     let (_contract_id, _topics, data): (

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -19,7 +19,17 @@ fn test_register_creator_with_locked_allocation() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let stored = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(stored.amount, 100);
@@ -47,7 +57,17 @@ fn test_register_creator_locked_allocation_reverts_past_ledger() {
         claimed: false,
     };
 
-    let result = client.try_register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    let result = client.try_register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
     assert_eq!(result, Err(Ok(ContractError::AllocationLocked)));
 }
 
@@ -68,7 +88,17 @@ fn test_claim_locked_allocation_success() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -100,7 +130,17 @@ fn test_claim_locked_allocation_reverts_early() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Try to claim before unlock
     let result = client.try_claim_locked_allocation(&creator);
@@ -124,7 +164,17 @@ fn test_claim_locked_allocation_reverts_double_claim() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Advance ledger past unlock
     ledger_info.sequence_number = 250;
@@ -162,7 +212,17 @@ fn test_get_locked_allocation_returns_allocation_when_set() {
         claimed: false,
     };
 
-    client.register_creator(&creator, &handle, &Some(locked), &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &Some(locked),
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let result = client.get_locked_allocation(&creator).unwrap();
     assert_eq!(result.amount, 100);
@@ -184,7 +244,17 @@ fn test_transfer_keys_basic() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
     client.buy_key(&creator, &sender, &100i128, &None);
@@ -208,7 +278,17 @@ fn test_transfer_keys_sender_zeroed_out() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     client.transfer_keys(&creator, &sender, &recipient, &1);
@@ -230,7 +310,17 @@ fn test_transfer_keys_new_recipient() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let supply_before = client.get_total_key_supply(&creator);
@@ -252,7 +342,17 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &sender, &1);
@@ -271,7 +371,17 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &0);
@@ -290,7 +400,17 @@ fn test_transfer_keys_insufficient_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.set_key_price(&admin, &100i128);
-    client.register_creator(&creator, &String::from_str(&env, "alice"), &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: String::from_str(&env, "alice"),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &sender, &100i128, &None);
 
     let result = client.try_transfer_keys(&creator, &sender, &recipient, &2);
@@ -308,7 +428,17 @@ fn test_register_creator_with_max_supply() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(1000), &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &Some(1000),
+    &None,
+    &None,
+    &None
+);
 
     let cap = client.get_max_supply(&creator).unwrap();
     assert_eq!(cap, 1000);
@@ -323,7 +453,17 @@ fn test_register_creator_max_supply_zero_reverts() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    let result = client.try_register_creator(&creator, &handle, &None, &Some(0), &None, &None);
+    let result = client.try_register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &Some(0),
+    &None,
+    &None,
+    &None
+);
     assert_eq!(result, Err(Ok(ContractError::NotPositiveAmount)));
 }
 
@@ -338,7 +478,17 @@ fn test_buy_exceeds_max_supply_reverts() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(5), &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &Some(5),
+    &None,
+    &None,
+    &None
+);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -363,7 +513,17 @@ fn test_buy_within_max_supply_succeeds() {
     let admin = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &Some(10), &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &Some(10),
+    &None,
+    &None,
+    &None
+);
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -385,7 +545,17 @@ fn test_get_max_supply_returns_none_for_uncapped() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let cap = client.get_max_supply(&creator);
     assert_eq!(cap, None);
@@ -484,7 +654,17 @@ fn test_update_creator_fee_recipient_success() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.update_creator_fee_recipient(&creator, &new_recipient);
 
     let profile = client.get_creator(&creator);
@@ -502,7 +682,17 @@ fn test_update_creator_fee_recipient_unauthorized_reverts() {
     let new_recipient = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let result = client.try_update_creator_fee_recipient(&unauthorized, &new_recipient);
     // This should fail because unauthorized is not the current fee recipient
@@ -552,7 +742,17 @@ fn test_sell_key_accepts_exact_min_proceeds_boundary() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     client.buy_key(&creator, &seller, &100, &None);
     client.buy_key(&creator, &seller, &100, &None);
@@ -580,7 +780,17 @@ fn test_sell_extends_creator_ttl_after_successful_sell() {
 
     client.set_key_price(&admin, &100);
     client.set_fee_config(&admin, &9000, &1000);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     client.buy_key(&creator, &seller, &100, &None);
 
     let creator_key = constants::storage::creator(&creator);
@@ -619,7 +829,17 @@ fn test_failed_sell_does_not_extend_creator_ttl() {
     let handle = String::from_str(&env, "alice");
 
     client.set_key_price(&admin, &100);
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let creator_key = constants::storage::creator(&creator);
     let mut ledger_info = env.ledger().get();
@@ -651,7 +871,17 @@ fn test_register_creator_without_optional_params_succeeds() {
     let handle = String::from_str(&env, "alice");
 
     // Registration with None for both optional params should work (backwards compatible)
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.supply, 0);
@@ -777,7 +1007,17 @@ fn test_get_fee_config_persists_across_repeated_reads() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Repeatedly read the fee config and verify stability
     for _ in 0..5 {
@@ -803,7 +1043,17 @@ fn test_register_creator() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.handle, handle);
@@ -823,7 +1073,17 @@ fn test_register_creator_persists_registration_metadata() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let profile = client.get_creator(&creator);
     assert_eq!(profile.creator, creator);
@@ -843,10 +1103,30 @@ fn test_duplicate_registration_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Second registration should fail with AlreadyRegistered error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
     assert_no_events(&env);
 }
@@ -881,7 +1161,17 @@ fn test_buy_key_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let buyer = Address::generate(&env);
     let supply = client.buy_key(&creator, &buyer, &100, &None);
@@ -904,7 +1194,17 @@ fn test_get_creator_holder_count_counts_unique_holders() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let holder_one = Address::generate(&env);
     let holder_two = Address::generate(&env);
@@ -945,7 +1245,17 @@ fn test_buy_key_insufficient_payment() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let buyer = Address::generate(&env);
     let result = client.try_buy_key(&creator, &buyer, &99, &None);
@@ -1016,7 +1326,17 @@ fn test_get_key_balance_returns_zero_for_unregistered_wallet() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let unregistered_wallet = Address::generate(&env);
 
@@ -1115,7 +1435,17 @@ fn test_get_buy_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let quote = client.get_buy_quote(&creator);
     assert_eq!(quote.price, 1000);
@@ -1137,7 +1467,17 @@ fn test_get_sell_quote_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &1000, &None);
@@ -1162,7 +1502,17 @@ fn test_get_sell_quote_fails_if_insufficient_balance() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let holder = Address::generate(&env); // Zero balance
     let result = client.try_get_sell_quote(&creator, &holder);
@@ -1197,7 +1547,17 @@ fn test_get_quote_fails_if_fee_not_set() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let result = client.try_get_buy_quote(&creator);
     assert_eq!(result, Err(Ok(ContractError::FeeConfigNotSet)));
@@ -1227,7 +1587,17 @@ fn test_get_creator_fee_recipient_success() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let recipient = client.get_creator_fee_recipient(&creator);
     assert_eq!(recipient, creator);
@@ -1259,7 +1629,17 @@ fn test_quote_overflow_guards() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     // Buy quote: price + fees (will overflow)
     let result = client.try_get_buy_quote(&creator);
@@ -1336,7 +1716,17 @@ fn test_register_event_field_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let all_events = env.events().all();
     assert_eq!(
@@ -1398,7 +1788,17 @@ fn test_buy_event_topic_and_data_order_is_stable() {
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "bob");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &500, &None);
@@ -1464,7 +1864,17 @@ fn test_register_event_fee_adjacent_fields_are_zero_and_ordered_after_identity_f
 
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "carol");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+    &crate::RegisterCreatorParams {
+        creator: creator.clone(),
+        handle: handle.clone(),
+    },
+    &None,
+    &None,
+    &None,
+    &None,
+    &None
+);
 
     let all_events = env.events().all();
     let (_contract_id, _topics, data): (

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -21,10 +21,10 @@ mod issue_tests {
         let handle = String::from_str(env, "alice");
         match cap {
             Some(c) => {
-                client.register_creator(&creator, &handle, &None, &Some(c), &None);
+                client.register_creator(&creator, &handle, &None, &Some(c), &None, &None);
             }
             None => {
-                client.register_creator(&creator, &handle, &None, &None, &None);
+                client.register_creator(&creator, &handle, &None, &None, &None, &None);
             }
         }
         creator

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -21,10 +21,30 @@ mod issue_tests {
         let handle = String::from_str(env, "alice");
         match cap {
             Some(c) => {
-                client.register_creator(&creator, &handle, &None, &Some(c), &None, &None);
+                client.register_creator(
+                    &crate::RegisterCreatorParams {
+                        creator: creator.clone(),
+                        handle: handle.clone(),
+                    },
+                    &None,
+                    &Some(c),
+                    &None,
+                    &None,
+                    &None,
+                );
             }
             None => {
-                client.register_creator(&creator, &handle, &None, &None, &None, &None);
+                client.register_creator(
+                    &crate::RegisterCreatorParams {
+                        creator: creator.clone(),
+                        handle: handle.clone(),
+                    },
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                );
             }
         }
         creator

--- a/creator-keys/test_snapshots/buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption.1.json
+++ b/creator-keys/test_snapshots/buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "maxed"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "maxed"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/holder_count_tracks_distinct_buyers_and_decrements_on_exit.1.json
+++ b/creator-keys/test_snapshots/holder_count_tracks_distinct_buyers_and_decrements_on_exit.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_100_creator_zero_protocol.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_100_creator_zero_protocol.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_50_50_equal_split.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_50_50_equal_split.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_90_10_nominal_case.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_90_10_nominal_case.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_across_multiple_fee_configs.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_across_multiple_fee_configs.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator0"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator0"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -121,11 +137,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -227,11 +259,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -333,11 +381,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1995,6 +2059,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 5
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 850
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_across_price_range.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_across_price_range.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator0"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator0"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -121,11 +137,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -227,11 +259,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -333,11 +381,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -439,11 +503,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4BV5"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator4"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator4"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -545,11 +625,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDWC6"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDWC6"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator5"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator5"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -651,11 +747,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABI7IO"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABI7IO"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator6"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator6"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -757,11 +869,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOHR6"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOHR6"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator7"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator7"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -863,11 +991,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVM7P"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVM7P"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator8"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator8"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -969,11 +1113,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2VE7"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2VE7"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator9"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator9"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -4707,6 +4867,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1229
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_odd_price_999.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_odd_price_999.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator7"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator7"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 99
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_one.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_one.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator5"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator5"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_two.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_boundary_price_two.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator6"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator6"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_deterministic_assertions.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_deterministic_assertions.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator_det"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator_det"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 15
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_large_amount.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_large_amount.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator8"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator8"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000000
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_max_protocol_50_percent.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_max_protocol_50_percent.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator4"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator4"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_fee_split_invariant_zero_net_boundary.1.json
+++ b/creator-keys/test_snapshots/sell_fee_split_invariant_zero_net_boundary.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator0"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator0"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -122,11 +138,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -229,11 +261,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -336,11 +384,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1999,6 +2063,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 5
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_100_percent_creator_seller_net_is_zero_fees_absorb_full_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr5"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr5"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_price_ten_equal_split_zero_net.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr4"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr4"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -641,6 +657,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 5
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
+++ b/creator-keys/test_snapshots/sell_quote_50_50_small_price_protocol_takes_first_floor_unit.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_dust_price_one_all_creator_no_protocol_rounding.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
+++ b/creator-keys/test_snapshots/sell_quote_90_10_remainder_favors_creator_on_indivisible_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 99
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
+++ b/creator-keys/test_snapshots/sell_quote_max_allowed_protocol_bps_50_50_dust_price_floors_protocol_share_to_zero.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "cr6"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "cr6"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_accumulator_grows_correctly_across_sequential_distributions.1.json
+++ b/creator-keys/test_snapshots/test_accumulator_grows_correctly_across_sequential_distributions.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -770,6 +786,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_assert_event_topic_matches_rejects_unexpected_identifier.1.json
+++ b/creator-keys/test_snapshots/test_assert_event_topic_matches_rejects_unexpected_identifier.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_balance_after_buys_then_sells.1.json
+++ b/creator-keys/test_snapshots/test_balance_after_buys_then_sells.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_balance_after_sequence_of_buys_and_sells.1.json
+++ b/creator-keys/test_snapshots/test_balance_after_sequence_of_buys_and_sells.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_balance_with_non_zero_initial.1.json
+++ b/creator-keys/test_snapshots/test_balance_with_non_zero_initial.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_batch_length_matches_input_length.1.json
+++ b/creator-keys/test_snapshots/test_batch_length_matches_input_length.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_batch_matches_individual_get_creator_details_calls.1.json
+++ b/creator-keys/test_snapshots/test_batch_matches_individual_get_creator_details_calls.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_batch_mixed_registered_and_unregistered.1.json
+++ b/creator-keys/test_snapshots/test_batch_mixed_registered_and_unregistered.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_batch_preserves_input_order.1.json
+++ b/creator-keys/test_snapshots/test_batch_preserves_input_order.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -65,11 +97,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "carol"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "carol"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_batch_registered_creators_have_correct_fields.1.json
+++ b/creator-keys/test_snapshots/test_batch_registered_creators_have_correct_fields.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_credits_creator_fee_recipient_balance_by_bps_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_credits_creator_fee_recipient_balance_by_bps_amount.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -641,6 +657,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_insufficient_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_insufficient_payment_fails.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_negative_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_negative_payment_fails.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_reverts_when_paused.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_reverts_when_paused.1.json
@@ -62,11 +62,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
@@ -62,11 +62,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_sufficient_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_sufficient_payment_succeeds.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
@@ -16,11 +16,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
@@ -16,11 +16,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_key_zero_payment_fails.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_zero_payment_fails.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_more_keys_mid_stream_does_not_earn_retroactively.1.json
+++ b/creator-keys/test_snapshots/test_buy_more_keys_mid_stream_does_not_earn_retroactively.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -771,6 +787,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_deterministic_across_zero_supply_transition.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_deterministic_across_zero_supply_transition.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "edge1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "edge1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -278,7 +294,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 90
+                    "lo": 180
                   }
                 }
               }
@@ -663,6 +679,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_fees_sum_to_total_minus_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_fees_sum_to_total_minus_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -670,6 +686,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_is_identical_across_consecutive_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_is_identical_across_consecutive_calls.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_is_stable_across_multiple_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_is_stable_across_multiple_calls.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_creator_fee.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_creator_fee.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_monotonic_with_zero_protocol_fee.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_multiple_creators_independent_monotonicity.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_multiple_creators_independent_monotonicity.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -90,11 +106,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1043,6 +1075,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 400
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_point_1_is_stable.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_point_1_is_stable.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_price_point_large_is_stable.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_point_large_is_stable.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_across_multiple_buyers_small_range.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_across_multiple_buyers_small_range.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -2340,6 +2356,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_five_buys.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_five_buys.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -758,6 +774,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 250
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_one_buy.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_price_unchanged_after_one_buy.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_recomputed_after_sell_reduces_supply.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_recomputed_after_sell_reduces_supply.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "edge3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "edge3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -309,7 +325,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 450
+                    "lo": 675
                   }
                 }
               }
@@ -694,6 +710,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 75
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_stability_with_different_fee_configs.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stability_with_different_fee_configs.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_stable_across_50_sequential_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stable_across_50_sequential_purchases.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -9900,6 +9916,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 3750
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_stable_over_medium_volume_20_buys.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_stable_over_medium_volume_20_buys.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -4230,6 +4246,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10000
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_total_amount_never_below_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_total_amount_never_below_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -902,6 +918,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10000
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_total_amount_ordering_is_deterministic_small_range.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_total_amount_ordering_is_deterministic_small_range.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -700,6 +716,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_quote_unchanged_after_creator_registration.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_unchanged_after_creator_registration.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -91,11 +107,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_updates_after_fee_config_mutation.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_updates_after_fee_config_mutation.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_with_large_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_large_amount_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator7"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator7"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_with_maximum_safe_amount_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator4"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator4"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_consistent_across_calls.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_consistent_across_calls.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "charlie"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "charlie"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_returns_first_key_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_returns_first_key_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_various_prices.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_various_prices.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator0"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator0"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -141,11 +157,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -217,11 +249,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -293,11 +341,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator3"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator3"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -369,11 +433,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator4"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator4"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -445,11 +525,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2ZMN"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator5"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator5"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_quote_zero_supply_well_formed.1.json
+++ b/creator-keys/test_snapshots/test_buy_quote_zero_supply_well_formed.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_slippage_reverts_when_price_exceeds_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_reverts_when_price_exceeds_max_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -837,6 +853,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buy_then_sell_has_symmetric_price_impact_after_fees.1.json
+++ b/creator-keys/test_snapshots/test_buy_then_sell_has_symmetric_price_impact_after_fees.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "carol"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "carol"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -281,7 +297,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1800
                   }
                 }
               }
@@ -666,6 +682,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_does_not_change_follow_on_buy_price_under_fixed_price_model.1.json
+++ b/creator-keys/test_snapshots/test_buyback_does_not_change_follow_on_buy_price_under_fixed_price_model.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -703,6 +719,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_does_not_credit_creator_fee_balance_and_does_credit_protocol_balance.1.json
+++ b/creator-keys/test_snapshots/test_buyback_does_not_credit_creator_fee_balance_and_does_credit_protocol_balance.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -675,6 +691,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_event_emits_expected_payload.1.json
+++ b/creator-keys/test_snapshots/test_buyback_event_emits_expected_payload.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -701,6 +717,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_exceeding_supply_reverts_with_insufficient_supply.1.json
+++ b/creator-keys/test_snapshots/test_buyback_exceeding_supply_reverts_with_insufficient_supply.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_full_supply_clears_creator_position.1.json
+++ b/creator-keys/test_snapshots/test_buyback_full_supply_clears_creator_position.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -704,6 +720,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_five.1.json
+++ b/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_five.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -397,7 +413,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 4500
+                    "lo": 5400
                   }
                 }
               }
@@ -782,6 +798,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 600
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_one.1.json
+++ b/creator-keys/test_snapshots/test_buyback_quote_matches_execution_at_supply_one.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -281,7 +297,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1800
                   }
                 }
               }
@@ -666,6 +682,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_reduces_supply_and_creator_balance.1.json
+++ b/creator-keys/test_snapshots/test_buyback_reduces_supply_and_creator_balance.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -704,6 +720,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_rejects_non_creator_caller.1.json
+++ b/creator-keys/test_snapshots/test_buyback_rejects_non_creator_caller.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -640,6 +656,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_rejects_when_creator_balance_is_below_amount_even_if_supply_is_higher.1.json
+++ b/creator-keys/test_snapshots/test_buyback_rejects_when_creator_balance_is_below_amount_even_if_supply_is_higher.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -831,6 +847,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_buyback_zero_amount_reverts.1.json
+++ b/creator-keys/test_snapshots/test_buyback_zero_amount_reverts.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -110,7 +126,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -640,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_after_sell_captures_pending.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_after_sell_captures_pending.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -325,7 +341,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 90
+                    "lo": 180
                   }
                 }
               }
@@ -758,6 +774,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_event_topics_and_payload.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_event_topics_and_payload.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -735,6 +751,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_happy_path_returns_correct_amount.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_happy_path_returns_correct_amount.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -735,6 +751,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_no_claimable_fails.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_no_claimable_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_proportional_amounts_across_holders.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_proportional_amounts_across_holders.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -974,6 +990,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 30
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_resets_claimable_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_resets_claimable_to_zero.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -736,6 +752,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_dividend_while_paused_fails.1.json
+++ b/creator-keys/test_snapshots/test_claim_dividend_while_paused_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -833,6 +849,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_claim_locked_allocation_reverts_at_every_ledger_before_unlock.1.json
+++ b/creator-keys/test_snapshots/test_claim_locked_allocation_reverts_at_every_ledger_before_unlock.1.json
@@ -15,10 +15,24 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "alice"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
                 {
                   "map": [
@@ -48,6 +62,8 @@
                     }
                   ]
                 },
+                "void",
+                "void",
                 "void",
                 "void"
               ]

--- a/creator-keys/test_snapshots/test_claim_locked_allocation_succeeds_at_unlock_ledger.1.json
+++ b/creator-keys/test_snapshots/test_claim_locked_allocation_succeeds_at_unlock_ledger.1.json
@@ -15,10 +15,24 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "alice"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
                 {
                   "map": [
@@ -48,6 +62,8 @@
                     }
                   ]
                 },
+                "void",
+                "void",
                 "void",
                 "void"
               ]

--- a/creator-keys/test_snapshots/test_creator_details_consistency_across_ten_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_consistency_across_ten_reads.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "dave"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "dave"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_creator_details_identical_across_five_consecutive_reads_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_identical_across_five_consecutive_reads_after_buy.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_creator_details_identical_across_three_consecutive_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_identical_across_three_consecutive_reads.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_creator_details_no_storage_writes_during_reads.1.json
+++ b/creator-keys/test_snapshots/test_creator_details_no_storage_writes_during_reads.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "charlie"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "charlie"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_distribute_dividend_deducts_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_deducts_protocol_fee.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -716,6 +732,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_event_topics_and_payload.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_event_topics_and_payload.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -713,6 +729,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_negative_amount_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_negative_amount_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_distribute_dividend_no_fee_config_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_no_fee_config_fails.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_distribute_dividend_no_key_holders_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_no_key_holders_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_distribute_dividend_proportional_to_balance.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_proportional_to_balance.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -961,6 +977,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 40
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_single_holder_receives_full_net.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_single_holder_receives_full_net.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -714,6 +730,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_two_equal_holders_split_evenly.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_two_equal_holders_split_evenly.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -903,6 +919,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_while_paused_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_while_paused_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -757,6 +773,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_distribute_dividend_zero_amount_fails.1.json
+++ b/creator-keys/test_snapshots/test_distribute_dividend_zero_amount_fails.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_double_claim_fails_with_no_claimable.1.json
+++ b/creator-keys/test_snapshots/test_double_claim_fails_with_no_claimable.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -736,6 +752,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_existing_holder_earns_from_all_distributions_via_checkpoint.1.json
+++ b/creator-keys/test_snapshots/test_existing_holder_earns_from_all_distributions_via_checkpoint.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -742,6 +758,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_fee_config_update_does_not_affect_other_creator.1.json
+++ b/creator-keys/test_snapshots/test_fee_config_update_does_not_affect_other_creator.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -90,11 +106,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_buy_quote_zero_amount_returns_noop_quote.1.json
+++ b/creator-keys/test_snapshots/test_get_buy_quote_zero_amount_returns_noop_quote.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_buyback_quote_returns_price_plus_protocol_fee_only.1.json
+++ b/creator-keys/test_snapshots/test_get_buyback_quote_returns_price_plus_protocol_fee_only.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -669,6 +685,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_accumulates_across_distributions.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_accumulates_across_distributions.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -770,6 +786,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_correct_after_distribution.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_correct_after_distribution.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -714,6 +730,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_is_read_only.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -720,6 +736,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_works_while_paused.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_works_while_paused.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -833,6 +849,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_zero_after_claim.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_zero_after_claim.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -736,6 +752,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_claimable_dividend_zero_before_any_distribution.1.json
+++ b/creator-keys/test_snapshots/test_get_claimable_dividend_zero_before_any_distribution.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_creator_details_read_on_unregistered_does_not_mutate_state.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_read_on_unregistered_does_not_mutate_state.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "anchor"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "anchor"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_details_reflects_latest_state_after_buy_then_sell.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_reflects_latest_state_after_buy_then_sell.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_details_registered_returns_correct_data.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_registered_returns_correct_data.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_details_updates_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_details_updates_after_buy.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_fails_when_fee_config_not_set.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_fails_when_fee_config_not_set.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_returns_configured_value.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_returns_configured_value.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_bps_tracks_fee_config_updates.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_bps_tracks_fee_config_updates.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test_creator"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test_creator"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_multiple_creators_independent.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_multiple_creators_independent.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator_one"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator_one"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator_two"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator_two"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_registered_no_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_registered_no_fee_config.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test_creator"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test_creator"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_registered_with_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_registered_with_fee_config.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test_creator"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test_creator"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_config_updates_after_fee_reconfiguration.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_config_updates_after_fee_reconfiguration.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test_creator"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test_creator"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_recipient_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_recipient_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_fee_recipient_returns_creator_address.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_fee_recipient_returns_creator_address.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_succeeds_after_supply_returns_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_succeeds_after_supply_returns_to_zero.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_supply_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_supply_is_read_only.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_supply_returns_current_supply.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_supply_returns_current_supply.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_fails_when_fee_config_not_set.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_fails_when_fee_config_not_set.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creator_treasury_share_returns_configured_value.1.json
+++ b/creator-keys/test_snapshots/test_get_creator_treasury_share_returns_configured_value.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_creators_batch_success.1.json
+++ b/creator-keys/test_snapshots/test_get_creators_batch_success.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_key_decimals_consistent_across_creator_instances.1.json
+++ b/creator-keys/test_snapshots/test_get_key_decimals_consistent_across_creator_instances.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -41,11 +57,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_key_name_success.1.json
+++ b/creator-keys/test_snapshots/test_get_key_name_success.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_key_symbol_success.1.json
+++ b/creator-keys/test_snapshots/test_get_key_symbol_success.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_protocol_state_version_increments_only_on_config_updates.1.json
+++ b/creator-keys/test_snapshots/test_get_protocol_state_version_increments_only_on_config_updates.1.json
@@ -67,11 +67,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -701,6 +717,48 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_get_sell_quote_zero_amount_returns_noop_quote.1.json
+++ b/creator-keys/test_snapshots/test_get_sell_quote_zero_amount_returns_noop_quote.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_total_key_supply_increments_after_buy.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_increments_after_buy.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_total_key_supply_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_is_read_only.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_get_total_key_supply_returns_zero_for_new_creator.1.json
+++ b/creator-keys/test_snapshots/test_get_total_key_supply_returns_zero_for_new_creator.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_count_reflects_mixed_trade_correctly.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_reflects_mixed_trade_correctly.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_count_unchanged_when_holder_still_has_keys.1.json
+++ b/creator-keys/test_snapshots/test_holder_count_unchanged_when_holder_still_has_keys.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_consistency_with_get_key_balance.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_consistency_with_get_key_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_increments_on_buy.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_increments_on_buy.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_multiple_holders.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_multiple_holders.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_no_state_mutation.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_no_state_mutation.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_registered_creator_unseen_wallet.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_registered_creator_unseen_wallet.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_starts_at_zero.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_starts_at_zero.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_structure_fields.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_structure_fields.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "test"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "test"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_holder_key_count_view_zero_keys_different_creators.1.json
+++ b/creator-keys/test_snapshots/test_holder_key_count_view_zero_keys_different_creators.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -65,11 +81,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_identical_fee_configs_apply_independently.1.json
+++ b/creator-keys/test_snapshots/test_identical_fee_configs_apply_independently.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -90,11 +106,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1043,6 +1075,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_is_creator_registered_different_creators_independent.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_different_creators_independent.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_is_creator_registered_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_is_creator_registered_returns_true_after_registration.1.json
+++ b/creator-keys/test_snapshots/test_is_creator_registered_returns_true_after_registration.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_decrements_correctly_after_each_partial_sell.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_decrements_correctly_after_each_partial_sell.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_increments_on_buy.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_increments_on_buy.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_is_per_buyer.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_is_per_buyer.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_is_per_creator.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_is_per_creator.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -65,11 +81,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_returns_zero_for_uninitialized_holder.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_returns_zero_for_uninitialized_holder.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_zero_for_registered_creator_and_unseen_wallet.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_zero_for_registered_creator_and_unseen_wallet.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist.1.json
+++ b/creator-keys/test_snapshots/test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_multiple_distributions_accumulate.1.json
+++ b/creator-keys/test_snapshots/test_multiple_distributions_accumulate.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -742,6 +758,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_new_buyer_after_distribution_earns_no_retroactive_dividends.1.json
+++ b/creator-keys/test_snapshots/test_new_buyer_after_distribution_earns_no_retroactive_dividends.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -902,6 +918,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_read_only_views_work_while_paused.1.json
+++ b/creator-keys/test_snapshots/test_read_only_views_work_while_paused.1.json
@@ -62,11 +62,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_accepts_max_handle_length.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_accepts_max_handle_length.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_accepts_min_handle_length.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_accepts_min_handle_length.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "aaa"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "aaa"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_different_addresses_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_different_addresses_succeeds.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_duplicate_different_handle_fails.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_duplicate_different_handle_fails.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_duplicate_fails.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_duplicate_fails.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_emits_event.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_emits_event.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_event_data_is_indexer_friendly.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_data_is_indexer_friendly.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_event_field_values_match_fixtures.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_field_values_match_fixtures.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "fixture_handle"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "fixture_handle"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_event_fields_update_with_fee_config.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_fields_update_with_fee_config.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator_1"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator_1"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -90,11 +106,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator_2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator_2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_event_fires_once.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_event_fires_once.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_max_length_handle_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_max_length_handle_succeeds.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_register_creator_minimum_handle_length_success.1.json
+++ b/creator-keys/test_snapshots/test_register_creator_minimum_handle_length_success.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "aaa"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "aaa"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_registered_at_enables_chronological_sort.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_enables_chronological_sort.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "first"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "first"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -40,11 +56,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "second"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "second"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -65,11 +97,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "third"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "third"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_registered_at_is_captured_at_registration_sequence.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_captured_at_registration_sequence.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_registered_at_is_immutable_after_buy_and_sell.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_immutable_after_buy_and_sell.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_registered_at_is_read_only.1.json
+++ b/creator-keys/test_snapshots/test_registered_at_is_read_only.1.json
@@ -15,11 +15,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_repeated_zero_amount_quote_calls_no_state_drift.1.json
+++ b/creator-keys/test_snapshots/test_repeated_zero_amount_quote_calls_no_state_drift.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_all_then_rebuy_starts_fresh_on_pending.1.json
+++ b/creator-keys/test_snapshots/test_sell_all_then_rebuy_starts_fresh_on_pending.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -361,7 +377,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 180
+                    "lo": 270
                   }
                 }
               }
@@ -794,6 +810,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 30
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_execution_applies_updated_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_sell_execution_applies_updated_protocol_fee.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -303,7 +319,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1700
                   }
                 }
               }
@@ -688,6 +704,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_execution_fee_matches_quote_after_fee_config_update.1.json
+++ b/creator-keys/test_snapshots/test_sell_execution_fee_matches_quote_after_fee_config_update.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -304,7 +320,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 450
+                    "lo": 825
                   }
                 }
               }
@@ -689,6 +705,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 175
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_full_exit_then_rebuy_updates_state.1.json
+++ b/creator-keys/test_snapshots/test_sell_full_exit_then_rebuy_updates_state.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_increases_protocol_fee_recipient_balance_by_bps_fee.1.json
+++ b/creator-keys/test_snapshots/test_sell_increases_protocol_fee_recipient_balance_by_bps_fee.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -300,7 +316,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1800
                   }
                 }
               }
@@ -724,6 +740,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_key_decrements_supply_and_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_decrements_supply_and_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_fails_when_seller_has_no_keys.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_fails_when_seller_has_no_keys.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_preserves_holder_count_when_seller_still_has_keys.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_preserves_holder_count_when_seller_still_has_keys.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_removes_holder_when_last_key_is_sold.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_removes_holder_when_last_key_is_sold.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_key_reverts_when_paused.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_reverts_when_paused.1.json
@@ -62,11 +62,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_protocol_fee_recipient_balance_accumulates_across_two_sells.1.json
+++ b/creator-keys/test_snapshots/test_sell_protocol_fee_recipient_balance_accumulates_across_two_sells.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -352,7 +368,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 1800
+                    "lo": 3600
                   }
                 }
               }
@@ -776,6 +792,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 400
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_five.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_five.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -397,7 +413,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 4500
+                    "lo": 5400
                   }
                 }
               }
@@ -782,6 +798,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 600
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_one.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_proceeds_match_execution_at_supply_one.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -281,7 +297,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1800
                   }
                 }
               }
@@ -666,6 +682,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_large_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_large_amount_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator5"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator5"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -615,6 +631,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50000000000
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_50_50_fees_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator8"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator8"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -615,6 +631,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 4611686018427387
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_with_maximum_safe_amount_succeeds.1.json
@@ -41,11 +41,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "creator6"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "creator6"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -615,6 +631,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 922337203685477
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_holder_no_keys_returns_zero_quote.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_holder_no_keys_returns_zero_quote.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_no_state_modification.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_no_state_modification.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "charlie"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "charlie"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -649,6 +665,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_amount_returns_zero_quote.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_amount_returns_zero_quote.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_quote_zero_supply_boundary_is_rejected.1.json
+++ b/creator-keys/test_snapshots/test_sell_quote_zero_supply_boundary_is_rejected.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "edge2"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "edge2"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_registered_zero_supply_creator_returns_sell_underflow_without_state_change.1.json
+++ b/creator-keys/test_snapshots/test_sell_registered_zero_supply_creator_returns_sell_underflow_without_state_change.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_reverts_when_seller_has_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_reverts_when_seller_has_insufficient_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_second_key_after_selling_last_returns_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_second_key_after_selling_last_returns_insufficient_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_slippage_reverts_when_proceeds_below_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_reverts_when_proceeds_below_min_proceeds.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -646,6 +662,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -341,7 +357,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 1800
+                    "lo": 3600
                   }
                 }
               }
@@ -885,6 +901,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 400
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_sell_with_no_keys_returns_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_sell_with_no_keys_returns_insufficient_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
+++ b/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -277,7 +293,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 900
+                    "lo": 1800
                   }
                 }
               }
@@ -662,6 +678,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_supply_alternating_buys_and_sells.1.json
+++ b/creator-keys/test_snapshots/test_supply_alternating_buys_and_sells.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_and_balance_decremented_correctly_after_sell.1.json
+++ b/creator-keys/test_snapshots/test_supply_and_balance_decremented_correctly_after_sell.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_buy_then_sell_returns_to_zero.1.json
+++ b/creator-keys/test_snapshots/test_supply_buy_then_sell_returns_to_zero.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_buy_two_sell_one_conserves_supply.1.json
+++ b/creator-keys/test_snapshots/test_supply_buy_two_sell_one_conserves_supply.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_changes_for_one_creator_do_not_affect_another.1.json
+++ b/creator-keys/test_snapshots/test_supply_changes_for_one_creator_do_not_affect_another.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -65,11 +81,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_mixed_trades_three_participants.1.json
+++ b/creator-keys/test_snapshots/test_supply_mixed_trades_three_participants.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_multiple_buys_per_holder_sum_equals_total.1.json
+++ b/creator-keys/test_snapshots/test_supply_multiple_buys_per_holder_sum_equals_total.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_never_goes_below_zero_after_all_sells.1.json
+++ b/creator-keys/test_snapshots/test_supply_never_goes_below_zero_after_all_sells.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_supply_three_buyers_sum_equals_total.1.json
+++ b/creator-keys/test_snapshots/test_supply_three_buyers_sum_equals_total.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_insufficient_balance.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_not_registered.1.json
+++ b/creator-keys/test_snapshots/test_total_supply_unchanged_after_failed_sell_not_registered.1.json
@@ -40,11 +40,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_transfer_keys_buy_quote_unchanged_after_transfer.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_buy_quote_unchanged_after_transfer.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -855,6 +871,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_exceeding_balance_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_exceeding_balance_reverts.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_holder_count_increments_when_recipient_new.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_holder_count_increments_when_recipient_new.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1043,6 +1059,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 30
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -827,6 +843,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_preserves_other_holders.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_preserves_other_holders.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1042,6 +1058,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 30
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_recipient_balance_increases.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_recipient_balance_increases.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -825,6 +841,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_self_transfer_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_self_transfer_reverts.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_sell_quote_unchanged_after_transfer.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_sell_quote_unchanged_after_transfer.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -855,6 +871,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_sender_balance_decreases.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_sender_balance_decreases.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -883,6 +899,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 30
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_total_supply_unchanged.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_total_supply_unchanged.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -855,6 +871,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_transfer_keys_zero_amount_reverts.1.json
+++ b/creator-keys/test_snapshots/test_transfer_keys_zero_amount_reverts.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_accumulates_protocol_fees_across_distinct_buyers.1.json
+++ b/creator-keys/test_snapshots/test_treasury_accumulates_protocol_fees_across_distinct_buyers.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -1084,6 +1100,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_insufficient_payment.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_insufficient_payment.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_unregistered_creator.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_buy_unregistered_creator.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -701,6 +717,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_sell_insufficient_balance.1.json
+++ b/creator-keys/test_snapshots/test_treasury_balance_unchanged_after_failed_sell_insufficient_balance.1.json
@@ -87,11 +87,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -701,6 +717,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_full_payment_to_creator_after_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_full_payment_to_creator_after_protocol_fee.1.json
@@ -66,11 +66,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "alice"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "alice"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_no_rounding_errors_with_odd_amounts.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_no_rounding_errors_with_odd_amounts.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "dave"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "dave"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -638,6 +654,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 332
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_creator_bps_with_partial_protocol_fee.1.json
+++ b/creator-keys/test_snapshots/test_zero_creator_bps_with_partial_protocol_fee.1.json
@@ -66,11 +66,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "bob"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "bob"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"
@@ -639,6 +655,48 @@
                 "durability": "persistent",
                 "val": {
                   "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryBalance"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryBalance"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
                 }
               }
             },

--- a/creator-keys/test_snapshots/test_zero_protocol_bps_full_payment_to_creator.1.json
+++ b/creator-keys/test_snapshots/test_zero_protocol_bps_full_payment_to_creator.1.json
@@ -65,11 +65,27 @@
               "function_name": "register_creator",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "handle"
+                      },
+                      "val": {
+                        "string": "charlie"
+                      }
+                    }
+                  ]
                 },
-                {
-                  "string": "charlie"
-                },
+                "void",
+                "void",
                 "void",
                 "void",
                 "void"

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -31,6 +31,7 @@ fn test_buy_event_buyer_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Clear any prior events then perform the buy
@@ -85,6 +86,7 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -26,8 +26,11 @@ fn test_buy_event_buyer_address_matches_caller() {
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -84,8 +87,11 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -17,8 +17,11 @@ fn test_buy_key_event_includes_payment_amount() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -50,8 +53,11 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -22,6 +22,7 @@ fn test_buy_key_event_includes_payment_amount() {
         &None,
         &None,
         &None,
+        &None,
     );
     let supply = client.buy_key(&creator, &buyer, &150i128, &None);
     assert_eq!(supply, 1);
@@ -51,6 +52,7 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -31,6 +31,7 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
         }),
         &None,
         &None,
+        &None,
     );
 
     // Immediately after registration — must revert.
@@ -75,6 +76,7 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
     );

--- a/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
+++ b/creator-keys/tests/claim_locked_allocation_ledger_boundary.rs
@@ -22,13 +22,16 @@ fn test_claim_locked_allocation_reverts_at_every_ledger_before_unlock() {
     env.ledger().set(ledger_info.clone());
 
     client.register_creator(
-        &creator,
-        &handle,
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
         &Some(LockedAllocation {
             amount: 50,
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
         &None,
@@ -69,13 +72,16 @@ fn test_claim_locked_allocation_succeeds_at_unlock_ledger() {
     env.ledger().set(ledger_info.clone());
 
     client.register_creator(
-        &creator,
-        &handle,
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
         &Some(LockedAllocation {
             amount,
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -33,6 +33,7 @@ fn setup_creator_with_locked_allocation(
         }),
         &None,
         &None,
+        &None,
     );
     creator
 }

--- a/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
+++ b/creator-keys/tests/claim_locked_allocation_non_creator_reverts.rs
@@ -24,13 +24,16 @@ fn setup_creator_with_locked_allocation(
     ledger_info.sequence_number = 1;
     env.ledger().set(ledger_info);
     client.register_creator(
-        &creator,
-        &String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, "alice"),
+        },
         &Some(LockedAllocation {
             amount: ALLOCATION_AMOUNT,
             unlock_ledger: UNLOCK_LEDGER,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/co_creator_revenue_split.rs
+++ b/creator-keys/tests/co_creator_revenue_split.rs
@@ -52,12 +52,15 @@ fn register_creator_with_co_creator(
     };
 
     client.register_creator(
-        &creator,
-        &String::from_str(env, handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, handle),
+        },
         &None,
         &None,
         &None,
         &Some(config.clone()),
+        &None,
     );
 
     (creator, co_creator, config)
@@ -91,12 +94,15 @@ fn test_register_creator_rejects_invalid_co_creator_share_bps() {
         };
 
         let result = client.try_register_creator(
-            &creator,
-            &String::from_str(&env, handle),
+            &creator_keys::RegisterCreatorParams {
+                creator: creator.clone(),
+                handle: String::from_str(&env, handle),
+            },
             &None,
             &None,
             &None,
             &Some(config),
+            &None,
         );
 
         assert_eq!(result, Err(Ok(ContractError::InvalidCoCreatorShare)));

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -106,8 +106,11 @@ pub fn register_test_creator(
 ) -> Address {
     let creator = Address::generate(env);
     client.register_creator(
-        &creator,
-        &String::from_str(env, handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, handle),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -138,8 +141,11 @@ pub fn register_test_creator_with_fee_config(
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     let creator = Address::generate(env);
     client.register_creator(
-        &creator,
-        &String::from_str(env, handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, handle),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -111,6 +111,7 @@ pub fn register_test_creator(
         &None,
         &None,
         &None,
+        &None,
     );
     creator
 }
@@ -139,6 +140,7 @@ pub fn register_test_creator_with_fee_config(
     client.register_creator(
         &creator,
         &String::from_str(env, handle),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_detail_read_consistency.rs
+++ b/creator-keys/tests/creator_detail_read_consistency.rs
@@ -23,7 +23,17 @@ fn test_creator_details_identical_across_three_consecutive_reads() {
     let handle = String::from_str(&env, "alice");
 
     // Register creator to establish initial state
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     // Perform three consecutive reads with NO state changes between them
     let read1 = client.get_creator_details(&creator);
@@ -131,7 +141,17 @@ fn test_creator_details_no_storage_writes_during_reads() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "charlie");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     // Use a sentinel holder address — no keys held, so balance stays 0.
     let sentinel = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/creator_detail_read_consistency.rs
+++ b/creator-keys/tests/creator_detail_read_consistency.rs
@@ -23,7 +23,7 @@ fn test_creator_details_identical_across_three_consecutive_reads() {
     let handle = String::from_str(&env, "alice");
 
     // Register creator to establish initial state
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Perform three consecutive reads with NO state changes between them
     let read1 = client.get_creator_details(&creator);
@@ -131,7 +131,7 @@ fn test_creator_details_no_storage_writes_during_reads() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "charlie");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Use a sentinel holder address — no keys held, so balance stays 0.
     let sentinel = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/creator_details_view.rs
+++ b/creator-keys/tests/creator_details_view.rs
@@ -29,7 +29,17 @@ fn test_get_creator_details_registered_returns_correct_data() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let details = client.get_creator_details(&creator);
     assert!(details.is_registered);

--- a/creator-keys/tests/creator_details_view.rs
+++ b/creator-keys/tests/creator_details_view.rs
@@ -29,7 +29,7 @@ fn test_get_creator_details_registered_returns_correct_data() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let details = client.get_creator_details(&creator);
     assert!(details.is_registered);

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -14,8 +14,11 @@ fn test_get_creator_fee_bps_returns_configured_value() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -37,8 +40,11 @@ fn test_get_creator_fee_bps_is_read_only() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -63,8 +69,11 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -19,6 +19,7 @@ fn test_get_creator_fee_bps_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -38,6 +39,7 @@ fn test_get_creator_fee_bps_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -63,6 +65,7 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -48,6 +48,7 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_fee_bps(&creator);

--- a/creator-keys/tests/creator_fee_bps_invalid_reads.rs
+++ b/creator-keys/tests/creator_fee_bps_invalid_reads.rs
@@ -43,8 +43,11 @@ fn test_get_creator_fee_bps_fails_when_fee_config_not_set() {
     let creator = soroban_sdk::Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -28,7 +28,17 @@ fn test_get_creator_fee_config_registered_no_fee_config() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let view = client.get_creator_fee_config(&creator);
 
@@ -50,7 +60,17 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view = client.get_creator_fee_config(&creator);
@@ -73,7 +93,17 @@ fn test_get_creator_fee_config_is_read_only() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -97,7 +127,17 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -124,8 +164,28 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let handle1 = String::from_str(&env, "creator_one");
     let handle2 = String::from_str(&env, "creator_two");
 
-    client.register_creator(&creator1, &handle1, &None, &None, &None, &None);
-    client.register_creator(&creator2, &handle2, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator1.clone(),
+            handle: handle1.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator2.clone(),
+            handle: handle2.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view1 = client.get_creator_fee_config(&creator1);

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -28,7 +28,7 @@ fn test_get_creator_fee_config_registered_no_fee_config() {
 
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let view = client.get_creator_fee_config(&creator);
 
@@ -50,7 +50,7 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view = client.get_creator_fee_config(&creator);
@@ -73,7 +73,7 @@ fn test_get_creator_fee_config_is_read_only() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -97,7 +97,7 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let v1 = client.get_creator_fee_config(&creator);
@@ -124,8 +124,8 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let handle1 = String::from_str(&env, "creator_one");
     let handle2 = String::from_str(&env, "creator_two");
 
-    client.register_creator(&creator1, &handle1, &None, &None, &None);
-    client.register_creator(&creator2, &handle2, &None, &None, &None);
+    client.register_creator(&creator1, &handle1, &None, &None, &None, &None);
+    client.register_creator(&creator2, &handle2, &None, &None, &None, &None);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let view1 = client.get_creator_fee_config(&creator1);

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -14,8 +14,11 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -35,8 +38,11 @@ fn test_get_creator_fee_recipient_is_read_only() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_fee_recipient.rs
+++ b/creator-keys/tests/creator_fee_recipient.rs
@@ -19,6 +19,7 @@ fn test_get_creator_fee_recipient_returns_creator_address() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_creator_fee_recipient(&creator), creator);
@@ -36,6 +37,7 @@ fn test_get_creator_fee_recipient_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -32,6 +32,7 @@ fn test_is_creator_registered_returns_true_after_registration() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -49,6 +50,7 @@ fn test_is_creator_registered_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -79,6 +81,7 @@ fn test_is_creator_registered_different_creators_independent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&alice));
@@ -98,9 +101,9 @@ fn test_register_creator_duplicate_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
     // Second registration with the same address should fail with error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -120,11 +123,13 @@ fn test_register_creator_duplicate_different_handle_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Re-registering with a different handle should still fail
     let result = client.try_register_creator(
         &creator,
         &String::from_str(&env, "alice_v2"),
+        &None,
         &None,
         &None,
         &None,
@@ -149,8 +154,16 @@ fn test_register_creator_different_addresses_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.register_creator(&bob, &String::from_str(&env, "bob"), &None, &None, &None);
+    client.register_creator(
+        &bob,
+        &String::from_str(&env, "bob"),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&alice));
     assert!(client.is_creator_registered(&bob));
@@ -169,6 +182,7 @@ fn test_register_creator_accepts_min_handle_length() {
     client.register_creator(
         &creator,
         &String::from_str(&env, &min_handle),
+        &None,
         &None,
         &None,
         &None,
@@ -193,6 +207,7 @@ fn test_register_creator_accepts_max_handle_length() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(client.is_creator_registered(&creator));
@@ -211,6 +226,7 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
     let result = client.try_register_creator(
         &creator,
         &String::from_str(&env, &short_handle),
+        &None,
         &None,
         &None,
         &None,
@@ -234,6 +250,7 @@ fn test_register_creator_rejects_handle_longer_than_max() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }
@@ -248,7 +265,7 @@ fn test_register_creator_rejects_invalid_characters_in_handle() {
 
     let creator = Address::generate(&env);
     let invalid_handle = String::from_str(&env, "Alice-01");
-    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::InvalidHandleCharacter)));
 }
 
@@ -264,7 +281,7 @@ fn test_register_creator_max_length_handle_succeeds() {
 
     let creator = Address::generate(&env);
     let max_handle = String::from_str(&env, &"a".repeat(HANDLE_LEN_MAX as usize));
-    client.register_creator(&creator, &max_handle, &None, &None, &None);
+    client.register_creator(&creator, &max_handle, &None, &None, &None, &None);
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -279,7 +296,8 @@ fn test_register_creator_handle_one_over_max_rejected() {
 
     let creator = Address::generate(&env);
     let over_max_handle = String::from_str(&env, &"a".repeat((HANDLE_LEN_MAX + 1) as usize));
-    let result = client.try_register_creator(&creator, &over_max_handle, &None, &None, &None);
+    let result =
+        client.try_register_creator(&creator, &over_max_handle, &None, &None, &None, &None);
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }

--- a/creator-keys/tests/creator_registration.rs
+++ b/creator-keys/tests/creator_registration.rs
@@ -27,8 +27,11 @@ fn test_is_creator_registered_returns_true_after_registration() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -48,8 +51,11 @@ fn test_is_creator_registered_is_read_only() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -76,8 +82,11 @@ fn test_is_creator_registered_different_creators_independent() {
     let bob = Address::generate(&env);
 
     client.register_creator(
-        &alice,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: alice.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -101,9 +110,29 @@ fn test_register_creator_duplicate_fails() {
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     // Second registration with the same address should fail with error
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::AlreadyRegistered)));
 }
 
@@ -118,8 +147,11 @@ fn test_register_creator_duplicate_different_handle_fails() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -127,8 +159,11 @@ fn test_register_creator_duplicate_different_handle_fails() {
     );
     // Re-registering with a different handle should still fail
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice_v2"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice_v2"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -149,16 +184,22 @@ fn test_register_creator_different_addresses_succeeds() {
     let bob = Address::generate(&env);
 
     client.register_creator(
-        &alice,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: alice.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
         &None,
     );
     client.register_creator(
-        &bob,
-        &String::from_str(&env, "bob"),
+        &creator_keys::RegisterCreatorParams {
+            creator: bob.clone(),
+            handle: String::from_str(&env, "bob"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -180,8 +221,11 @@ fn test_register_creator_accepts_min_handle_length() {
     let creator = Address::generate(&env);
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, &min_handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, &min_handle),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -202,8 +246,11 @@ fn test_register_creator_accepts_max_handle_length() {
     let creator = Address::generate(&env);
     let max_handle = "a".repeat(HANDLE_LEN_MAX as usize);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, &max_handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, &max_handle),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -224,8 +271,11 @@ fn test_register_creator_rejects_handle_shorter_than_min() {
     let creator = Address::generate(&env);
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, &short_handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, &short_handle),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -245,8 +295,11 @@ fn test_register_creator_rejects_handle_longer_than_max() {
     let creator = Address::generate(&env);
     let long_handle = "a".repeat((HANDLE_LEN_MAX + 1) as usize);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, &long_handle),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, &long_handle),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -265,7 +318,17 @@ fn test_register_creator_rejects_invalid_characters_in_handle() {
 
     let creator = Address::generate(&env);
     let invalid_handle = String::from_str(&env, "Alice-01");
-    let result = client.try_register_creator(&creator, &invalid_handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: invalid_handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::InvalidHandleCharacter)));
 }
 
@@ -281,7 +344,17 @@ fn test_register_creator_max_length_handle_succeeds() {
 
     let creator = Address::generate(&env);
     let max_handle = String::from_str(&env, &"a".repeat(HANDLE_LEN_MAX as usize));
-    client.register_creator(&creator, &max_handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: max_handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert!(client.is_creator_registered(&creator));
 }
@@ -296,8 +369,17 @@ fn test_register_creator_handle_one_over_max_rejected() {
 
     let creator = Address::generate(&env);
     let over_max_handle = String::from_str(&env, &"a".repeat((HANDLE_LEN_MAX + 1) as usize));
-    let result =
-        client.try_register_creator(&creator, &over_max_handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: over_max_handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooLong)));
 }

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -12,8 +12,11 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
 
     let creator = Address::generate(env);
     client.register_creator(
-        &creator,
-        &String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_supply.rs
+++ b/creator-keys/tests/creator_supply.rs
@@ -17,6 +17,7 @@ fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
         &None,
         &None,
         &None,
+        &None,
     );
 
     (client, admin, creator)

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -14,8 +14,11 @@ fn test_get_creator_treasury_share_returns_configured_value() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -37,8 +40,11 @@ fn test_get_creator_treasury_share_is_read_only() {
     let creator = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -19,6 +19,7 @@ fn test_get_creator_treasury_share_returns_configured_value() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -38,6 +39,7 @@ fn test_get_creator_treasury_share_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -48,6 +48,7 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_get_creator_treasury_share(&creator);

--- a/creator-keys/tests/creator_treasury_share_invalid_reads.rs
+++ b/creator-keys/tests/creator_treasury_share_invalid_reads.rs
@@ -43,8 +43,11 @@ fn test_get_creator_treasury_share_fails_when_fee_config_not_set() {
 
     // Register creator WITHOUT calling set_fee_config.
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -17,31 +17,40 @@ fn test_curve_preset_variants_and_error_handling() {
 
     // Register creator with Linear preset
     client.register_creator(
-        &creator_linear,
-        &String::from_str(&env, "linear_c"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_linear.clone(),
+            handle: String::from_str(&env, "linear_c"),
+        },
         &None,
         &None,
         &Some(CurvePreset::Linear),
+        &None,
         &None,
     );
 
     // Register creator with Quadratic preset
     client.register_creator(
-        &creator_quadratic,
-        &String::from_str(&env, "quadratic_c"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_quadratic.clone(),
+            handle: String::from_str(&env, "quadratic_c"),
+        },
         &None,
         &None,
         &Some(CurvePreset::Quadratic),
+        &None,
         &None,
     );
 
     // Register creator with Flat preset
     client.register_creator(
-        &creator_flat,
-        &String::from_str(&env, "flat_c"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_flat.clone(),
+            handle: String::from_str(&env, "flat_c"),
+        },
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
         &None,
     );
 

--- a/creator-keys/tests/curve_preset_storage.rs
+++ b/creator-keys/tests/curve_preset_storage.rs
@@ -22,6 +22,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Linear),
+        &None,
     );
 
     // Register creator with Quadratic preset
@@ -31,6 +32,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Quadratic),
+        &None,
     );
 
     // Register creator with Flat preset
@@ -40,6 +42,7 @@ fn test_curve_preset_variants_and_error_handling() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     // Assert each returns the correct variant

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -150,6 +150,7 @@ fn test_register_creator_reverts_when_paused() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 }
@@ -203,6 +204,8 @@ fn test_pause_blocks_registration_not_reads() {
         &soroban_sdk::String::from_str(&env, "creatorb"),
         &None,
         &None,
+        &None,
+        &None,
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 
@@ -218,6 +221,8 @@ fn test_pause_blocks_registration_not_reads() {
         .try_register_creator(
             &creator_b,
             &soroban_sdk::String::from_str(&env, "creatorb"),
+            &None,
+            &None,
             &None,
             &None,
         )

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -205,10 +205,7 @@ fn test_pause_blocks_registration_not_reads() {
         &None,
         &None,
         &None,
-
         &None,
-
-
     );
     assert_eq!(result, Err(Ok(ContractError::ProtocolPaused)));
 
@@ -220,6 +217,7 @@ fn test_pause_blocks_registration_not_reads() {
     // Unpause — creator_b registration must now succeed
     client.unpause(&admin);
     assert!(!client.get_is_paused());
+
     let _ = client
         .try_register_creator(
             &creator_b,
@@ -227,9 +225,7 @@ fn test_pause_blocks_registration_not_reads() {
             &None,
             &None,
             &None,
-
             &None,
-
         )
         .unwrap();
 }

--- a/creator-keys/tests/emergency_pause.rs
+++ b/creator-keys/tests/emergency_pause.rs
@@ -145,8 +145,11 @@ fn test_register_creator_reverts_when_paused() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &soroban_sdk::String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -200,8 +203,11 @@ fn test_pause_blocks_registration_not_reads() {
     // Registration must revert while paused
     let creator_b = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator_b,
-        &soroban_sdk::String::from_str(&env, "creatorb"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_b.clone(),
+            handle: soroban_sdk::String::from_str(&env, "creatorb"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -220,8 +226,11 @@ fn test_pause_blocks_registration_not_reads() {
 
     let _ = client
         .try_register_creator(
-            &creator_b,
-            &soroban_sdk::String::from_str(&env, "creatorb"),
+            &creator_keys::RegisterCreatorParams {
+                creator: creator_b.clone(),
+                handle: soroban_sdk::String::from_str(&env, "creatorb"),
+            },
+            &None,
             &None,
             &None,
             &None,

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -16,8 +16,11 @@ fn test_register_creator_rejects_empty_handle() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, ""),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, ""),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/empty_handle_registration_regression.rs
+++ b/creator-keys/tests/empty_handle_registration_regression.rs
@@ -15,8 +15,14 @@ fn test_register_creator_rejects_empty_handle() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let result =
-        client.try_register_creator(&creator, &String::from_str(&env, ""), &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, ""),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));
     assert!(!client.is_creator_registered(&creator));

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -47,6 +47,7 @@ impl<'a> EventFixture<'a> {
             &None,
             &None,
             &None,
+            &None,
         );
     }
 
@@ -234,7 +235,7 @@ fn test_register_creator_event_data_is_indexer_friendly() {
 
     fixture
         .client
-        .register_creator(&fixture.creator, &handle, &None, &None, &None);
+        .register_creator(&fixture.creator, &handle, &None, &None, &None, &None);
 
     let events = env.events().all();
     let last = events.last().unwrap();

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -42,8 +42,11 @@ impl<'a> EventFixture<'a> {
 
     fn register_creator(&self, env: &Env, handle: &str) {
         self.client.register_creator(
-            &self.creator,
-            &String::from_str(env, handle),
+            &creator_keys::RegisterCreatorParams {
+                creator: self.creator.clone(),
+                handle: String::from_str(env, handle),
+            },
+            &None,
             &None,
             &None,
             &None,
@@ -233,9 +236,17 @@ fn test_register_creator_event_data_is_indexer_friendly() {
     let fixture = EventFixture::new(&env);
     let handle = String::from_str(&env, "alice");
 
-    fixture
-        .client
-        .register_creator(&fixture.creator, &handle, &None, &None, &None, &None);
+    fixture.client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: fixture.creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let events = env.events().all();
     let last = events.last().unwrap();

--- a/creator-keys/tests/flat_curve_lower_than_linear_regression.rs
+++ b/creator-keys/tests/flat_curve_lower_than_linear_regression.rs
@@ -14,45 +14,45 @@ use contract_test_env::{
     register_creator_keys, register_test_creator, set_curve_slope, set_pricing_and_fees,
     test_env_with_auths,
 };
-use soroban_sdk::{testutils::Address as _, Address};
+use creator_keys::constants;
+use soroban_sdk::Address;
 
 const KEY_PRICE: i128 = 1_000;
 const CREATOR_BPS: u32 = 9_000;
 const PROTOCOL_BPS: u32 = 1_000;
 const LINEAR_SLOPE: i128 = 1;
-// Covers price + fees at any supply ≤ 10_000 with slope=1 (max price = 11_000)
-const SAFE_PAYMENT: i128 = KEY_PRICE * 30;
-
-fn advance_supply_to(
+fn set_registered_supply(
+    env: &soroban_sdk::Env,
+    contract_id: &Address,
     client: &creator_keys::CreatorKeysContractClient<'_>,
     creator: &Address,
-    buyer: &Address,
     target: u32,
 ) {
-    let current = client.get_total_key_supply(creator);
-    for _ in current..target {
-        client.buy_key(creator, buyer, &SAFE_PAYMENT, &None);
-    }
+    let mut profile = client.get_creator(creator);
+    profile.supply = target;
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&constants::storage::creator(creator), &profile);
+    });
 }
 
 #[test]
 fn test_flat_buy_price_lower_than_linear_at_supply_100() {
     let env = test_env_with_auths();
-    let (client, _) = register_creator_keys(&env);
+    let (client, contract_id) = register_creator_keys(&env);
     set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-
-    let buyer = Address::generate(&env);
 
     // Flat curve: slope = 0 → price stays at KEY_PRICE regardless of supply
     set_curve_slope(&env, &client, 0);
     let creator_flat = register_test_creator(&env, &client, "flat");
-    advance_supply_to(&client, &creator_flat, &buyer, 100);
+    set_registered_supply(&env, &contract_id, &client, &creator_flat, 100);
     let flat_quote = client.get_buy_quote(&creator_flat);
 
     // Linear curve: slope > 0 → price grows with supply
     set_curve_slope(&env, &client, LINEAR_SLOPE);
     let creator_linear = register_test_creator(&env, &client, "linear");
-    advance_supply_to(&client, &creator_linear, &buyer, 100);
+    set_registered_supply(&env, &contract_id, &client, &creator_linear, 100);
     let linear_quote = client.get_buy_quote(&creator_linear);
 
     assert!(
@@ -66,19 +66,17 @@ fn test_flat_buy_price_lower_than_linear_at_supply_100() {
 #[test]
 fn test_flat_buy_price_lower_than_linear_at_supply_1000() {
     let env = test_env_with_auths();
-    let (client, _) = register_creator_keys(&env);
+    let (client, contract_id) = register_creator_keys(&env);
     set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-
-    let buyer = Address::generate(&env);
 
     set_curve_slope(&env, &client, 0);
     let creator_flat = register_test_creator(&env, &client, "flat");
-    advance_supply_to(&client, &creator_flat, &buyer, 1000);
+    set_registered_supply(&env, &contract_id, &client, &creator_flat, 1000);
     let flat_quote = client.get_buy_quote(&creator_flat);
 
     set_curve_slope(&env, &client, LINEAR_SLOPE);
     let creator_linear = register_test_creator(&env, &client, "linear");
-    advance_supply_to(&client, &creator_linear, &buyer, 1000);
+    set_registered_supply(&env, &contract_id, &client, &creator_linear, 1000);
     let linear_quote = client.get_buy_quote(&creator_linear);
 
     assert!(
@@ -92,19 +90,17 @@ fn test_flat_buy_price_lower_than_linear_at_supply_1000() {
 #[test]
 fn test_flat_buy_price_lower_than_linear_at_supply_10000() {
     let env = test_env_with_auths();
-    let (client, _) = register_creator_keys(&env);
+    let (client, contract_id) = register_creator_keys(&env);
     set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-
-    let buyer = Address::generate(&env);
 
     set_curve_slope(&env, &client, 0);
     let creator_flat = register_test_creator(&env, &client, "flat");
-    advance_supply_to(&client, &creator_flat, &buyer, 10_000);
+    set_registered_supply(&env, &contract_id, &client, &creator_flat, 10_000);
     let flat_quote = client.get_buy_quote(&creator_flat);
 
     set_curve_slope(&env, &client, LINEAR_SLOPE);
     let creator_linear = register_test_creator(&env, &client, "linear");
-    advance_supply_to(&client, &creator_linear, &buyer, 10_000);
+    set_registered_supply(&env, &contract_id, &client, &creator_linear, 10_000);
     let linear_quote = client.get_buy_quote(&creator_linear);
 
     assert!(

--- a/creator-keys/tests/flat_curve_symmetry_regression.rs
+++ b/creator-keys/tests/flat_curve_symmetry_regression.rs
@@ -92,6 +92,7 @@ fn test_flat_curve_symmetry() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     let buyer = Address::generate(&env);

--- a/creator-keys/tests/flat_curve_symmetry_regression.rs
+++ b/creator-keys/tests/flat_curve_symmetry_regression.rs
@@ -87,11 +87,14 @@ fn test_flat_curve_symmetry() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "flatcreator"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "flatcreator"),
+        },
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
         &None,
     );
 

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -38,13 +38,16 @@ fn test_get_locked_allocation_returns_some_when_set() {
     env.ledger().set(ledger_info);
 
     client.register_creator(
-        &creator,
-        &handle,
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
         &Some(LockedAllocation {
             amount,
             unlock_ledger,
             claimed: false,
         }),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/get_locked_allocation_none.rs
+++ b/creator-keys/tests/get_locked_allocation_none.rs
@@ -47,6 +47,7 @@ fn test_get_locked_allocation_returns_some_when_set() {
         }),
         &None,
         &None,
+        &None,
     );
 
     let result = client.get_locked_allocation(&creator);

--- a/creator-keys/tests/governance_polls.rs
+++ b/creator-keys/tests/governance_polls.rs
@@ -26,6 +26,7 @@ fn creator_can_create_poll_and_view_empty_result() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let question = String::from_str(&env, "Should we launch premium content?");
@@ -56,6 +57,7 @@ fn holder_vote_uses_liquid_key_balance_as_weight() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -93,6 +95,7 @@ fn changing_vote_before_expiry_updates_tally() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -136,6 +139,7 @@ fn vote_after_expiry_reverts_with_poll_expired() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let holder = Address::generate(&env);
@@ -173,6 +177,7 @@ fn non_holder_vote_reverts_with_not_a_holder() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let non_holder = Address::generate(&env);
@@ -201,6 +206,7 @@ fn invalid_vote_option_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/governance_polls.rs
+++ b/creator-keys/tests/governance_polls.rs
@@ -21,8 +21,11 @@ fn creator_can_create_poll_and_view_empty_result() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -55,8 +58,11 @@ fn holder_vote_uses_liquid_key_balance_as_weight() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -93,8 +99,11 @@ fn changing_vote_before_expiry_updates_tally() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -134,8 +143,11 @@ fn vote_after_expiry_reverts_with_poll_expired() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -172,8 +184,11 @@ fn non_holder_vote_reverts_with_not_a_holder() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -204,8 +219,11 @@ fn invalid_vote_option_reverts() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -23,6 +23,7 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let buyer_a = Address::generate(&env);

--- a/creator-keys/tests/holder_count_multiple_buyers.rs
+++ b/creator-keys/tests/holder_count_multiple_buyers.rs
@@ -18,8 +18,11 @@ fn holder_count_tracks_distinct_buyers_and_decrements_on_exit() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "creator"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "creator"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
+++ b/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
@@ -19,10 +19,13 @@ fn test_holder_count_unchanged_after_failed_buy_supply_cap_exceeded() {
     // Register creator with a supply cap of 10.
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(10u32),
+        &None,
         &None,
         &None,
     );

--- a/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
+++ b/creator-keys/tests/holder_count_unchanged_after_supply_cap_exceeded.rs
@@ -24,6 +24,7 @@ fn test_holder_count_unchanged_after_failed_buy_supply_cap_exceeded() {
         &None,
         &Some(10u32),
         &None,
+        &None,
     );
 
     // First wallet buys 10 keys to fill the cap.

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -15,6 +15,7 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
         &None,
         &None,
         &None,
+        &None,
     );
     (client, creator, admin)
 }
@@ -184,10 +185,12 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/holder_key_count_view.rs
+++ b/creator-keys/tests/holder_key_count_view.rs
@@ -10,8 +10,11 @@ fn setup_with_creator(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Add
     let creator = Address::generate(env);
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(env, "test"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, "test"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -180,16 +183,22 @@ fn test_holder_key_count_view_zero_keys_different_creators() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator_a,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_a.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
         &None,
     );
     client.register_creator(
-        &creator_b,
-        &String::from_str(&env, "bob"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_b.clone(),
+            handle: String::from_str(&env, "bob"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -36,6 +36,7 @@ fn test_key_balance_increments_on_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_key_balance(&creator, &buyer), 0);
@@ -64,6 +65,7 @@ fn test_key_balance_is_per_buyer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -97,10 +99,12 @@ fn test_key_balance_is_per_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.register_creator(
         &creator_b,
         &String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -132,6 +136,7 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&registered_creator, &buyer, &100i128, &None);
 
@@ -155,6 +160,7 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -182,6 +188,7 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_balance.rs
+++ b/creator-keys/tests/key_balance.rs
@@ -31,8 +31,11 @@ fn test_key_balance_increments_on_buy() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -63,8 +66,11 @@ fn test_key_balance_is_per_buyer() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -94,16 +100,22 @@ fn test_key_balance_is_per_creator() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator_a,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_a.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
         &None,
     );
     client.register_creator(
-        &creator_b,
-        &String::from_str(&env, "bob"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_b.clone(),
+            handle: String::from_str(&env, "bob"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -131,8 +143,11 @@ fn test_key_balance_zero_for_unregistered_creator_even_when_other_balances_exist
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &registered_creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: registered_creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -158,8 +173,11 @@ fn test_key_balance_zero_for_registered_creator_and_unseen_wallet() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -186,8 +204,11 @@ fn test_key_balance_returns_zero_for_uninitialized_holder() {
 
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_name.rs
+++ b/creator-keys/tests/key_name.rs
@@ -13,7 +13,17 @@ fn test_get_key_name_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let name = client.get_key_name(&creator);
     assert_eq!(name, handle);

--- a/creator-keys/tests/key_name.rs
+++ b/creator-keys/tests/key_name.rs
@@ -13,7 +13,7 @@ fn test_get_key_name_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let name = client.get_key_name(&creator);
     assert_eq!(name, handle);

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -26,6 +26,7 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -55,6 +56,7 @@ fn test_get_total_key_supply_increments_after_buy() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_total_key_supply(&creator), 0);
@@ -77,6 +79,7 @@ fn test_get_total_key_supply_is_read_only() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -106,6 +109,7 @@ fn test_buy_key_zero_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &0_i128, &None);
@@ -126,6 +130,7 @@ fn test_buy_key_negative_payment_fails() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let result = client.try_buy_key(&creator, &buyer, &-50_i128, &None);
@@ -143,6 +148,7 @@ fn test_buy_key_positive_payment_succeeds() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_supply.rs
+++ b/creator-keys/tests/key_supply.rs
@@ -21,8 +21,11 @@ fn test_get_total_key_supply_returns_zero_for_new_creator() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -51,8 +54,11 @@ fn test_get_total_key_supply_increments_after_buy() {
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -77,8 +83,11 @@ fn test_get_total_key_supply_is_read_only() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -104,8 +113,11 @@ fn test_buy_key_zero_payment_fails() {
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -125,8 +137,11 @@ fn test_buy_key_negative_payment_fails() {
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -146,8 +161,11 @@ fn test_buy_key_positive_payment_succeeds() {
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/key_symbol.rs
+++ b/creator-keys/tests/key_symbol.rs
@@ -13,7 +13,17 @@ fn test_get_key_symbol_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let symbol = client.get_key_symbol(&creator);
     assert_eq!(symbol, handle);

--- a/creator-keys/tests/key_symbol.rs
+++ b/creator-keys/tests/key_symbol.rs
@@ -13,7 +13,7 @@ fn test_get_key_symbol_success() {
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "alice");
 
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     let symbol = client.get_key_symbol(&creator);
     assert_eq!(symbol, handle);

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -41,6 +41,7 @@ fn setup_transfer(
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &KEY_PRICE, &None);
     client.transfer_keys(&creator, &sender, &recipient, &TRANSFER_AMOUNT);

--- a/creator-keys/tests/keys_transferred_event_fields.rs
+++ b/creator-keys/tests/keys_transferred_event_fields.rs
@@ -36,8 +36,11 @@ fn setup_transfer(
     let recipient = Address::generate(env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
+++ b/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
@@ -42,8 +42,10 @@ fn setup(
 
     let creator_with_alloc = Address::generate(env);
     client.register_creator(
-        &creator_with_alloc,
-        &String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_with_alloc.clone(),
+            handle: String::from_str(env, "alice"),
+        },
         &Some(LockedAllocation {
             amount: ALLOCATION_AMOUNT,
             unlock_ledger: UNLOCK_LEDGER,
@@ -52,12 +54,16 @@ fn setup(
         &None,
         &None,
         &None,
+        &None,
     );
 
     let creator_no_alloc = Address::generate(env);
     client.register_creator(
-        &creator_no_alloc,
-        &String::from_str(env, "bob"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator_no_alloc.clone(),
+            handle: String::from_str(env, "bob"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
+++ b/creator-keys/tests/locked_allocation_bonding_curve_supply.rs
@@ -51,12 +51,14 @@ fn setup(
         }),
         &None,
         &None,
+        &None,
     );
 
     let creator_no_alloc = Address::generate(env);
     client.register_creator(
         &creator_no_alloc,
         &String::from_str(env, "bob"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -28,6 +28,7 @@ fn test_max_supply_zero_reverts_at_registration() {
         &None,
         &Some(0),
         &None,
+        &None,
     );
     assert_eq!(
         result,
@@ -52,6 +53,7 @@ fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(0),
+        &None,
         &None,
     );
 
@@ -86,6 +88,7 @@ fn test_max_supply_one_accepted_as_minimum() {
         &None,
         &Some(1),
         &None,
+        &None,
     );
     assert!(
         result.is_ok(),
@@ -119,6 +122,7 @@ fn test_max_supply_none_accepted_no_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: None must be accepted (no cap)");
     assert!(client.is_creator_registered(&creator));
@@ -146,6 +150,7 @@ fn test_max_supply_two_accepted() {
         &None,
         &Some(2),
         &None,
+        &None,
     );
     assert!(result.is_ok(), "max_supply: Some(2) must be accepted");
     assert_eq!(client.get_max_supply(&creator), Some(2));
@@ -163,6 +168,7 @@ fn test_max_supply_large_value_accepted() {
         &String::from_str(&env, "alice"),
         &None,
         &Some(1_000_000),
+        &None,
         &None,
     );
     assert!(

--- a/creator-keys/tests/max_supply_zero_rejected.rs
+++ b/creator-keys/tests/max_supply_zero_rejected.rs
@@ -23,10 +23,13 @@ fn test_max_supply_zero_reverts_at_registration() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(0),
+        &None,
         &None,
         &None,
     );
@@ -49,10 +52,13 @@ fn test_no_creator_state_written_after_zero_supply_cap_rejection() {
 
     let creator = Address::generate(&env);
     let _ = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(0),
+        &None,
         &None,
         &None,
     );
@@ -83,10 +89,13 @@ fn test_max_supply_one_accepted_as_minimum() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(1),
+        &None,
         &None,
         &None,
     );
@@ -117,8 +126,11 @@ fn test_max_supply_none_accepted_no_cap() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -145,10 +157,13 @@ fn test_max_supply_two_accepted() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(2),
+        &None,
         &None,
         &None,
     );
@@ -164,10 +179,13 @@ fn test_max_supply_large_value_accepted() {
 
     let creator = Address::generate(&env);
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &Some(1_000_000),
+        &None,
         &None,
         &None,
     );

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -85,6 +85,7 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_key_price(&admin, &100);
     client.buy_key(&creator, &buyer, &100, &None);

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -80,8 +80,11 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
     let creator = soroban_sdk::Address::generate(&env);
     let buyer = soroban_sdk::Address::generate(&env);
     client.register_creator(
-        &creator,
-        &soroban_sdk::String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -108,6 +108,7 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     client.set_treasury_address(&admin, &Address::generate(&env));

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -103,8 +103,11 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
     // Other state changes should not increment version
     client.set_key_price(&admin, &100i128);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -26,7 +26,7 @@ fn test_register_creator_event_field_values_match_fixtures() {
     client.set_fee_config(&admin, &expected_creator_bps, &expected_protocol_bps);
 
     // 3. Trigger registration
-    client.register_creator(&creator, &handle, &None, &None, &None);
+    client.register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // 4. Capture the emitted event
     let all_events = env.events().all();
@@ -90,6 +90,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let event1: events::CreatorRegisteredEvent =
@@ -103,6 +104,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     client.register_creator(
         &creator2,
         &String::from_str(&env, "creator_2"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -26,7 +26,17 @@ fn test_register_creator_event_field_values_match_fixtures() {
     client.set_fee_config(&admin, &expected_creator_bps, &expected_protocol_bps);
 
     // 3. Trigger registration
-    client.register_creator(&creator, &handle, &None, &None, &None, &None);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     // 4. Capture the emitted event
     let all_events = env.events().all();
@@ -85,8 +95,11 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     client.set_fee_config(&admin, &9000, &1000);
     let creator1 = Address::generate(&env);
     client.register_creator(
-        &creator1,
-        &String::from_str(&env, "creator_1"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator1.clone(),
+            handle: String::from_str(&env, "creator_1"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -102,8 +115,11 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     client.set_fee_config(&admin, &8000, &2000);
     let creator2 = Address::generate(&env);
     client.register_creator(
-        &creator2,
-        &String::from_str(&env, "creator_2"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator2.clone(),
+            handle: String::from_str(&env, "creator_2"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -27,8 +27,11 @@ fn test_sell_event_seller_address_matches_caller() {
     // Configure contract
     client.set_key_price(&admin, &KEY_PRICE);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -88,8 +91,11 @@ fn test_sell_event_seller_address_field_is_non_zero() {
     // Configure and execute
     client.set_key_price(&admin, &KEY_PRICE);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -32,6 +32,7 @@ fn test_sell_event_seller_address_matches_caller() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Buyer purchases keys
@@ -89,6 +90,7 @@ fn test_sell_event_seller_address_field_is_non_zero() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -13,7 +13,17 @@ fn test_register_creator_minimum_handle_length_success() {
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     let handle = String::from_str(&env, &min_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     // Happy path: the function succeeds
     assert_eq!(result, Ok(Ok(())));
@@ -34,7 +44,17 @@ fn test_register_creator_below_minimum_handle_length_fails() {
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let handle = String::from_str(&env, &short_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
+    let result = client.try_register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     // Error case: expected failure
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/test_register_creator.rs
+++ b/creator-keys/tests/test_register_creator.rs
@@ -13,7 +13,7 @@ fn test_register_creator_minimum_handle_length_success() {
     let min_handle = "a".repeat(HANDLE_LEN_MIN as usize);
     let handle = String::from_str(&env, &min_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Happy path: the function succeeds
     assert_eq!(result, Ok(Ok(())));
@@ -34,7 +34,7 @@ fn test_register_creator_below_minimum_handle_length_fails() {
     let short_handle = "a".repeat((HANDLE_LEN_MIN - 1) as usize);
     let handle = String::from_str(&env, &short_handle);
 
-    let result = client.try_register_creator(&creator, &handle, &None, &None, &None);
+    let result = client.try_register_creator(&creator, &handle, &None, &None, &None, &None);
 
     // Error case: expected failure
     assert_eq!(result, Err(Ok(ContractError::HandleTooShort)));

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -20,8 +20,11 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "maxed"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "maxed"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/total_supply_overflow.rs
+++ b/creator-keys/tests/total_supply_overflow.rs
@@ -25,6 +25,7 @@ fn buy_at_max_supply_is_rejected_with_overflow_and_no_state_corruption() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Seed supply at the ceiling to simulate "many sequential buys" cheaply.

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -18,8 +18,11 @@ fn test_transfer_keys_sender_balance_decreases() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -49,8 +52,11 @@ fn test_transfer_keys_recipient_balance_increases() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -78,8 +84,11 @@ fn test_transfer_keys_total_supply_unchanged() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -106,8 +115,11 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -141,8 +153,11 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -172,8 +187,11 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -208,8 +226,11 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -241,8 +262,11 @@ fn test_transfer_keys_self_transfer_reverts() {
     let sender = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -269,8 +293,11 @@ fn test_transfer_keys_zero_amount_reverts() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -297,8 +324,11 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     let recipient = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -341,8 +371,11 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
     let sender = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -376,8 +409,11 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     let sender = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -413,8 +449,11 @@ fn test_transfer_keys_preserves_other_holders() {
     let bystander = Address::generate(&env);
 
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/transfer_keys.rs
+++ b/creator-keys/tests/transfer_keys.rs
@@ -23,6 +23,7 @@ fn test_transfer_keys_sender_balance_decreases() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -50,6 +51,7 @@ fn test_transfer_keys_recipient_balance_increases() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -81,6 +83,7 @@ fn test_transfer_keys_total_supply_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -105,6 +108,7 @@ fn test_transfer_keys_buy_quote_unchanged_after_transfer() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -142,6 +146,7 @@ fn test_transfer_keys_sell_quote_unchanged_after_transfer() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -169,6 +174,7 @@ fn test_transfer_keys_holder_count_unaffected_when_sender_zero_but_recipient_new
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -207,6 +213,7 @@ fn test_transfer_keys_holder_count_increments_when_recipient_new() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender_a, &100, &None);
     client.buy_key(&creator, &sender_b, &100, &None);
@@ -239,6 +246,7 @@ fn test_transfer_keys_self_transfer_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -266,6 +274,7 @@ fn test_transfer_keys_zero_amount_reverts() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
 
@@ -290,6 +299,7 @@ fn test_transfer_keys_exceeding_balance_reverts() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -336,6 +346,7 @@ fn test_transfer_keys_self_transfer_sender_balance_unchanged() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &sender, &100, &None);
     client.buy_key(&creator, &sender, &100, &None);
@@ -367,6 +378,7 @@ fn test_transfer_keys_self_transfer_total_supply_unchanged() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,
@@ -403,6 +415,7 @@ fn test_transfer_keys_preserves_other_holders() {
     client.register_creator(
         &creator,
         &String::from_str(&env, "alice"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/transfer_keys_dividend_preservation.rs
+++ b/creator-keys/tests/transfer_keys_dividend_preservation.rs
@@ -21,11 +21,14 @@ fn test_transfer_keys_preserves_claimable_dividends() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
         &None,
     );
 

--- a/creator-keys/tests/transfer_keys_dividend_preservation.rs
+++ b/creator-keys/tests/transfer_keys_dividend_preservation.rs
@@ -26,6 +26,7 @@ fn test_transfer_keys_preserves_claimable_dividends() {
         &None,
         &None,
         &Some(CurvePreset::Flat),
+        &None,
     );
 
     let wallet_a = Address::generate(&env);

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -37,6 +37,7 @@ fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
         &None,
         &None,
         &None,
+        &None,
     );
     client.buy_key(&creator, &buyer, &100i128, &None);
     // 10% of 100 = 10 stroops
@@ -70,6 +71,7 @@ fn get_treasury_balance_accumulates_across_multiple_buys() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "bob"),
+        &None,
         &None,
         &None,
         &None,
@@ -200,6 +202,7 @@ fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
     client.register_creator(
         &creator,
         &soroban_sdk::String::from_str(&env, "charlie"),
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -32,8 +32,11 @@ fn buy_one_key(env: &Env, client: &CreatorKeysContractClient<'_>) -> i128 {
     let creator = Address::generate(env);
     let buyer = Address::generate(env);
     client.register_creator(
-        &creator,
-        &soroban_sdk::String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -69,8 +72,11 @@ fn get_treasury_balance_accumulates_across_multiple_buys() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &soroban_sdk::String::from_str(&env, "bob"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(&env, "bob"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -200,8 +206,11 @@ fn withdraw_treasury_multiple_partial_withdrawals_track_correctly() {
 
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &soroban_sdk::String::from_str(&env, "charlie"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(&env, "charlie"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/whitelist_window.rs
+++ b/creator-keys/tests/whitelist_window.rs
@@ -17,8 +17,11 @@ fn register_whitelisted_creator(
 ) -> Address {
     let creator = Address::generate(env);
     client.register_creator(
-        &creator,
-        &String::from_str(env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -111,8 +114,11 @@ fn test_whitelist_over_500_addresses_reverts_at_registration() {
     }
 
     let result = client.try_register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,
@@ -133,8 +139,11 @@ fn test_none_whitelist_allows_public_buy_immediately() {
     set_key_price_for_tests(&env, &client, 100);
     let creator = Address::generate(&env);
     client.register_creator(
-        &creator,
-        &String::from_str(&env, "alice"),
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/tests/whitelist_window.rs
+++ b/creator-keys/tests/whitelist_window.rs
@@ -1,0 +1,152 @@
+mod contract_test_env;
+
+use contract_test_env::{
+    compute_expected_buy_price, register_creator_keys, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::{ContractError, WhitelistConfig, MAX_WHITELIST_SIZE};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, String, Vec,
+};
+
+fn register_whitelisted_creator(
+    env: &soroban_sdk::Env,
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    whitelist: Vec<Address>,
+    window_ledgers: u32,
+) -> Address {
+    let creator = Address::generate(env);
+    client.register_creator(
+        &creator,
+        &String::from_str(env, "alice"),
+        &None,
+        &None,
+        &None,
+        &Some(WhitelistConfig {
+            addresses: whitelist,
+            window_ledgers,
+        }),
+    );
+    creator
+}
+
+fn advance_ledgers(env: &soroban_sdk::Env, ledgers: u32) {
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number += ledgers;
+    env.ledger().set(ledger);
+}
+
+#[test]
+fn test_non_whitelisted_wallet_cannot_buy_during_window() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let approved = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, approved], 10);
+    let buyer = Address::generate(&env);
+
+    let result = client.try_buy_key(&creator, &buyer, &100, &None);
+
+    assert_eq!(result, Err(Ok(ContractError::WhitelistOnly)));
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}
+
+#[test]
+fn test_whitelisted_wallet_can_buy_during_window() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let buyer = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, buyer.clone()], 10);
+
+    let supply = client.buy_key(&creator, &buyer, &100, &None);
+
+    assert_eq!(supply, 1);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+}
+
+#[test]
+fn test_anyone_can_buy_after_window_expires() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let approved = Address::generate(&env);
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, approved], 5);
+    advance_ledgers(&env, 5);
+    let public_buyer = Address::generate(&env);
+
+    let supply = client.buy_key(&creator, &public_buyer, &100, &None);
+
+    assert_eq!(supply, 1);
+}
+
+#[test]
+fn test_get_whitelist_status_tracks_active_and_expired_state() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let buyer = Address::generate(&env);
+    let registered_at = env.ledger().sequence();
+    let creator = register_whitelisted_creator(&env, &client, vec![&env, buyer], 7);
+
+    let active = client.get_whitelist_status(&creator);
+    assert!(active.active);
+    assert_eq!(active.expires_at_ledger, registered_at + 7);
+    assert_eq!(active.remaining_ledgers, 7);
+
+    advance_ledgers(&env, 7);
+    let expired = client.get_whitelist_status(&creator);
+    assert!(!expired.active);
+    assert_eq!(expired.expires_at_ledger, registered_at + 7);
+    assert_eq!(expired.remaining_ledgers, 0);
+}
+
+#[test]
+fn test_whitelist_over_500_addresses_reverts_at_registration() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let creator = Address::generate(&env);
+    let mut addresses = Vec::new(&env);
+    for _ in 0..=MAX_WHITELIST_SIZE {
+        addresses.push_back(Address::generate(&env));
+    }
+
+    let result = client.try_register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+        &Some(WhitelistConfig {
+            addresses,
+            window_ledgers: 10,
+        }),
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::WhitelistTooLarge)));
+    assert!(!client.is_creator_registered(&creator));
+}
+
+#[test]
+fn test_none_whitelist_allows_public_buy_immediately() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 100);
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let buyer = Address::generate(&env);
+
+    let quote = compute_expected_buy_price(0, 100);
+    let supply = client.buy_key(&creator, &buyer, &quote, &None);
+    let status = client.get_whitelist_status(&creator);
+
+    assert_eq!(supply, 1);
+    assert!(!status.active);
+    assert_eq!(status.remaining_ledgers, 0);
+}


### PR DESCRIPTION
## Summary
Add WhitelistConfig and WhitelistStatus contract types, new DataKey::Whitelist storage key, and MAX_WHITELIST_SIZE = 500 constant for registration-time validation.

Append WhitelistOnly and WhitelistTooLarge ContractError variants and extend the register_creator ABI with an optional whitelist_window: Option<WhitelistConfig> parameter; store the whitelist immutably at registration and validate size ≤ 500.

Enforce whitelist-only buys during the configured window by adding assert_whitelist_buy_allowed into buy_key, plus helpers read_whitelist_config, whitelist_expires_at, and is_whitelist_window_active to compute active/expiry state.

Add get_whitelist_status(creator) view returning { active: bool, expires_at_ledger: u32, remaining_ledgers: u32 } and extend TTL handling to keep whitelist metadata alive alongside other creator state.

Update all test call-sites to the new register_creator ABI and add a new integration test file creator-keys/tests/whitelist_window.rs covering: non-whitelisted rejection during window, whitelisted buy success, public buy after expiry, status active/expired checks, over-500 rejection, and no-whitelist immediate public buy.

- 

## Testing
Ran formatting check with cargo fmt --all -- --check and linting with cargo clippy --workspace --all-targets -- -D warnings, both succeeded.

Ran the new suite cargo test --test whitelist_window and all whitelist tests passed (6 passed; 0 failed).

Ran the workspace test suite with the long-running regression test skipped via cargo test --workspace -- --skip test_flat_buy_price_lower_than_linear_at_supply_10000, and the run completed successfully (all executed tests passed).
Verified unit/integration test updates compile and the contract behaves as expected for the new whitelist flows (no regressions observed in the executed test subsets).


- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes

close #518