### PR TITLE
feat(creator-keys): emit ProtocolFeeRecipientUpdatedEvent in set_prot…

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2385,18 +2385,29 @@ impl CreatorKeysContract {
         admin.require_auth();
         validate_non_zero_address(&env, &recipient)?;
 
-        if env
+        let old_recipient: Option<Address> = env
             .storage()
             .persistent()
-            .get::<DataKey, Address>(&constants::storage::PROTOCOL_FEE_RECIPIENT)
-            .as_ref()
-            == Some(&recipient)
-        {
+            .get(&constants::storage::PROTOCOL_FEE_RECIPIENT);
+
+        if old_recipient.as_ref() == Some(&recipient) {
             return Ok(());
         }
+
         env.storage()
             .persistent()
             .set(&constants::storage::PROTOCOL_FEE_RECIPIENT, &recipient);
+
+        if let Some(old) = old_recipient {
+            env.events().publish(
+                (events::PROTOCOL_FEE_RECIPIENT_UPDATED_EVENT_NAME, admin),
+                events::ProtocolFeeRecipientUpdatedEvent {
+                    old_recipient: old,
+                    new_recipient: recipient,
+                },
+            );
+        }
+
         Ok(())
     }
 

--- a/creator-keys/tests/set_protocol_fee_recipient.rs
+++ b/creator-keys/tests/set_protocol_fee_recipient.rs
@@ -73,3 +73,45 @@ fn test_set_protocol_fee_recipient_idempotent() {
         "recipient unchanged after idempotent set"
     );
 }
+
+#[test]
+fn test_set_protocol_fee_recipient_emits_event_on_update() {
+    use creator_keys::events;
+    use soroban_sdk::{testutils::Events, IntoVal};
+
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = Address::generate(&env);
+    let old_recipient = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+
+    client.set_protocol_fee_recipient(&admin, &old_recipient);
+    client.set_protocol_fee_recipient(&admin, &new_recipient);
+
+    let all_events = env.events().all();
+    let update_events: Vec<_> = all_events
+        .iter()
+        .filter(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .map(|v| {
+                    let sym: soroban_sdk::Symbol = v.into_val(&env);
+                    sym == events::PROTOCOL_FEE_RECIPIENT_UPDATED_EVENT_NAME
+                })
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        update_events.len(),
+        1,
+        "updating fee recipient via set_protocol_fee_recipient must emit exactly one event"
+    );
+
+    let (_, _, data) = update_events.last().unwrap();
+    let payload: events::ProtocolFeeRecipientUpdatedEvent = data.into_val(&env);
+
+    assert_eq!(payload.old_recipient, old_recipient);
+    assert_eq!(payload.new_recipient, new_recipient);
+}


### PR DESCRIPTION
closes #561 
## Summary

- Implemented `ProtocolFeeRecipientUpdatedEvent` emission in `set_protocol_fee_recipient` (`creator-keys/src/lib.rs`) when an existing protocol fee recipient is updated.
- Preserved idempotency: no event is emitted if the new recipient matches the currently stored recipient.
- Added integration test `test_set_protocol_fee_recipient_emits_event_on_update` in `creator-keys/tests/set_protocol_fee_recipient.rs` to verify event name, topic index, and payload contents (`old_recipient` and `new_recipient`).

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item (Closes #561)
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes