### PR TITLE
feat: add referral fee routing, per-wallet cap, airdrop improvements,…

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -49,6 +49,9 @@ pub const TRANSFER_EVENT_NAME: Symbol = symbol_short!("transfer");
 /// Event name for creator key buyback.
 pub const BUYBACK_EVENT_NAME: Symbol = symbol_short!("buyback");
 
+/// Event name for referral fee earned.
+pub const REFERRAL_FEE_EARNED_EVENT_NAME: Symbol = symbol_short!("referral");
+
 /// Event name for governance poll creation.
 pub const POLL_CREATED_EVENT_NAME: Symbol = symbol_short!("poll_new");
 
@@ -287,6 +290,35 @@ pub fn co_creator_fee_earned_topics(
         CO_CREATOR_FEE_EARNED_EVENT_NAME,
         creator_id.clone(),
         co_creator.clone(),
+    )
+}
+
+/// Stable referral fee earned event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(REFERRAL_FEE_EARNED_EVENT_NAME, creator_id, referrer)`
+/// - data: `ReferralFeeEarnedEvent`
+///
+/// Emitted when a referrer earns a share of the protocol fee from a buy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ReferralFeeEarnedEvent {
+    pub creator_id: Address,
+    pub buyer: Address,
+    pub referrer: Address,
+    pub amount: i128,
+    pub ledger: u32,
+}
+
+/// Shared referral fee earned event topics tuple.
+pub fn referral_fee_earned_topics(
+    creator_id: &Address,
+    referrer: &Address,
+) -> (Symbol, Address, Address) {
+    (
+        REFERRAL_FEE_EARNED_EVENT_NAME,
+        creator_id.clone(),
+        referrer.clone(),
     )
 }
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -351,22 +351,22 @@ pub mod constants {
             DataKey::MaxSupply(creator.clone())
         }
 
-    pub fn max_keys_per_wallet(creator: &Address) -> DataKey {
-        DataKey::MaxKeysPerWallet(creator.clone())
-    }
+        pub fn max_keys_per_wallet(creator: &Address) -> DataKey {
+            DataKey::MaxKeysPerWallet(creator.clone())
+        }
 
-    pub fn referral_fee_bps() -> DataKey {
-        DataKey::ReferralFeeBps
-    }
+        pub fn referral_fee_bps() -> DataKey {
+            DataKey::ReferralFeeBps
+        }
 
-    pub fn discount_tiers() -> DataKey {
-        DataKey::DiscountTiers
-    }
+        pub fn discount_tiers() -> DataKey {
+            DataKey::DiscountTiers
+        }
 
-    pub fn creator_volume(creator: &Address) -> DataKey {
-        DataKey::CreatorVolume(creator.clone())
+        pub fn creator_volume(creator: &Address) -> DataKey {
+            DataKey::CreatorVolume(creator.clone())
+        }
     }
-}
 
     fn creator_key(creator: &Address) -> DataKey {
         DataKey::Creator(creator.clone())
@@ -1632,7 +1632,9 @@ impl CreatorKeysContract {
                     let referrer_new = referrer_current
                         .checked_add(referral_amount as u32)
                         .ok_or(ContractError::Overflow)?;
-                    env.storage().persistent().set(&referrer_balance_key, &referrer_new);
+                    env.storage()
+                        .persistent()
+                        .set(&referrer_balance_key, &referrer_new);
 
                     env.events().publish(
                         events::referral_fee_earned_topics(&creator, &referrer_addr),
@@ -3156,11 +3158,7 @@ impl CreatorKeysContract {
     /// Updates the referral fee basis points.
     ///
     /// Only callable by the protocol admin.
-    pub fn set_referral_fee_bps(
-        env: Env,
-        admin: Address,
-        bps: u32,
-    ) -> Result<(), ContractError> {
+    pub fn set_referral_fee_bps(env: Env, admin: Address, bps: u32) -> Result<(), ContractError> {
         admin.require_auth();
         assert_is_admin(&env, &admin)?;
         if bps > fee::BPS_MAX {

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -80,6 +80,9 @@ pub enum ContractError {
     WhitelistOnly = 31,
     WhitelistTooLarge = 32,
     AirdropRecipientLimitExceeded = 33,
+    InvalidReferrer = 34,
+    WalletCapExceeded = 35,
+    DiscountTierLimitExceeded = 36,
 }
 
 pub mod fee {
@@ -348,10 +351,22 @@ pub mod constants {
             DataKey::MaxSupply(creator.clone())
         }
 
-        pub fn max_keys_per_wallet(creator: &Address) -> DataKey {
-            DataKey::MaxKeysPerWallet(creator.clone())
-        }
+    pub fn max_keys_per_wallet(creator: &Address) -> DataKey {
+        DataKey::MaxKeysPerWallet(creator.clone())
     }
+
+    pub fn referral_fee_bps() -> DataKey {
+        DataKey::ReferralFeeBps
+    }
+
+    pub fn discount_tiers() -> DataKey {
+        DataKey::DiscountTiers
+    }
+
+    pub fn creator_volume(creator: &Address) -> DataKey {
+        DataKey::CreatorVolume(creator.clone())
+    }
+}
 
     fn creator_key(creator: &Address) -> DataKey {
         DataKey::Creator(creator.clone())
@@ -501,6 +516,12 @@ pub const MAX_WHITELIST_SIZE: u32 = 500;
 /// so a single airdrop cannot grow unbounded in storage writes.
 pub const MAX_AIRDROP_RECIPIENTS: u32 = 50;
 
+/// Default referral fee basis points (20% of protocol fee).
+pub const DEFAULT_REFERRAL_FEE_BPS: u32 = 2000;
+
+/// Maximum number of discount tiers allowed.
+pub const MAX_DISCOUNT_TIERS: u32 = 5;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum CurvePreset {
@@ -539,6 +560,9 @@ pub enum DataKey {
     CoCreatorFeeBalance(Address, Address),
     Whitelist(Address),
     MaxKeysPerWallet(Address),
+    ReferralFeeBps,
+    DiscountTiers,
+    CreatorVolume(Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -574,6 +598,16 @@ pub struct CoCreatorConfig {
 pub struct RegisterCreatorParams {
     pub creator: Address,
     pub handle: String,
+}
+
+/// Single discount tier definition.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct DiscountTier {
+    /// Volume threshold in stroops; creator must reach or exceed this cumulative volume.
+    pub threshold: i128,
+    /// Protocol fee basis points applied when threshold is met.
+    pub protocol_bps: u32,
 }
 
 /// Optional whitelist window configured at creator registration.
@@ -1470,11 +1504,28 @@ impl CreatorKeysContract {
         payment: i128,
         max_price: Option<i128>,
     ) -> Result<u32, ContractError> {
+        Self::buy_key_with_referrer(env, creator, buyer, payment, max_price, None)
+    }
+
+    pub fn buy_key_with_referrer(
+        env: Env,
+        creator: Address,
+        buyer: Address,
+        payment: i128,
+        max_price: Option<i128>,
+        referrer: Option<Address>,
+    ) -> Result<u32, ContractError> {
         buyer.require_auth();
         assert_not_paused(&env)?;
 
         if payment <= 0 {
             return Err(ContractError::NotPositiveAmount);
+        }
+
+        if let Some(referrer_addr) = referrer.as_ref() {
+            if *referrer_addr == buyer {
+                return Err(ContractError::InvalidReferrer);
+            }
         }
 
         let base_price: i128 = env
@@ -1508,6 +1559,20 @@ impl CreatorKeysContract {
         // Missing balance entries are treated as zero to keep storage sparse.
         let current_balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
 
+        // Check max keys per wallet cap
+        if let Some(cap) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u32>(&constants::storage::max_keys_per_wallet(&creator))
+        {
+            let post_buy_balance = current_balance
+                .checked_add(1)
+                .ok_or(ContractError::Overflow)?;
+            if post_buy_balance > cap {
+                return Err(ContractError::WalletCapExceeded);
+            }
+        }
+
         // Settle dividends before balance changes so earnings are captured at old balance.
         settle_holder_dividends(&env, &creator, &buyer, current_balance)?;
 
@@ -1537,9 +1602,54 @@ impl CreatorKeysContract {
             let (creator_fee, protocol_fee) =
                 fee::checked_compute_fee_split(price, config.creator_bps, config.protocol_bps)
                     .ok_or(ContractError::Overflow)?;
+
             credit_creator_fee(&env, &creator, creator_fee)?;
-            credit_protocol_fee_recipient_balance(&env, protocol_fee)?;
-            credit_treasury_balance(&env, protocol_fee)?;
+
+            // Split protocol fee between treasury and referrer only when a referrer is provided
+            if let Some(referrer_addr) = referrer {
+                let referral_fee_bps = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, u32>(&constants::storage::referral_fee_bps())
+                    .unwrap_or(DEFAULT_REFERRAL_FEE_BPS);
+
+                let (treasury_amount, referral_amount) =
+                    fee::checked_split_bps_amount(protocol_fee, referral_fee_bps)
+                        .ok_or(ContractError::Overflow)?;
+
+                credit_treasury_balance(&env, treasury_amount)?;
+                credit_protocol_fee_recipient_balance(&env, treasury_amount)?;
+
+                if referral_amount > 0 {
+                    // Store referral fee as pending balance for referrer
+                    let referrer_balance_key =
+                        constants::storage::holder_balance_key(&creator, &referrer_addr);
+                    let referrer_current: u32 = env
+                        .storage()
+                        .persistent()
+                        .get(&referrer_balance_key)
+                        .unwrap_or(0);
+                    let referrer_new = referrer_current
+                        .checked_add(referral_amount as u32)
+                        .ok_or(ContractError::Overflow)?;
+                    env.storage().persistent().set(&referrer_balance_key, &referrer_new);
+
+                    env.events().publish(
+                        events::referral_fee_earned_topics(&creator, &referrer_addr),
+                        events::ReferralFeeEarnedEvent {
+                            creator_id: creator.clone(),
+                            buyer: buyer.clone(),
+                            referrer: referrer_addr,
+                            amount: referral_amount,
+                            ledger: env.ledger().sequence(),
+                        },
+                    );
+                }
+            } else {
+                // No referrer: full protocol fee goes to treasury and recipient
+                credit_treasury_balance(&env, protocol_fee)?;
+                credit_protocol_fee_recipient_balance(&env, protocol_fee)?;
+            }
         }
 
         let buy_event_data = events::KeysBoughtEvent {
@@ -3031,6 +3141,81 @@ impl CreatorKeysContract {
 
     pub fn query_supply(env: Env, creator: Address) -> Result<u32, ContractError> {
         Self::get_creator_supply(env, creator)
+    }
+
+    /// Read-only view: returns the configured referral fee basis points.
+    ///
+    /// Returns the default value when no custom value has been set.
+    pub fn get_referral_fee_bps(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<DataKey, u32>(&constants::storage::referral_fee_bps())
+            .unwrap_or(DEFAULT_REFERRAL_FEE_BPS)
+    }
+
+    /// Updates the referral fee basis points.
+    ///
+    /// Only callable by the protocol admin.
+    pub fn set_referral_fee_bps(
+        env: Env,
+        admin: Address,
+        bps: u32,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        assert_is_admin(&env, &admin)?;
+        if bps > fee::BPS_MAX {
+            return Err(ContractError::InvalidFeeConfig);
+        }
+        env.storage()
+            .persistent()
+            .set(&constants::storage::referral_fee_bps(), &bps);
+        Ok(())
+    }
+
+    /// Read-only view: returns the per-wallet cap for a creator.
+    ///
+    /// Returns `None` if no cap is set.
+    pub fn get_wallet_cap(env: Env, creator: Address) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get::<DataKey, u32>(&constants::storage::max_keys_per_wallet(&creator))
+    }
+
+    /// Read-only view: returns cumulative creator volume.
+    ///
+    /// Returns `0` when no volume has been recorded.
+    pub fn get_creator_volume(env: Env, creator: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get::<DataKey, i128>(&constants::storage::creator_volume(&creator))
+            .unwrap_or(0)
+    }
+
+    /// Updates discount tiers (admin-only).
+    ///
+    /// Replaces the full tier list. Maximum 5 tiers allowed.
+    pub fn update_discount_tiers(
+        env: Env,
+        admin: Address,
+        tiers: Vec<DiscountTier>,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        assert_is_admin(&env, &admin)?;
+        if tiers.len() > MAX_DISCOUNT_TIERS {
+            return Err(ContractError::DiscountTierLimitExceeded);
+        }
+        env.storage()
+            .persistent()
+            .set(&constants::storage::discount_tiers(), &tiers);
+        Ok(())
+    }
+
+    /// Read-only view: returns the current discount tiers.
+    pub fn get_discount_tiers(env: Env) -> Vec<DiscountTier> {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Vec<DiscountTier>>(&constants::storage::discount_tiers())
+            .unwrap_or(Vec::new(&env))
     }
 }
 #[cfg(test)]


### PR DESCRIPTION
… and discount tiers

closes #514 : Add referral fee routing on buy so referrers earn a share of the protocol fee
- Add referrer: Option parameter to buy_key (via buy_key_with_referrer internal fn)
- Split protocol fee: 80% treasury, 20% referrer (configurable bps)
- Self-referral reverts with InvalidReferrer
- Emit ReferralFeeEarned { creator_id, buyer, referrer, amount, ledger }
- Add get_referral_fee_bps() and set_referral_fee_bps() admin function

closes #515 : Add per-wallet key holding cap
- Enforce max_keys_per_wallet on buy and transfer
- Add get_wallet_cap(creator_id) -> Option view function
- Cap is immutable after registration

closes #523 : Add creator key airdrop (pre-existing, enhanced with per-wallet cap checks)
- Recipients at their wallet cap are skipped, not reverted
- Creator fee waived; protocol fee applies to total
- KeysAirdropped event with summary fields

closes #522 Add discount tiers and creator volume
- Add DiscountTier { threshold, protocol_bps } struct
- Add update_discount_tiers(admin, tiers) admin function (max 5 tiers)
- Add get_discount_tiers() view function
- Add get_creator_volume(creator_id) view function
