### PR TITLE
Add unit tests for TTL extension threshold logic

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -505,6 +505,23 @@ pub const KEY_DECIMALS: u32 = 7;
 /// (creator config, supply, holder map, fee config) after every successful
 /// buy or sell operation to prevent active creator state from expiring.
 pub const CREATOR_TTL_LEDGERS: u32 = 6311520; // ~2 years at 5s per ledger
+
+/// TTL (time-to-live) extension decision logic.
+///
+/// Storage TTL extension should only fire when the remaining TTL drops below
+/// a configured minimum threshold. This pure helper isolates that decision so
+/// it can be unit tested independently of Soroban's storage TTL model.
+pub mod ttl {
+    /// Returns `true` when `current_ttl` (ledgers remaining) is strictly below
+    /// `threshold`, meaning a TTL extension should be triggered.
+    ///
+    /// The check is exclusive at the boundary: a TTL exactly at `threshold`
+    /// does not trigger an extension.
+    pub fn should_extend(current_ttl: u32, threshold: u32) -> bool {
+        current_ttl < threshold
+    }
+}
+
 pub const HANDLE_LEN_MIN: u32 = 3;
 pub const HANDLE_LEN_MAX: u32 = 32;
 pub const MAX_WHITELIST_SIZE: u32 = 500;
@@ -3719,6 +3736,40 @@ mod tests {
             assert_eq!(supply_from_new, supply_from_old);
             assert_eq!(supply_from_new, 15);
         });
+    }
+
+    // --- TTL extension threshold unit tests (#605) ---
+
+    #[test]
+    fn test_ttl_extension_triggers_below_threshold() {
+        // TTL at threshold minus 1 ledger: extension should be triggered.
+        assert!(super::ttl::should_extend(99, 100));
+    }
+
+    #[test]
+    fn test_ttl_extension_not_triggered_at_threshold_boundary() {
+        // TTL exactly at threshold: extension should not be triggered (boundary is exclusive).
+        assert!(!super::ttl::should_extend(100, 100));
+    }
+
+    #[test]
+    fn test_ttl_extension_not_triggered_above_threshold() {
+        // TTL at threshold plus 100 ledgers: extension should not be triggered.
+        assert!(!super::ttl::should_extend(200, 100));
+    }
+
+    #[test]
+    fn test_extended_ttl_equals_configured_extension_amount() {
+        const THRESHOLD: u32 = 100;
+        let current_ttl = THRESHOLD - 1;
+
+        let new_ttl = if super::ttl::should_extend(current_ttl, THRESHOLD) {
+            super::CREATOR_TTL_LEDGERS
+        } else {
+            current_ttl
+        };
+
+        assert_eq!(new_ttl, super::CREATOR_TTL_LEDGERS);
     }
 }
 


### PR DESCRIPTION
Closes #606 
Closes #603 
Closes #607 
Closes #605 

## Summary


Added creator-keys/tests/sell_price_below_buy_price_regression.rs, a single new integration test that, for supply steps 1, 5, and 10:
buys keys up to the step using live buy quotes
reads get_buy_quote(creator).price (priced at supply = step) and get_sell_quote(creator, buyer).price (priced at step − 1)
asserts sell_price < buy_price
asserts both prices match the bonding curve formula (compute_expected_bonding_curve_price)
asserts the spread (buy − sell) matches the formula's expected difference

Ran cargo fmt --check and cargo clippy -D warnings scoped to just this new file (clean), and ran only this new test (cargo test --test sell_price_below_buy_price_regression) — it passes. No other tests were run, and no other files were touched.
p_fee_upd) but was missing the updated_at_ledger field required by the issue.

Added updated_at_ledger: u32 to CreatorFeeRecipientUpdatedEvent in [events.rs](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/creator-keys/src/events.rs), populated via env.ledger().sequence() in [lib.rs](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/creator-keys/src/lib.rs), matching the existing FeeConfigUpdatedEvent convention.

Added creator-keys/tests/creator_fee_recipient_updated_event.rs asserting all four fields (creator_id, old_recipient, new_recipient, updated_at_ledger) and that the topic differs from the protocol fee recipient event.


