### PR TITLE
test: add integration test for buy transaction reverting on insuffici…

### DIFF
--- a/creator-keys/tests/buy_insufficient_xlm_revert.rs
+++ b/creator-keys/tests/buy_insufficient_xlm_revert.rs
@@ -1,0 +1,41 @@
+//! Integration test for buy transaction reverting when buyer sends insufficient XLM / attached amount < current price.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    capture_snapshot, compute_expected_buy_price, register_creator_keys, register_test_creator,
+    set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address};
+
+#[test]
+fn test_buy_key_insufficient_xlm_reverts_without_state_mutation() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let base_price = 100i128;
+    set_key_price_for_tests(&env, &client, base_price);
+
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
+
+    let current_price = compute_expected_buy_price(0, base_price);
+    let insufficient_amount = current_price - 1;
+
+    let snapshot_before = capture_snapshot(&client, &creator, &buyer);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 0);
+
+    // Invoke buy with attached amount 1 stroop below the current price
+    let result = client.try_buy_key(&creator, &buyer, &insufficient_amount, &None);
+
+    // Assert transaction reverts with InsufficientPayment error code
+    assert_eq!(result, Err(Ok(ContractError::InsufficientPayment)));
+
+    // Assert creator's key supply and buyer's holdings are unchanged after revert
+    let snapshot_after = capture_snapshot(&client, &creator, &buyer);
+    snapshot_before.assert_unchanged(&snapshot_after);
+
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+    assert_eq!(client.get_key_balance(&creator, &buyer), 0);
+}


### PR DESCRIPTION
test: add integration test for buy transaction reverting on insufficient XLM (#551)

Closes #551

## Summary

- Added an integration test in `creator-keys/tests/buy_insufficient_xlm_revert.rs` to verify that `buy_key` cleanly reverts with `ContractError::InsufficientPayment` when the attached amount is 1 stroop below the current bonding curve price.
- Verified that key total supply and buyer holdings remain completely unchanged after the transaction reverts (no state mutation).

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item (#551)
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
