### PR TITLE
test(governance-polls): verify vote change updates tally without double counting

### DIFF
--- a/creator-keys/tests/governance_polls.rs
+++ b/creator-keys/tests/governance_polls.rs
@@ -132,6 +132,56 @@ fn changing_vote_before_expiry_updates_tally() {
 }
 
 #[test]
+fn changing_vote_before_expiry_removes_previous_weight_without_double_counting() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_key_price(&admin, &100);
+
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "alice"),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let holder = Address::generate(&env);
+    for _ in 0..10 {
+        client.buy_key(&creator, &holder, &100, &None);
+    }
+
+    let poll_id = client.create_poll(
+        &creator,
+        &String::from_str(&env, "Pick one"),
+        &poll_options(&env),
+        &10,
+    );
+
+    client.cast_vote(&creator, &holder, &poll_id, &0);
+
+    let after_first_vote = client.get_poll_result(&creator, &poll_id);
+    assert_eq!(after_first_vote.vote_counts.get(0).unwrap(), 10);
+    assert_eq!(after_first_vote.vote_counts.get(1).unwrap(), 0);
+    assert_eq!(after_first_vote.total_weight, 10);
+
+    client.cast_vote(&creator, &holder, &poll_id, &1);
+
+    let after_revote = client.get_poll_result(&creator, &poll_id);
+    assert_eq!(after_revote.vote_counts.get(0).unwrap(), 0);
+    assert_eq!(after_revote.vote_counts.get(1).unwrap(), 10);
+    assert_eq!(after_revote.total_weight, 10);
+}
+
+#[test]
 fn vote_after_expiry_reverts_with_poll_expired() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION

Add a regression test covering a holder who changes their vote before a poll
expires. Wallet A votes option 0 with 10 keys, then switches to option 1.
Asserts option 0 tally decrements by 10, option 1 increments by 10, and total
vote weight stays unchanged, confirming the previous weight is removed rather
than double-counted.

## Summary

- Add `changing_vote_before_expiry_removes_previous_weight_without_double_counting`
  to `creator-keys/tests/governance_polls.rs`
- Buys 10 keys for a single holder, casts a vote for option 0, then re-votes for
  option 1
- Verifies the intermediate tally (option 0 = 10, total = 10), then the final
  tally (option 0 = 0, option 1 = 10, total = 10), proving weight moves rather
  than accumulates
- Test-only change; no contract logic, storage, or event schema touched

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note — _N/A, no storage changes_
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan — _N/A, no event changes_
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow — _N/A, test-only change_
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
Closes #539