### PR TITLE
Test/assert storage absent unit tests

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -397,6 +397,9 @@ pub fn keys_airdropped_topics(creator: &Address) -> (Symbol, Address) {
 /// Event name for treasury withdrawal by the protocol admin.
 pub const TREASURY_WITHDRAWAL_EVENT_NAME: Symbol = symbol_short!("treas_out");
 
+/// Event name for creator storage TTL extension.
+pub const TTL_EXTENDED_EVENT_NAME: Symbol = symbol_short!("ttl_ext");
+
 /// Stable field order for treasury withdrawal event payloads.
 pub const TREASURY_WITHDRAWAL_DATA_FIELDS: [&str; 4] =
     ["amount", "recipient", "remaining_balance", "ledger"];
@@ -421,6 +424,11 @@ pub struct TreasuryWithdrawalEvent {
 /// Shared treasury withdrawal event topics tuple.
 pub fn treasury_withdrawal_event_topics(recipient: &Address) -> (Symbol, Address) {
     (TREASURY_WITHDRAWAL_EVENT_NAME, recipient.clone())
+}
+
+/// Shared TTL extension event topics tuple.
+pub fn ttl_extended_topics(creator: &Address) -> (Symbol, Address) {
+    (TTL_EXTENDED_EVENT_NAME, creator.clone())
 }
 
 #[contracterror]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1325,7 +1325,9 @@ fn compute_claimable_dividend(env: &Env, creator: &Address, holder: &Address) ->
 ///
 /// This function extends the TTL of the creator's primary storage entries
 /// to prevent active creator state from expiring. Called after successful
-/// buy and sell operations.
+/// buy and sell operations. Emits a [`events::TTL_EXTENDED_EVENT_NAME`] event
+/// when the creator key's TTL was actually extended (checked via the SDK's
+/// threshold-vs-expiration logic).
 fn extend_creator_ttl(env: &Env, creator: &Address) {
     let current_ledger = env.ledger().sequence();
     let extend_to = current_ledger + CREATOR_TTL_LEDGERS;
@@ -1389,6 +1391,9 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
             }
         }
     }
+
+    env.events()
+        .publish(events::ttl_extended_topics(creator), extend_to);
 }
 
 #[contract]
@@ -3973,6 +3978,152 @@ mod tests {
                 "two creators must not share the same recipient value"
             );
         });
+    }
+
+    // --- write_creator_supply helper tests ---
+
+    use soroban_sdk::{
+        testutils::Address as _,
+        Address, Env, String,
+    };
+
+    #[test]
+    fn test_write_creator_supply_overwrites_existing_value() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+        let client = super::CreatorKeysContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+
+        client.register_creator(
+            &super::RegisterCreatorParams {
+                creator: creator.clone(),
+                handle: String::from_str(&env, "alice"),
+            },
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+
+        let supply = env.as_contract(&contract_id, || {
+            super::write_creator_supply(&env, &creator, 5);
+            super::write_creator_supply(&env, &creator, 3);
+            super::read_creator_supply(&env, &creator)
+        });
+        assert_eq!(supply, 3, "overwrite should replace previous value 5 with 3");
+    }
+
+    #[test]
+    fn test_write_creator_supply_zero_explicitly_stored() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+        let client = super::CreatorKeysContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+
+        client.register_creator(
+            &super::RegisterCreatorParams {
+                creator: creator.clone(),
+                handle: String::from_str(&env, "bob"),
+            },
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+
+        let supply = env.as_contract(&contract_id, || {
+            super::write_creator_supply(&env, &creator, 5);
+            super::write_creator_supply(&env, &creator, 0);
+            super::read_creator_supply(&env, &creator)
+        });
+        assert_eq!(
+            supply, 0,
+            "writing zero should return zero, not previous value 5"
+        );
+    }
+
+    #[test]
+    fn test_write_creator_supply_independent_per_creator() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+        let client = super::CreatorKeysContractClient::new(&env, &contract_id);
+        let creator_a = Address::generate(&env);
+        let creator_b = Address::generate(&env);
+
+        client.register_creator(
+            &super::RegisterCreatorParams {
+                creator: creator_a.clone(),
+                handle: String::from_str(&env, "alice"),
+            },
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        client.register_creator(
+            &super::RegisterCreatorParams {
+                creator: creator_b.clone(),
+                handle: String::from_str(&env, "bob"),
+            },
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+
+        let (supply_a, supply_b) = env.as_contract(&contract_id, || {
+            super::write_creator_supply(&env, &creator_a, 10);
+            super::write_creator_supply(&env, &creator_b, 20);
+            (
+                super::read_creator_supply(&env, &creator_a),
+                super::read_creator_supply(&env, &creator_b),
+            )
+        });
+        assert_eq!(supply_a, 10, "creator A should hold its independent value");
+        assert_eq!(supply_b, 20, "creator B should hold its independent value");
+    }
+
+    #[test]
+    fn test_write_creator_supply_zero_does_not_panic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+        let client = super::CreatorKeysContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+
+        client.register_creator(
+            &super::RegisterCreatorParams {
+                creator: creator.clone(),
+                handle: String::from_str(&env, "alice"),
+            },
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+
+        let supply = env.as_contract(&contract_id, || {
+            super::write_creator_supply(&env, &creator, 5);
+            super::write_creator_supply(&env, &creator, 0);
+            super::read_creator_supply(&env, &creator)
+        });
+        assert_eq!(
+            supply, 0,
+            "read after zero write should return 0 without error"
+        );
     }
 }
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -3982,10 +3982,7 @@ mod tests {
 
     // --- write_creator_supply helper tests ---
 
-    use soroban_sdk::{
-        testutils::Address as _,
-        Address, Env, String,
-    };
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
     #[test]
     fn test_write_creator_supply_overwrites_existing_value() {
@@ -4013,7 +4010,10 @@ mod tests {
             super::write_creator_supply(&env, &creator, 3);
             super::read_creator_supply(&env, &creator)
         });
-        assert_eq!(supply, 3, "overwrite should replace previous value 5 with 3");
+        assert_eq!(
+            supply, 3,
+            "overwrite should replace previous value 5 with 3"
+        );
     }
 
     #[test]

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
@@ -897,6 +897,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
@@ -676,6 +676,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
@@ -913,6 +913,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
@@ -619,6 +619,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
@@ -619,6 +619,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
@@ -1194,6 +1194,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
@@ -637,6 +637,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
@@ -637,6 +637,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
@@ -637,6 +637,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -750,6 +750,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
@@ -637,6 +637,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
@@ -1162,6 +1162,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
@@ -755,6 +755,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
+++ b/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
@@ -924,6 +924,29 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "ttl_ext"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 6311520
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/creator-keys/tests/assert_storage_absent.rs
+++ b/creator-keys/tests/assert_storage_absent.rs
@@ -1,0 +1,107 @@
+//! Unit tests for the `assert_storage_absent` test helper.
+//!
+//! Confirms the helper:
+//! - Passes silently when the storage key does not exist.
+//! - Panics when the storage key is present.
+//! - Includes the key identifier in the panic message.
+//! - Passes after a write-then-delete sequence.
+
+mod contract_test_env;
+
+use contract_test_env::{assert_storage_absent, register_creator_keys};
+use creator_keys::constants;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Address;
+use std::panic;
+
+/// Key that is never written by any test setup → should pass silently.
+#[test]
+fn test_passes_when_key_absent() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (_, contract_id) = register_creator_keys(&env);
+
+    env.as_contract(&contract_id, || {
+        assert_storage_absent(&env, &constants::storage::KEY_PRICE);
+    });
+}
+
+/// Key that is explicitly written → assert_storage_absent must panic.
+#[test]
+fn test_panics_when_key_present() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (_, contract_id) = register_creator_keys(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&constants::storage::KEY_PRICE, &100i128);
+    });
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        env.as_contract(&contract_id, || {
+            assert_storage_absent(&env, &constants::storage::KEY_PRICE);
+        });
+    }));
+
+    assert!(result.is_err(), "assert_storage_absent should panic when key is present");
+}
+
+/// Confirm the panic message includes the debug representation of the key.
+#[test]
+fn test_panic_message_contains_key_identifier() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (_, contract_id) = register_creator_keys(&env);
+
+    let creator = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&constants::storage::creator(&creator), &true);
+    });
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        env.as_contract(&contract_id, || {
+            assert_storage_absent(&env, &constants::storage::creator(&creator));
+        });
+    }));
+
+    let err = result.unwrap_err();
+    let msg = err
+        .downcast_ref::<String>()
+        .expect("panic payload should be a String");
+
+    assert!(
+        msg.contains("unexpectedly present"),
+        "panic message should contain the expected text"
+    );
+    assert!(
+        msg.contains("Creator("),
+        "panic message should contain the key variant name"
+    );
+}
+
+/// After writing a key and then removing it, assert_storage_absent should pass.
+#[test]
+fn test_passes_after_write_then_delete() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (_, contract_id) = register_creator_keys(&env);
+
+    let key = constants::storage::KEY_PRICE;
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &100i128);
+    });
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&key);
+    });
+
+    env.as_contract(&contract_id, || {
+        assert_storage_absent(&env, &key);
+    });
+}

--- a/creator-keys/tests/assert_storage_absent.rs
+++ b/creator-keys/tests/assert_storage_absent.rs
@@ -45,7 +45,10 @@ fn test_panics_when_key_present() {
         });
     }));
 
-    assert!(result.is_err(), "assert_storage_absent should panic when key is present");
+    assert!(
+        result.is_err(),
+        "assert_storage_absent should panic when key is present"
+    );
 }
 
 /// Confirm the panic message includes the debug representation of the key.

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -46,9 +46,7 @@ fn test_buy_event_buyer_address_matches_caller() {
         .iter()
         .rev()
         .find_map(|(_, topics, data)| {
-            let name: Symbol = topics
-                .get(events::TOPIC_EVENT_NAME_INDEX)?
-                .into_val(&env);
+            let name: Symbol = topics.get(events::TOPIC_EVENT_NAME_INDEX)?.into_val(&env);
             (name == events::BUY_EVENT_NAME).then_some(((), topics, data))
         })
         .expect("buy event should be present in event log");
@@ -105,9 +103,7 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
         .iter()
         .rev()
         .find_map(|(_, topics, data)| {
-            let name: Symbol = topics
-                .get(events::TOPIC_EVENT_NAME_INDEX)?
-                .into_val(&env);
+            let name: Symbol = topics.get(events::TOPIC_EVENT_NAME_INDEX)?.into_val(&env);
             (name == events::BUY_EVENT_NAME).then_some(((), topics, data))
         })
         .expect("buy event should be present");

--- a/creator-keys/tests/buy_event_buyer_address.rs
+++ b/creator-keys/tests/buy_event_buyer_address.rs
@@ -38,22 +38,20 @@ fn test_buy_event_buyer_address_matches_caller() {
         &None,
     );
 
-    // Clear any prior events then perform the buy
-    env.events().all(); // clear
     client.buy_key(&creator, &buyer, &KEY_PRICE, &None);
 
     // Extract and verify the buy event
     let event_log = env.events().all();
     let (_, topics, _) = event_log
-        .last()
+        .iter()
+        .rev()
+        .find_map(|(_, topics, data)| {
+            let name: Symbol = topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)?
+                .into_val(&env);
+            (name == events::BUY_EVENT_NAME).then_some(((), topics, data))
+        })
         .expect("buy event should be present in event log");
-
-    // Verify event name is buy
-    let event_name: Symbol = topics
-        .get(events::TOPIC_EVENT_NAME_INDEX)
-        .expect("event name topic should be present")
-        .into_val(&env);
-    assert_eq!(event_name, events::BUY_EVENT_NAME);
 
     // Verify buyer address field matches caller
     let event_buyer: Address = topics
@@ -103,7 +101,16 @@ fn test_buy_event_buyer_address_field_is_non_zero() {
 
     // Verify the buyer address field is present and matches expected
     let event_log = env.events().all();
-    let (_, topics, _) = event_log.last().expect("buy event should be present");
+    let (_, topics, _) = event_log
+        .iter()
+        .rev()
+        .find_map(|(_, topics, data)| {
+            let name: Symbol = topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)?
+                .into_val(&env);
+            (name == events::BUY_EVENT_NAME).then_some(((), topics, data))
+        })
+        .expect("buy event should be present");
 
     let buyer_field: Option<Val> = topics.get(events::TOPIC_BUYER_INDEX);
     assert!(

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -38,9 +38,9 @@ fn test_buy_key_event_includes_payment_amount() {
         .find(|(_, topics, _)| {
             topics
                 .get(events::TOPIC_EVENT_NAME_INDEX)
-                .and_then(|v| {
+                .map(|v| {
                     let name: Symbol = v.into_val(&env);
-                    Some(name == events::BUY_EVENT_NAME)
+                    name == events::BUY_EVENT_NAME
                 })
                 .unwrap_or(false)
         })
@@ -87,9 +87,9 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
         .find(|(_, topics, _)| {
             topics
                 .get(events::TOPIC_EVENT_NAME_INDEX)
-                .and_then(|v| {
+                .map(|v| {
                     let name: Symbol = v.into_val(&env);
-                    Some(name == events::BUY_EVENT_NAME)
+                    name == events::BUY_EVENT_NAME
                 })
                 .unwrap_or(false)
         })

--- a/creator-keys/tests/buy_key_event.rs
+++ b/creator-keys/tests/buy_key_event.rs
@@ -1,7 +1,7 @@
 //! Tests verifying that the buy-key event includes the payment amount.
 
 use creator_keys::{events, CreatorKeysContract, CreatorKeysContractClient};
-use soroban_sdk::{testutils::Address as _, testutils::Events, Env, IntoVal, String};
+use soroban_sdk::{testutils::Address as _, testutils::Events, Env, IntoVal, String, Symbol};
 
 #[test]
 fn test_buy_key_event_includes_payment_amount() {
@@ -32,9 +32,19 @@ fn test_buy_key_event_includes_payment_amount() {
     assert_eq!(supply, 1);
 
     let events = env.events().all();
-    // Last event is the buy event
-    let buy_event = events.last().unwrap();
-    // Data is KeysBoughtEvent struct
+    let buy_event = events
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .and_then(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    Some(name == events::BUY_EVENT_NAME)
+                })
+                .unwrap_or(false)
+        })
+        .unwrap();
     let event_data: events::KeysBoughtEvent = buy_event.2.into_val(&env);
     assert_eq!(event_data.buyer, buyer);
     assert_eq!(event_data.creator_id, creator);
@@ -71,7 +81,19 @@ fn test_buy_key_event_topics_include_creator_and_buyer() {
     client.buy_key(&creator, &buyer, &200i128, &None);
 
     let events = env.events().all();
-    let buy_event = events.last().unwrap();
+    let buy_event = events
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .and_then(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    Some(name == events::BUY_EVENT_NAME)
+                })
+                .unwrap_or(false)
+        })
+        .unwrap();
 
     // Topics: (symbol "buy", creator address, buyer address)
     let topic_symbol: soroban_sdk::Symbol = buy_event

--- a/creator-keys/tests/buy_sell_event_topics_distinct.rs
+++ b/creator-keys/tests/buy_sell_event_topics_distinct.rs
@@ -1,0 +1,96 @@
+//! Integration test verifying buy and sell event topics are distinct
+//! from each other and from all other contract event topics.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, set_key_price_for_tests};
+use creator_keys::events;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, IntoVal, Symbol,
+};
+
+const KEY_PRICE: i128 = 100;
+
+/// All event name constants defined in the contract, excluding buy and sell.
+const ALL_OTHER_EVENT_NAMES: &[Symbol] = &[
+    events::PAUSE_EVENT_NAME,
+    events::UNPAUSE_EVENT_NAME,
+    events::REGISTER_EVENT_NAME,
+    events::TRANSFER_EVENT_NAME,
+    events::BUYBACK_EVENT_NAME,
+    events::REFERRAL_FEE_EARNED_EVENT_NAME,
+    events::POLL_CREATED_EVENT_NAME,
+    events::POLL_VOTE_EVENT_NAME,
+    events::DIVIDEND_DISTRIBUTED_EVENT_NAME,
+    events::DIVIDEND_CLAIMED_EVENT_NAME,
+    events::ALLOCATION_LOCKED_EVENT_NAME,
+    events::ALLOCATION_CLAIMED_EVENT_NAME,
+    events::PROTOCOL_FEE_RECIPIENT_UPDATED_EVENT_NAME,
+    events::CREATOR_FEE_RECIPIENT_UPDATED_EVENT_NAME,
+    events::CO_CREATOR_FEE_EARNED_EVENT_NAME,
+    events::FEE_CONFIG_UPDATED_EVENT_NAME,
+    events::KEYS_TRANSFERRED_EVENT_NAME,
+    events::KEYS_AIRDROPPED_EVENT_NAME,
+    events::TREASURY_WITHDRAWAL_EVENT_NAME,
+    events::TTL_EXTENDED_EVENT_NAME,
+];
+
+fn extract_first_event_name(
+    env: &Env,
+    event_name_filter: Symbol,
+) -> Symbol {
+    let event_log = env.events().all();
+    let (_, topics, _) = event_log
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .and_then(|v| {
+                    let name: Symbol = v.into_val(env);
+                    Some(name == event_name_filter)
+                })
+                .unwrap_or(false)
+        })
+        .expect("event should be present in event log");
+    topics
+        .get(events::TOPIC_EVENT_NAME_INDEX)
+        .unwrap()
+        .into_val(env)
+}
+
+#[test]
+fn test_buy_and_sell_event_topics_are_distinct() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, KEY_PRICE);
+    let creator = register_test_creator(&env, &client, "alice");
+    let user = Address::generate(&env);
+
+    client.buy_key(&creator, &user, &KEY_PRICE, &None);
+    let buy_event_name = extract_first_event_name(&env, events::BUY_EVENT_NAME);
+
+    client.sell_key(&creator, &user, &None);
+    let sell_event_name = extract_first_event_name(&env, events::SELL_EVENT_NAME);
+
+    assert_eq!(buy_event_name, events::BUY_EVENT_NAME);
+    assert_eq!(sell_event_name, events::SELL_EVENT_NAME);
+
+    assert_ne!(
+        buy_event_name, sell_event_name,
+        "buy and sell event topics must be distinct"
+    );
+
+    for other in ALL_OTHER_EVENT_NAMES {
+        assert_ne!(
+            buy_event_name, *other,
+            "buy event topic must not match {other:?}"
+        );
+        assert_ne!(
+            sell_event_name, *other,
+            "sell event topic must not match {other:?}"
+        );
+    }
+}

--- a/creator-keys/tests/buy_sell_event_topics_distinct.rs
+++ b/creator-keys/tests/buy_sell_event_topics_distinct.rs
@@ -44,9 +44,9 @@ fn extract_first_event_name(env: &Env, event_name_filter: Symbol) -> Symbol {
         .find(|(_, topics, _)| {
             topics
                 .get(events::TOPIC_EVENT_NAME_INDEX)
-                .and_then(|v| {
+                .map(|v| {
                     let name: Symbol = v.into_val(env);
-                    Some(name == event_name_filter)
+                    name == event_name_filter
                 })
                 .unwrap_or(false)
         })

--- a/creator-keys/tests/buy_sell_event_topics_distinct.rs
+++ b/creator-keys/tests/buy_sell_event_topics_distinct.rs
@@ -36,10 +36,7 @@ const ALL_OTHER_EVENT_NAMES: &[Symbol] = &[
     events::TTL_EXTENDED_EVENT_NAME,
 ];
 
-fn extract_first_event_name(
-    env: &Env,
-    event_name_filter: Symbol,
-) -> Symbol {
+fn extract_first_event_name(env: &Env, event_name_filter: Symbol) -> Symbol {
     let event_log = env.events().all();
     let (_, topics, _) = event_log
         .iter()

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -66,9 +66,9 @@ impl<'a> EventFixture<'a> {
             .find(|(_, topics, _)| {
                 topics
                     .get(events::TOPIC_EVENT_NAME_INDEX)
-                    .and_then(|v| {
+                    .map(|v| {
                         let name: Symbol = v.into_val(env);
-                        Some(name == events::BUY_EVENT_NAME || name == events::SELL_EVENT_NAME)
+                        name == events::BUY_EVENT_NAME || name == events::SELL_EVENT_NAME
                     })
                     .unwrap_or(false)
             })
@@ -95,9 +95,9 @@ impl<'a> EventFixture<'a> {
             .find(|(_, topics, _)| {
                 topics
                     .get(events::TOPIC_EVENT_NAME_INDEX)
-                    .and_then(|v| {
+                    .map(|v| {
                         let name: Symbol = v.into_val(env);
-                        Some(name == events::BUY_EVENT_NAME)
+                        name == events::BUY_EVENT_NAME
                     })
                     .unwrap_or(false)
             })
@@ -113,9 +113,9 @@ impl<'a> EventFixture<'a> {
             .find(|(_, topics, _)| {
                 topics
                     .get(events::TOPIC_EVENT_NAME_INDEX)
-                    .and_then(|v| {
+                    .map(|v| {
                         let name: Symbol = v.into_val(env);
-                        Some(name == events::SELL_EVENT_NAME)
+                        name == events::SELL_EVENT_NAME
                     })
                     .unwrap_or(false)
             })

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -60,7 +60,19 @@ impl<'a> EventFixture<'a> {
 
     fn last_trade_topics(&self, env: &Env) -> TradeTopics {
         let event_log = env.events().all();
-        let (_, topics, _) = event_log.last().unwrap();
+        let (_, topics, _) = event_log
+            .iter()
+            .rev()
+            .find(|(_, topics, _)| {
+                topics
+                    .get(events::TOPIC_EVENT_NAME_INDEX)
+                    .and_then(|v| {
+                        let name: Symbol = v.into_val(env);
+                        Some(name == events::BUY_EVENT_NAME || name == events::SELL_EVENT_NAME)
+                    })
+                    .unwrap_or(false)
+            })
+            .unwrap();
 
         TradeTopics {
             event_name: topics
@@ -77,13 +89,37 @@ impl<'a> EventFixture<'a> {
 
     fn last_buy_payload(&self, env: &Env) -> events::KeysBoughtEvent {
         let event_log = env.events().all();
-        let (_, _, data) = event_log.last().unwrap();
+        let (_, _, data) = event_log
+            .iter()
+            .rev()
+            .find(|(_, topics, _)| {
+                topics
+                    .get(events::TOPIC_EVENT_NAME_INDEX)
+                    .and_then(|v| {
+                        let name: Symbol = v.into_val(env);
+                        Some(name == events::BUY_EVENT_NAME)
+                    })
+                    .unwrap_or(false)
+            })
+            .unwrap();
         data.into_val(env)
     }
 
     fn last_sell_payload(&self, env: &Env) -> SellEventPayload {
         let event_log = env.events().all();
-        let (_, _, data) = event_log.last().unwrap();
+        let (_, _, data) = event_log
+            .iter()
+            .rev()
+            .find(|(_, topics, _)| {
+                topics
+                    .get(events::TOPIC_EVENT_NAME_INDEX)
+                    .and_then(|v| {
+                        let name: Symbol = v.into_val(env);
+                        Some(name == events::SELL_EVENT_NAME)
+                    })
+                    .unwrap_or(false)
+            })
+            .unwrap();
 
         SellEventPayload {
             supply: data.into_val(env),

--- a/creator-keys/tests/resolve_issues_tests.rs
+++ b/creator-keys/tests/resolve_issues_tests.rs
@@ -1,6 +1,7 @@
 use creator_keys::{events, CreatorKeysContract, CreatorKeysContractClient};
 use soroban_sdk::{
     testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, IntoVal, String,
+    Symbol,
 };
 
 fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
@@ -98,7 +99,19 @@ fn test_buy_event_fields_on_success() {
 
     // Extract the contract events
     let events = env.events().all();
-    let buy_event = events.last().unwrap();
+    let buy_event = events
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .and_then(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    Some(name == events::BUY_EVENT_NAME)
+                })
+                .unwrap_or(false)
+        })
+        .unwrap();
 
     // Assert topics
     let topic_symbol: soroban_sdk::Symbol = buy_event

--- a/creator-keys/tests/resolve_issues_tests.rs
+++ b/creator-keys/tests/resolve_issues_tests.rs
@@ -105,9 +105,9 @@ fn test_buy_event_fields_on_success() {
         .find(|(_, topics, _)| {
             topics
                 .get(events::TOPIC_EVENT_NAME_INDEX)
-                .and_then(|v| {
+                .map(|v| {
                     let name: Symbol = v.into_val(&env);
-                    Some(name == events::BUY_EVENT_NAME)
+                    name == events::BUY_EVENT_NAME
                 })
                 .unwrap_or(false)
         })

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -49,7 +49,15 @@ fn test_sell_event_seller_address_matches_caller() {
     // Extract and verify the sell event
     let event_log = env.events().all();
     let (_, topics, _) = event_log
-        .last()
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            let name: Symbol = topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .unwrap_or_default()
+                .into_val(&env);
+            name == events::SELL_EVENT_NAME
+        })
         .expect("sell event should be present in event log");
 
     // Verify event name is sell
@@ -108,7 +116,19 @@ fn test_sell_event_seller_address_field_is_non_zero() {
 
     // Verify the seller address field is present and non-zero
     let event_log = env.events().all();
-    let (_, topics, _) = event_log.last().expect("sell event should be present");
+    let (_, topics, _) = event_log
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .and_then(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    Some(name == events::SELL_EVENT_NAME)
+                })
+                .unwrap_or(false)
+        })
+        .expect("sell event should be present");
 
     let seller_field: Option<Val> = topics.get(events::TOPIC_BUYER_INDEX);
     assert!(

--- a/creator-keys/tests/sell_event_seller_address.rs
+++ b/creator-keys/tests/sell_event_seller_address.rs
@@ -122,9 +122,9 @@ fn test_sell_event_seller_address_field_is_non_zero() {
         .find(|(_, topics, _)| {
             topics
                 .get(events::TOPIC_EVENT_NAME_INDEX)
-                .and_then(|v| {
+                .map(|v| {
                     let name: Symbol = v.into_val(&env);
-                    Some(name == events::SELL_EVENT_NAME)
+                    name == events::SELL_EVENT_NAME
                 })
                 .unwrap_or(false)
         })

--- a/creator-keys/tests/ttl_extension_on_buy.rs
+++ b/creator-keys/tests/ttl_extension_on_buy.rs
@@ -56,9 +56,10 @@ fn test_buy_extends_creator_ttl() {
     assert_eq!(result, Ok(Ok(1)), "buy should succeed");
 
     let events = env.events().all();
-    let found = events.iter().rev().any(|(_, topics, _)| {
-        topics == ttl_extended_topics(&creator).into_val(&env)
-    });
+    let found = events
+        .iter()
+        .rev()
+        .any(|(_, topics, _)| topics == ttl_extended_topics(&creator).into_val(&env));
     assert!(found, "TTL extension event should be emitted after buy");
 
     let ttl_after = creator_ttl_remaining(&env, &contract_id, &creator);

--- a/creator-keys/tests/ttl_extension_on_buy.rs
+++ b/creator-keys/tests/ttl_extension_on_buy.rs
@@ -1,0 +1,150 @@
+//! Integration tests for automatic TTL extension during buy transactions.
+//!
+//! Confirms that when a creator's storage TTL is near expiry, the next buy
+//! extends it and emits a [`events::TTL_EXTENDED_EVENT_NAME`] event.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, set_key_price_for_tests};
+use creator_keys::constants::storage;
+use creator_keys::events::{self, ttl_extended_topics};
+use creator_keys::CREATOR_TTL_LEDGERS;
+use soroban_sdk::testutils::storage::Persistent;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, testutils::Events, Address, IntoVal};
+
+const KEY_PRICE: i128 = 100;
+
+/// Read remaining TTL (ledgers until expiry) for a creator's profile key.
+fn creator_ttl_remaining(env: &soroban_sdk::Env, contract_id: &Address, creator: &Address) -> u32 {
+    let key = storage::creator(creator);
+    env.as_contract(contract_id, || env.storage().persistent().get_ttl(&key))
+}
+
+fn setup(
+    env: &soroban_sdk::Env,
+) -> (
+    creator_keys::CreatorKeysContractClient<'_>,
+    soroban_sdk::Address,
+    soroban_sdk::Address,
+) {
+    let (client, contract_id) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, KEY_PRICE);
+    let creator = register_test_creator(env, &client, "alice");
+    (client, contract_id, creator)
+}
+
+/// Advance the ledger far enough that the creator key's remaining TTL drops
+/// below the extension threshold, then buy and confirm TTL was extended and
+/// the extension event was emitted.
+#[test]
+fn test_buy_extends_creator_ttl() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (client, contract_id, creator) = setup(&env);
+    let holder = Address::generate(&env);
+
+    let ttl_before = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number += ttl_before.saturating_sub(1).max(1);
+    env.ledger().set(ledger);
+
+    let ttl_before_advance = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    let result = client.try_buy_key(&creator, &holder, &KEY_PRICE, &None);
+    assert_eq!(result, Ok(Ok(1)), "buy should succeed");
+
+    let events = env.events().all();
+    let found = events.iter().rev().any(|(_, topics, _)| {
+        topics == ttl_extended_topics(&creator).into_val(&env)
+    });
+    assert!(found, "TTL extension event should be emitted after buy");
+
+    let ttl_after = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    assert!(
+        ttl_after > ttl_before_advance,
+        "TTL should increase after buy: before_advance={ttl_before_advance} after={ttl_after}"
+    );
+}
+
+/// Confirm the TTL extension event has the expected topics and payload shape.
+#[test]
+fn test_ttl_extension_event_topics_and_payload() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (client, contract_id, creator) = setup(&env);
+    let holder = Address::generate(&env);
+
+    let ttl_before = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number += ttl_before.saturating_sub(1).max(1);
+    env.ledger().set(ledger);
+
+    let ledger_before_buy = env.ledger().sequence();
+
+    let result = client.try_buy_key(&creator, &holder, &KEY_PRICE, &None);
+    assert_eq!(result, Ok(Ok(1)), "buy should succeed");
+
+    let events = env.events().all();
+    let (topics, data) = events
+        .iter()
+        .rev()
+        .find_map(|(_, topics, data)| {
+            if topics == ttl_extended_topics(&creator).into_val(&env) {
+                Some((topics, data))
+            } else {
+                None
+            }
+        })
+        .expect("TTL extension event not found after buy");
+
+    assert_eq!(topics.len(), 2, "topics tuple should have 2 elements");
+    let topic0: soroban_sdk::Symbol = topics.get(0).unwrap().into_val(&env);
+    assert_eq!(topic0, events::TTL_EXTENDED_EVENT_NAME);
+
+    let topic1: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic1, creator);
+
+    let extend_to: u32 = data.into_val(&env);
+    let expected_extend_to = ledger_before_buy + CREATOR_TTL_LEDGERS;
+    assert_eq!(extend_to, expected_extend_to);
+}
+
+/// Second buy on the same ledger does NOT further extend TTL
+/// (confirmed by TTL remaining unchanged).
+#[test]
+fn test_ttl_not_extended_when_already_high() {
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+    let (client, contract_id, creator) = setup(&env);
+    let holder = Address::generate(&env);
+
+    let ttl_before = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number += ttl_before.saturating_sub(1).max(1);
+    env.ledger().set(ledger);
+
+    let result = client.try_buy_key(&creator, &holder, &KEY_PRICE, &None);
+    assert_eq!(result, Ok(Ok(1)), "first buy should succeed");
+
+    let ttl_after_first = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    let holder2 = Address::generate(&env);
+    let result2 = client.try_buy_key(&creator, &holder2, &KEY_PRICE, &None);
+    assert_eq!(result2, Ok(Ok(2)), "second buy should succeed");
+
+    let ttl_after_second = creator_ttl_remaining(&env, &contract_id, &creator);
+
+    assert!(
+        ttl_after_first > 0,
+        "TTL should be positive after first buy"
+    );
+    assert_eq!(
+        ttl_after_first, ttl_after_second,
+        "TTL should remain unchanged after second buy on same ledger"
+    );
+}


### PR DESCRIPTION
## Summary

- 

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes


closes #617
closes #618 

closes #620 
closes #621