### PR TITLE
test: airdrop reverts when recipient list exceeds 50 addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -295,6 +295,42 @@ pub struct KeysTransferredEvent {
     pub ledger: u32,
 }
 
+/// Event name for creator key airdrops.
+pub const KEYS_AIRDROPPED_EVENT_NAME: Symbol = symbol_short!("airdrop");
+
+/// Stable field order for airdrop event payloads.
+pub const KEYS_AIRDROPPED_DATA_FIELDS: [&str; 5] = [
+    "creator_id",
+    "total_keys",
+    "total_cost",
+    "recipient_count",
+    "ledger",
+];
+
+/// Stable airdrop event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(KEYS_AIRDROPPED_EVENT_NAME, creator_id)`
+/// - data: `KeysAirdroppedEvent`
+///
+/// `total_cost` is the full amount charged to the creator (curve cost plus
+/// protocol fee) and `ledger` is the Soroban ledger sequence number at airdrop
+/// time so off-chain indexers can reconstruct the timeline.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct KeysAirdroppedEvent {
+    pub creator_id: Address,
+    pub total_keys: u32,
+    pub total_cost: i128,
+    pub recipient_count: u32,
+    pub ledger: u32,
+}
+
+/// Shared airdrop event topics tuple.
+pub fn keys_airdropped_topics(creator: &Address) -> (Symbol, Address) {
+    (KEYS_AIRDROPPED_EVENT_NAME, creator.clone())
+}
+
 /// Event name for treasury withdrawal by the protocol admin.
 pub const TREASURY_WITHDRAWAL_EVENT_NAME: Symbol = symbol_short!("treas_out");
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -79,6 +79,7 @@ pub enum ContractError {
     InvalidCoCreatorShare = 30,
     WhitelistOnly = 31,
     WhitelistTooLarge = 32,
+    AirdropRecipientLimitExceeded = 33,
 }
 
 pub mod fee {
@@ -489,6 +490,13 @@ pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
 pub const MAX_WHITELIST_SIZE: u32 = 500;
 
+/// Maximum number of recipient entries accepted by a single
+/// [`CreatorKeysContract::airdrop_keys`] call.
+///
+/// Larger lists revert with [`ContractError::AirdropRecipientLimitExceeded`]
+/// so a single airdrop cannot grow unbounded in storage writes.
+pub const MAX_AIRDROP_RECIPIENTS: u32 = 50;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum CurvePreset {
@@ -601,6 +609,27 @@ pub struct CreatorProfile {
 pub struct ClaimResult {
     pub creator: Address,
     pub amount_claimed: i128,
+}
+
+/// One recipient of a creator key airdrop: the wallet to credit and how many
+/// keys it receives.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AirdropEntry {
+    pub address: Address,
+    pub amount: u32,
+}
+
+/// Result of a successful [`CreatorKeysContract::airdrop_keys`] call.
+///
+/// `total_cost` is the full amount charged to the creator: the bonding curve
+/// cost for every minted key plus the protocol fee on that cost.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AirdropSummary {
+    pub total_keys: u32,
+    pub total_cost: i128,
+    pub recipient_count: u32,
 }
 
 fn validate_whitelist_config(config: &WhitelistConfig) -> Result<(), ContractError> {
@@ -1657,6 +1686,151 @@ impl CreatorKeysContract {
         );
 
         Ok(profile.supply)
+    }
+
+    /// Creator-only airdrop that mints keys to a list of recipient wallets.
+    ///
+    /// The creator pays the bonding curve cost for every key across all
+    /// recipients plus the protocol fee on that total; the creator fee is
+    /// waived (the creator cannot pay themselves a fee). Supply increases by
+    /// the total airdropped amount, moving the curve exactly as if the keys
+    /// had been bought one by one.
+    ///
+    /// At most [`MAX_AIRDROP_RECIPIENTS`] recipient entries are accepted per
+    /// call. All recipients are credited atomically: if any validation fails,
+    /// no keys are minted.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::Unauthorized`] if `caller` is not `creator`.
+    /// - [`ContractError::AirdropRecipientLimitExceeded`] if `recipients`
+    ///   holds more than [`MAX_AIRDROP_RECIPIENTS`] entries.
+    /// - [`ContractError::NotPositiveAmount`] if `recipients` is empty, an
+    ///   entry's `amount` is zero, or `payment` is not positive.
+    /// - [`ContractError::NotRegistered`] if the creator is not registered.
+    /// - [`ContractError::KeyPriceNotSet`] if no key price is configured.
+    /// - [`ContractError::SupplyCapExceeded`] if minting would push supply
+    ///   over the creator's max supply cap.
+    /// - [`ContractError::InsufficientPayment`] if `payment` does not cover
+    ///   the total curve cost plus protocol fee.
+    pub fn airdrop_keys(
+        env: Env,
+        creator: Address,
+        caller: Address,
+        recipients: Vec<AirdropEntry>,
+        payment: i128,
+    ) -> Result<AirdropSummary, ContractError> {
+        caller.require_auth();
+        assert_not_paused(&env)?;
+
+        if caller != creator {
+            return Err(ContractError::Unauthorized);
+        }
+        if recipients.len() > MAX_AIRDROP_RECIPIENTS {
+            return Err(ContractError::AirdropRecipientLimitExceeded);
+        }
+        if recipients.is_empty() || payment <= 0 {
+            return Err(ContractError::NotPositiveAmount);
+        }
+
+        let base_price: i128 = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::KEY_PRICE)
+            .ok_or(ContractError::KeyPriceNotSet)?;
+        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+        let max_supply = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u32>(&constants::storage::max_supply(&creator));
+
+        // First pass: validate every entry and price the whole airdrop before
+        // any storage write, so a failing call cannot leave partial state.
+        let mut new_supply = profile.supply;
+        let mut total_keys: u32 = 0;
+        let mut total_cost: i128 = 0;
+        for entry in recipients.iter() {
+            if entry.amount == 0 {
+                return Err(ContractError::NotPositiveAmount);
+            }
+            for _ in 0..entry.amount {
+                if let Some(cap) = max_supply {
+                    if new_supply >= cap {
+                        return Err(ContractError::SupplyCapExceeded);
+                    }
+                }
+                let price = compute_bonding_curve_price(&env, &creator, base_price, new_supply)?;
+                total_cost = total_cost
+                    .checked_add(price)
+                    .ok_or(ContractError::Overflow)?;
+                new_supply = new_supply.checked_add(1).ok_or(ContractError::Overflow)?;
+                total_keys = total_keys.checked_add(1).ok_or(ContractError::Overflow)?;
+            }
+        }
+
+        let mut protocol_fee: i128 = 0;
+        if let Some(config) = read_protocol_fee_config(&env) {
+            protocol_fee = fee::apply_percentage_fee(total_cost, config.protocol_bps)
+                .ok_or(ContractError::Overflow)?;
+        }
+        let required_payment = total_cost
+            .checked_add(protocol_fee)
+            .ok_or(ContractError::Overflow)?;
+        if payment < required_payment {
+            return Err(ContractError::InsufficientPayment);
+        }
+
+        // Second pass: credit balances. Entries are applied sequentially so a
+        // wallet listed twice accumulates both amounts and is counted as a new
+        // holder at most once.
+        for entry in recipients.iter() {
+            let balance_key = constants::storage::key_balance(&creator, &entry.address);
+            let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+
+            // Settle dividends before balance changes so earnings are captured at old balance.
+            settle_holder_dividends(&env, &creator, &entry.address, current_balance)?;
+
+            if current_balance == 0 {
+                profile.holder_count = profile
+                    .holder_count
+                    .checked_add(1)
+                    .ok_or(ContractError::Overflow)?;
+            }
+            let new_balance = current_balance
+                .checked_add(entry.amount)
+                .ok_or(ContractError::Overflow)?;
+            env.storage().persistent().set(&balance_key, &new_balance);
+        }
+
+        profile.supply = new_supply;
+        let key = constants::storage::creator(&creator);
+        env.storage().persistent().set(&key, &profile);
+
+        if protocol_fee > 0 {
+            credit_protocol_fee_recipient_balance(&env, protocol_fee)?;
+            credit_treasury_balance(&env, protocol_fee)?;
+        }
+
+        let summary = AirdropSummary {
+            total_keys,
+            total_cost: required_payment,
+            recipient_count: recipients.len(),
+        };
+
+        env.events().publish(
+            events::keys_airdropped_topics(&creator),
+            events::KeysAirdroppedEvent {
+                creator_id: creator.clone(),
+                total_keys: summary.total_keys,
+                total_cost: summary.total_cost,
+                recipient_count: summary.recipient_count,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        extend_creator_ttl(&env, &creator);
+
+        Ok(summary)
     }
 
     /// Halts all state-changing operations (buy, sell, register_creator).

--- a/creator-keys/tests/airdrop_recipient_limit.rs
+++ b/creator-keys/tests/airdrop_recipient_limit.rs
@@ -1,0 +1,155 @@
+//! Tests for the `airdrop_keys` recipient limit (issue #537).
+//!
+//! The airdrop entrypoint accepts at most [`MAX_AIRDROP_RECIPIENTS`] (50)
+//! recipient entries per call. These tests pin the boundary behavior:
+//! 51 entries revert with a clear error and mint nothing, while exactly 50
+//! entries succeed and credit every recipient.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+    DEFAULT_CREATOR_BPS, DEFAULT_PROTOCOL_BPS,
+};
+use creator_keys::{AirdropEntry, ContractError, MAX_AIRDROP_RECIPIENTS};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+const KEY_PRICE: i128 = 100;
+const KEYS_PER_RECIPIENT: u32 = 1;
+
+/// Builds `count` airdrop entries, each minting one key to a fresh wallet.
+fn airdrop_entries(env: &Env, count: u32) -> Vec<AirdropEntry> {
+    let mut entries = Vec::new(env);
+    for _ in 0..count {
+        entries.push_back(AirdropEntry {
+            address: Address::generate(env),
+            amount: KEYS_PER_RECIPIENT,
+        });
+    }
+    entries
+}
+
+/// Expected creator payment for `key_count` keys under the default flat curve:
+/// curve cost plus the protocol fee on that cost.
+fn expected_airdrop_payment(key_count: u32) -> i128 {
+    let curve_cost = KEY_PRICE * i128::from(key_count);
+    let protocol_fee = (curve_cost * i128::from(DEFAULT_PROTOCOL_BPS)) / 10_000;
+    curve_cost + protocol_fee
+}
+
+#[test]
+fn test_airdrop_over_limit_reverts_with_clear_error() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(
+        &env,
+        &client,
+        KEY_PRICE,
+        DEFAULT_CREATOR_BPS,
+        DEFAULT_PROTOCOL_BPS,
+    );
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let over_limit = MAX_AIRDROP_RECIPIENTS + 1;
+    let entries = airdrop_entries(&env, over_limit);
+    let payment = expected_airdrop_payment(over_limit);
+
+    let result = client.try_airdrop_keys(&creator, &creator, &entries, &payment);
+
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::AirdropRecipientLimitExceeded)),
+        "51 recipients must revert with AirdropRecipientLimitExceeded"
+    );
+}
+
+#[test]
+fn test_airdrop_at_limit_succeeds_and_credits_every_recipient() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(
+        &env,
+        &client,
+        KEY_PRICE,
+        DEFAULT_CREATOR_BPS,
+        DEFAULT_PROTOCOL_BPS,
+    );
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let entries = airdrop_entries(&env, MAX_AIRDROP_RECIPIENTS);
+    let payment = expected_airdrop_payment(MAX_AIRDROP_RECIPIENTS);
+
+    let summary = client.airdrop_keys(&creator, &creator, &entries, &payment);
+
+    assert_eq!(summary.total_keys, MAX_AIRDROP_RECIPIENTS);
+    assert_eq!(summary.recipient_count, MAX_AIRDROP_RECIPIENTS);
+    assert_eq!(summary.total_cost, payment);
+    assert_eq!(
+        client.get_total_key_supply(&creator),
+        MAX_AIRDROP_RECIPIENTS,
+        "supply must grow by the total airdropped amount"
+    );
+    assert_eq!(
+        client.get_creator_holder_count(&creator),
+        MAX_AIRDROP_RECIPIENTS,
+        "each recipient is a new holder"
+    );
+    for entry in entries.iter() {
+        assert_eq!(
+            client.get_key_balance(&creator, &entry.address),
+            KEYS_PER_RECIPIENT,
+            "every recipient at the limit must be credited"
+        );
+    }
+}
+
+#[test]
+fn test_failed_over_limit_airdrop_mints_nothing() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(
+        &env,
+        &client,
+        KEY_PRICE,
+        DEFAULT_CREATOR_BPS,
+        DEFAULT_PROTOCOL_BPS,
+    );
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // Seed non-trivial state so "unchanged" is distinguishable from "empty".
+    let existing_holder = Address::generate(&env);
+    client.buy_key(&creator, &existing_holder, &KEY_PRICE, &None);
+    let supply_before = client.get_total_key_supply(&creator);
+    let holder_count_before = client.get_creator_holder_count(&creator);
+    let protocol_balance_before = client.get_protocol_recipient_balance();
+
+    let over_limit = MAX_AIRDROP_RECIPIENTS + 1;
+    let entries = airdrop_entries(&env, over_limit);
+    let payment = expected_airdrop_payment(over_limit);
+
+    let result = client.try_airdrop_keys(&creator, &creator, &entries, &payment);
+    assert!(result.is_err(), "over-limit airdrop must revert");
+
+    assert_eq!(
+        client.get_total_key_supply(&creator),
+        supply_before,
+        "supply must not change after a failed airdrop"
+    );
+    assert_eq!(
+        client.get_creator_holder_count(&creator),
+        holder_count_before,
+        "holder count must not change after a failed airdrop"
+    );
+    assert_eq!(
+        client.get_protocol_recipient_balance(),
+        protocol_balance_before,
+        "no protocol fee may accrue from a failed airdrop"
+    );
+    for entry in entries.iter() {
+        assert_eq!(
+            client.get_key_balance(&creator, &entry.address),
+            0,
+            "no keys may be minted to any recipient after a failed airdrop"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Closes #537.

The airdrop entrypoint did not exist yet (tracked in #523), so this PR first adds `airdrop_keys` and then the boundary tests #537 asks for.

### `airdrop_keys` (prerequisite, per #523 spec)
- Creator-only: mints keys to a list of `AirdropEntry { address, amount }` recipients; non-creator callers revert with `Unauthorized`
- Creator pays the bonding curve cost for every key plus the protocol fee on the total; creator fee is waived
- Supply increases by the total airdropped amount, moving the curve exactly as individual buys would
- Max 50 recipients per call (`MAX_AIRDROP_RECIPIENTS`); larger lists revert with the new `AirdropRecipientLimitExceeded` error (appended at the end of the enum, ABI-safe)
- The whole airdrop is priced and validated before any storage write, so a failed call mints nothing
- Emits `KeysAirdropped { creator_id, total_keys, total_cost, recipient_count, ledger }` and returns `AirdropSummary { total_keys, total_cost, recipient_count }`

### Tests (`creator-keys/tests/airdrop_recipient_limit.rs`)
- **51 recipients reverts with clear error** — asserts `AirdropRecipientLimitExceeded`
- **50 recipients succeeds** — summary fields, supply, holder count, and every recipient balance verified
- **No state change after failed airdrop** — seeds non-trivial state first, then asserts supply, holder count, protocol fee balance, and all 51 recipient balances are untouched after the revert

### Build fix
`ethnum` 1.5.2 fails to compile on current stable rustc (1.97); bumped to 1.5.3 in `Cargo.lock` (no other dependency changes).

## Verification
- `cargo test --workspace` — all 120 test targets pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean