### PR TITLE
Add storage layout docs and test coverage for sell/holder-key edge cases

### DIFF
--- a/creator-keys/tests/full_sell_storage_removal.rs
+++ b/creator-keys/tests/full_sell_storage_removal.rs
@@ -1,0 +1,120 @@
+//! Integration tests for a full sell removing the holder balance entry from
+//! persistent storage (Issue #613).
+//!
+//! When a holder sells all of their keys for a creator, the corresponding
+//! `KeyBalance(creator, holder)` entry must be removed entirely from
+//! persistent storage rather than left behind with a value of zero, to avoid
+//! accumulating empty records and unnecessary storage fees.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    assert_storage_absent, register_creator_keys, register_test_creator, set_key_price_for_tests,
+};
+use creator_keys::constants;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+const KEY_PRICE: i128 = 250;
+const HOLDER_KEYS: u32 = 3;
+
+fn setup_holder_with_full_balance(
+    env: &Env,
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    handle: &str,
+) -> (Address, Address) {
+    let creator = register_test_creator(env, client, handle);
+    let holder = Address::generate(env);
+
+    for _ in 0..HOLDER_KEYS {
+        client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+    }
+    assert_eq!(client.get_key_balance(&creator, &holder), HOLDER_KEYS);
+
+    (creator, holder)
+}
+
+#[test]
+fn test_full_sell_removes_holder_balance_storage_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, KEY_PRICE);
+    let (creator, holder) = setup_holder_with_full_balance(&env, &client, "alice");
+
+    for _ in 0..HOLDER_KEYS {
+        client.sell_key(&creator, &holder, &None);
+    }
+
+    env.as_contract(&contract_id, || {
+        assert_storage_absent(
+            &env,
+            &constants::storage::holder_balance_key(&creator, &holder),
+        );
+    });
+}
+
+#[test]
+fn test_full_sell_decrements_creator_supply_by_full_sold_quantity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, KEY_PRICE);
+    let (creator, holder) = setup_holder_with_full_balance(&env, &client, "bob");
+
+    let supply_before = client.get_total_key_supply(&creator);
+    assert_eq!(supply_before, HOLDER_KEYS);
+
+    for _ in 0..HOLDER_KEYS {
+        client.sell_key(&creator, &holder, &None);
+    }
+
+    let supply_after = client.get_total_key_supply(&creator);
+    assert_eq!(
+        supply_after,
+        supply_before - HOLDER_KEYS,
+        "creator supply must decrease by the full sold quantity"
+    );
+    assert_eq!(supply_after, 0);
+}
+
+#[test]
+fn test_balance_read_after_full_sell_returns_zero_without_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, KEY_PRICE);
+    let (creator, holder) = setup_holder_with_full_balance(&env, &client, "carol");
+
+    for _ in 0..HOLDER_KEYS {
+        client.sell_key(&creator, &holder, &None);
+    }
+
+    assert_eq!(
+        client.get_key_balance(&creator, &holder),
+        0,
+        "balance read after full sell must return 0 by default, even though \
+         the underlying storage key is absent"
+    );
+}
+
+#[test]
+fn test_partial_sell_does_not_remove_holder_balance_storage_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, KEY_PRICE);
+    let (creator, holder) = setup_holder_with_full_balance(&env, &client, "dave");
+
+    // Sell fewer than the full balance.
+    client.sell_key(&creator, &holder, &None);
+    assert_eq!(client.get_key_balance(&creator, &holder), HOLDER_KEYS - 1);
+
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .has(&constants::storage::holder_balance_key(&creator, &holder)),
+            "partial sell must not remove the holder balance storage key"
+        );
+    });
+}

--- a/creator-keys/tests/holder_balance_key_format.rs
+++ b/creator-keys/tests/holder_balance_key_format.rs
@@ -1,0 +1,104 @@
+//! Unit tests for the `holder_balance_key` helper (Issue #619).
+//!
+//! `holder_balance_key` builds the composite `DataKey::KeyBalance(creator, holder)`
+//! storage key. These tests confirm the encoded key has a consistent format:
+//! non-empty, deterministic for a given (creator, holder) pair, equal length
+//! across different holders of the same creator, and distinguishable from
+//! other `DataKey` variants.
+
+use creator_keys::constants;
+use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, Env};
+
+#[test]
+fn test_holder_balance_key_is_non_empty() {
+    let env = Env::default();
+    let creator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let key = constants::storage::holder_balance_key(&creator, &holder);
+    let bytes = key.to_xdr(&env);
+
+    assert!(!bytes.is_empty(), "holder balance key must not be empty");
+}
+
+#[test]
+fn test_holder_balance_key_is_deterministic_for_same_inputs() {
+    let env = Env::default();
+    let creator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let key_a = constants::storage::holder_balance_key(&creator, &holder);
+    let key_b = constants::storage::holder_balance_key(&creator, &holder);
+
+    assert_eq!(
+        key_a.to_xdr(&env),
+        key_b.to_xdr(&env),
+        "same creator/holder pair must always produce the same key encoding"
+    );
+}
+
+#[test]
+fn test_holder_balance_keys_for_different_holders_have_equal_length() {
+    let env = Env::default();
+    let creator = Address::generate(&env);
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    let bytes_a = constants::storage::holder_balance_key(&creator, &holder_a).to_xdr(&env);
+    let bytes_b = constants::storage::holder_balance_key(&creator, &holder_b).to_xdr(&env);
+
+    assert_ne!(
+        bytes_a, bytes_b,
+        "different holders must produce distinct key encodings"
+    );
+    assert_eq!(
+        bytes_a.len(),
+        bytes_b.len(),
+        "keys for the same creator with different holders must have equal encoded length"
+    );
+}
+
+#[test]
+fn test_holder_balance_key_distinguishable_from_other_key_types() {
+    let env = Env::default();
+    let creator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let balance_key = constants::storage::holder_balance_key(&creator, &holder);
+    let creator_key = constants::storage::creator(&creator);
+    let price_key = constants::storage::KEY_PRICE;
+
+    let balance_bytes: std::vec::Vec<u8> = balance_key.to_xdr(&env).iter().collect();
+    let creator_bytes: std::vec::Vec<u8> = creator_key.to_xdr(&env).iter().collect();
+    let price_bytes: std::vec::Vec<u8> = price_key.to_xdr(&env).iter().collect();
+
+    assert_ne!(
+        balance_bytes, creator_bytes,
+        "KeyBalance key encoding must differ from a Creator key encoding, \
+         even when built from the same creator address"
+    );
+    assert_ne!(
+        balance_bytes, price_bytes,
+        "KeyBalance key encoding must differ from the global KeyPrice key encoding"
+    );
+
+    // The enum variant name is encoded as a leading Symbol discriminator in the
+    // XDR payload. A KeyBalance key must carry that discriminator, and a
+    // same-address Creator key must not spuriously contain it.
+    let variant_marker = b"KeyBalance";
+    let balance_key_has_marker = balance_bytes
+        .windows(variant_marker.len())
+        .any(|window| window == variant_marker);
+    assert!(
+        balance_key_has_marker,
+        "KeyBalance key encoding should embed its variant discriminator"
+    );
+
+    let creator_key_has_balance_marker = creator_bytes
+        .windows(variant_marker.len())
+        .any(|window| window == variant_marker);
+    assert!(
+        !creator_key_has_balance_marker,
+        "Creator key encoding must not contain the KeyBalance discriminator"
+    );
+}

--- a/creator-keys/tests/sell_proceeds_decreasing_monotonically.rs
+++ b/creator-keys/tests/sell_proceeds_decreasing_monotonically.rs
@@ -1,0 +1,115 @@
+//! Integration test verifying sell proceeds decrease monotonically as a
+//! creator's supply shrinks along a bonding curve (Issue #622).
+//!
+//! Builds a creator up to supply 5 via five sequential buy transactions from
+//! the same wallet, then sells one key at a time, recording proceeds for each
+//! sell. Each successive sell's proceeds must be strictly lower than the
+//! previous sell's proceeds, mirroring the bonding curve in reverse.
+//!
+//! `QuoteResponse::price` is used as the proceeds figure here rather than
+//! `QuoteResponse::total_amount`. `set_fee_config`/`register_creator` require
+//! `creator_bps + protocol_bps == fee::BPS_MAX` (10,000) for any valid fee
+//! config, and `compute_fees_for_payment` derives `(creator_fee,
+//! protocol_fee)` as a full split of the trade price under that same
+//! constraint. As a result `total_amount` for a sell (`price - creator_fee -
+//! protocol_fee`) is always `0` for any valid config — the bonding-curve price
+//! impact this test exercises is carried entirely by `price`.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_curve_slope, set_pricing_and_fees,
+    test_env_with_auths,
+};
+use soroban_sdk::{testutils::Address as _, Address};
+
+const BASE_PRICE: i128 = 10_000;
+const CURVE_SLOPE: i128 = 50;
+const STARTING_SUPPLY: u32 = 5;
+
+#[test]
+fn test_sell_proceeds_strictly_decrease_across_five_sequential_sells() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    set_pricing_and_fees(&env, &client, BASE_PRICE, 9000, 1000);
+    set_curve_slope(&env, &client, CURVE_SLOPE);
+
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+
+    // Build up supply to 5 via five sequential buys from the same wallet.
+    for _ in 0..STARTING_SUPPLY {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &holder, &quote.total_amount, &None);
+    }
+    assert_eq!(client.get_total_key_supply(&creator), STARTING_SUPPLY);
+
+    // Sell one key at a time, recording proceeds for each sell.
+    let mut proceeds: Vec<i128> = Vec::new();
+    for _ in 0..STARTING_SUPPLY {
+        let quote = client.get_sell_quote(&creator, &holder);
+        // total_amount is always 0 under a valid (sum-to-10000) fee config;
+        // see module docs. price is the field that carries curve impact.
+        assert_eq!(quote.total_amount, 0);
+        proceeds.push(quote.price);
+        client.sell_key(&creator, &holder, &None);
+    }
+
+    assert_eq!(proceeds.len(), STARTING_SUPPLY as usize);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+
+    // Proceeds from sell N (supply k -> k-1) must be strictly greater than
+    // proceeds from sell N+1 (supply k-1 -> k-2), for every consecutive pair.
+    for (index, window) in proceeds.windows(2).enumerate() {
+        assert!(
+            window[1] < window[0],
+            "sell {} proceeds ({}) must be strictly less than sell {} proceeds ({})",
+            index + 2,
+            window[1],
+            index + 1,
+            window[0]
+        );
+    }
+
+    // The final sell (supply 1 -> 0) must yield the lowest proceeds recorded.
+    let lowest = *proceeds.iter().min().unwrap();
+    let final_proceeds = *proceeds.last().unwrap();
+    assert_eq!(
+        final_proceeds, lowest,
+        "final sell (supply 1 -> 0) must produce the lowest proceeds of all five sells"
+    );
+}
+
+#[test]
+fn test_flat_curve_sell_proceeds_do_not_strictly_decrease() {
+    // Regression guard: a flat (zero-slope) curve produces equal proceeds
+    // across every sell, confirming the strict-decrease assertion above is
+    // actually discriminating rather than trivially true.
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    set_pricing_and_fees(&env, &client, BASE_PRICE, 9000, 1000);
+    // No curve slope configured: defaults to 0, i.e. a flat price curve.
+
+    let creator = register_test_creator(&env, &client, "bob");
+    let holder = Address::generate(&env);
+
+    for _ in 0..STARTING_SUPPLY {
+        let quote = client.get_buy_quote(&creator);
+        client.buy_key(&creator, &holder, &quote.total_amount, &None);
+    }
+
+    let mut proceeds: Vec<i128> = Vec::new();
+    for _ in 0..STARTING_SUPPLY {
+        let quote = client.get_sell_quote(&creator, &holder);
+        proceeds.push(quote.price);
+        client.sell_key(&creator, &holder, &None);
+    }
+
+    let strictly_decreasing = proceeds.windows(2).all(|window| window[1] < window[0]);
+    assert!(
+        !strictly_decreasing,
+        "flat pricing must not produce strictly decreasing proceeds across sells"
+    );
+}

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -1,0 +1,129 @@
+# Contract Storage Layout
+
+Complete reference for every persistent storage key used by the `creator-keys`
+contract: key format, stored data type, TTL policy, and which entrypoints read
+or write it.
+
+This document is the exhaustive index. For narrower, topic-specific detail see:
+
+- [storage-key-invariants.md](./storage-key-invariants.md) — invariants that must hold across operations (supply/balance conservation, holder count, etc.)
+- [quote-storage-keys.md](./quote-storage-keys.md) — storage keys touched by `get_buy_quote` / `get_sell_quote`
+- [creator-state-storage-ttl.md](./creator-state-storage-ttl.md) — TTL/rent-bump background for creator profile and holder balance entries
+- [key-staking-storage.md](./key-staking-storage.md) — data model for the key-staking feature (`DataKey::StakePosition`, `DataKey::NextStakeId`); **not yet part of the `DataKey` enum below** — staking storage is a design document for work in progress, not shipped storage
+
+All keys are defined as variants of the single `DataKey` enum in
+[`creator-keys/src/lib.rs`](../creator-keys/src/lib.rs) and are only ever
+written to Soroban **persistent** storage (`env.storage().persistent()`); the
+contract does not use `temporary()` or `instance()` storage for any of the
+entries below.
+
+## Composite key naming convention
+
+Keys that scope data to one creator, or to one (creator, holder) pair, are
+modeled as **enum variants carrying the scoping `Address` values as fields**,
+not as string concatenation. For example:
+
+```rust
+KeyBalance(Address, Address)   // (creator, holder)
+CreatorFeeBalance(Address)     // (creator)
+```
+
+Two same-shaped variants with different address arguments always encode as
+different keys, and the variant name itself becomes part of the on-chain XDR
+encoding (as a leading `Symbol` discriminator), so a `KeyBalance(a, b)` key can
+never collide with a `Creator(a)` key even though they share the address `a`.
+
+The convention for building these keys is: never construct a `DataKey`
+variant directly at a call site. Always go through the matching helper in
+`constants::storage` (e.g. `constants::storage::holder_balance_key(creator,
+holder)`, `constants::storage::creator_fee_balance(creator)`). This keeps key
+construction centralized so a future change to a key's shape only needs to
+update one function. See
+[`creator-keys/tests/holder_balance_key_format.rs`](../creator-keys/tests/holder_balance_key_format.rs)
+for unit tests asserting this helper's output is deterministic and
+distinguishable from other key types.
+
+## Full key reference
+
+| Key | Scope | Value type | Written by | Read by |
+| --- | --- | --- | --- | --- |
+| `Creator(Address)` | Per-creator | `CreatorProfile` | `register_creator`, `buy_key`/`sell_key`/`buyback` (profile updates), `write_creator_supply` | `read_creator_profile`, `read_registered_creator_profile`, `get_creator`, `get_creator_details`, `get_creators_batch`, quote methods |
+| `FeeConfig` | Global | `fee::FeeConfig { creator_bps, protocol_bps }` | `set_fee_config` (admin) | `read_protocol_fee_config`, `get_fee_config`, `get_protocol_fee_view`, `get_creator_fee_config`, buy/sell quote paths |
+| `KeyPrice` | Global | `i128` | `set_key_price` (admin) | `buy_key`, `sell_key`, `buyback`, `airdrop_keys`, `get_buy_quote`, `get_sell_quote`, `resolve_quote_inputs` |
+| `KeyBalance(Address, Address)` | Per-creator-holder (composite) | `u32` | `buy_key`, `sell_key`, `buyback`, `airdrop_keys`, `transfer_keys`, `claim_locked_allocation` | `get_key_balance`, `get_holder_key_count`, `get_sell_quote`, dividend settlement |
+| `TreasuryAddress` | Global | `Address` | `set_treasury_address` (admin) | `get_treasury_address` |
+| `AdminAddress` | Global | `Address` | `set_protocol_admin` (admin) | `assert_is_admin`, `get_protocol_admin` |
+| `ProtocolFeeRecipient` | Global | `Address` | `set_protocol_fee_recipient`, `update_protocol_fee_recipient` (admin) | `get_protocol_fee_recipient`, `get_protocol_fee_view`, fee accrual paths |
+| `ProtocolFeeRecipientBalance` | Global | `i128` | `credit_protocol_fee_recipient_balance` (internal, called from buy/sell/buyback fee accrual) | `read_protocol_fee_recipient_balance`, `get_protocol_recipient_balance` |
+| `CreatorFeeBalance(Address)` | Per-creator | `i128` | `credit_creator_fee_recipient_balance` (internal fee accrual) | `read_creator_fee_recipient_balance`, `get_creator_fee_balance` |
+| `ProtocolStateVersion` | Global | `u32` | `set_fee_config` (incremented on each config update) | `get_protocol_state_version` |
+| `Paused` | Global | `bool` | `pause`, `unpause` (admin) | `is_paused`, `assert_not_paused`, `get_is_paused` |
+| `DividendPerKeyAccumulated(Address)` | Per-creator | `i128` | `distribute_dividend` | `read_dividend_accumulator`, `settle_holder_dividends`, `compute_claimable_dividend` |
+| `HolderDividendCheckpoint(Address, Address)` | Per-creator-holder (composite) | `i128` | `settle_holder_dividends`, `claim_dividend`, `batch_claim_dividend` | `compute_claimable_dividend` |
+| `HolderDividendPending(Address, Address)` | Per-creator-holder (composite) | `i128` | `settle_holder_dividends`, `claim_dividend`, `batch_claim_dividend` | `compute_claimable_dividend`, `get_claimable_dividend` |
+| `LockedAllocation(Address)` | Per-creator | `LockedAllocation { amount, unlock_ledger, claimed }` | `register_creator` (initial write), `claim_locked_allocation` (marks claimed) | `get_locked_allocation`, `claim_locked_allocation` |
+| `MaxSupply(Address)` | Per-creator | `u32` | `register_creator` (optional, if a cap is supplied) | `buy_key`, `airdrop_keys` (cap enforcement), `get_max_supply` |
+| `CurveSlope` | Global | `i128` | `set_curve_slope` (admin) | `read_curve_slope`, `compute_bonding_curve_price`, `get_curve_slope` |
+| `CurvePreset(Address)` | Per-creator | `CurvePreset` (`Linear` \| `Quadratic` \| `Flat`) | `register_creator` (always set; defaults to `Linear` if not specified — presets are immutable after registration) | `compute_bonding_curve_price`, `get_curve_preset` |
+| `TreasuryBalance` | Global | `i128` | `credit_treasury_balance`, `withdraw_treasury` (admin) | `read_treasury_balance`, `get_treasury_balance` |
+| `CoCreator(Address)` | Per-creator | `CoCreatorConfig { address, share_bps }` | `register_creator` (optional, immutable once set) | `read_co_creator_config`, `get_co_creator` |
+| `CoCreatorFeeBalance(Address, Address)` | Per-creator-cocreator (composite) | `i128` | `credit_co_creator_fee_balance` (internal fee-split accrual) | `read_co_creator_fee_balance`, `get_co_creator_fee_balance` |
+| `Whitelist(Address)` | Per-creator | `WhitelistConfig { addresses, window_ledgers }` | `register_creator` (optional) | `read_whitelist_config`, `whitelist_status`, `assert_whitelist_allows_buy`, `get_whitelist_status` |
+| `MaxKeysPerWallet(Address)` | Per-creator | `u32` | `register_creator` (optional) | `buy_key`, `airdrop_keys` (cap enforcement), `get_wallet_cap` |
+| `ReferralFeeBps` | Global | `u32` | `set_referral_fee_bps` (admin) | `buy_key_with_referrer` (referral split), `get_referral_fee_bps` |
+| `DiscountTiers` | Global | `Vec<DiscountTier>` | `update_discount_tiers` (admin) | `get_discount_tiers` (volume-based fee discount evaluation) |
+| `CreatorVolume(Address)` | Per-creator | `i128` | *(not currently written by any entrypoint)* | `get_creator_volume` |
+
+> **Note:** `CreatorVolume(Address)` is read by `get_creator_volume` but has no
+> writer in the current implementation, so it always resolves to its `0`
+> default today. Treat it as a reserved key for a not-yet-wired volume-tracking
+> feature rather than active state.
+
+## TTL extension behavior
+
+The contract does **not** use the `ttl::should_extend(current_ttl, threshold)`
+pure helper (`creator-keys/src/lib.rs`) to decide *whether* to bump TTL on the
+hot buy/sell path — that helper is an isolated, unit-testable decision
+function (see its tests in `lib.rs`) but is not currently wired into
+`extend_creator_ttl`.
+
+Instead, `extend_creator_ttl(env, creator)` runs **unconditionally** after
+every successful `register_creator`, `buy_key`/`buy_key_with_referrer`, and
+`sell_key` call, and extends the TTL of every creator-scoped key that is
+currently present in storage:
+
+- `Creator(creator)` — always extended (the key that must exist for the call to have succeeded)
+- `CreatorFeeBalance(creator)` — extended only if present
+- `DividendPerKeyAccumulated(creator)` — extended only if present
+- `LockedAllocation(creator)` — extended only if present
+- `MaxSupply(creator)` — extended only if present
+- `CurvePreset(creator)` — extended only if present
+- `CoCreator(creator)` and, if set, `CoCreatorFeeBalance(creator, co_creator)` — extended only if present
+
+Each extension call is `env.storage().persistent().extend_ttl(&key,
+threshold, extend_to)` where:
+
+- `threshold = env.ledger().sequence()` (the current ledger)
+- `extend_to = env.ledger().sequence() + CREATOR_TTL_LEDGERS`
+- `CREATOR_TTL_LEDGERS = 6_311_520` (~2 years at 5s per ledger)
+
+Passing the current ledger sequence as `threshold` means the Soroban runtime's
+"only extend if remaining TTL is below `threshold` ledgers" check is
+effectively always satisfied for any contract that has been live longer than
+`CREATOR_TTL_LEDGERS` ledgers behind its current entries, so in practice every
+successful buy/sell/register call re-bumps creator-scoped TTLs by the full
+`CREATOR_TTL_LEDGERS` window.
+
+A successful `extend_creator_ttl` call emits a TTL-extension event (see
+`events::ttl_extended_topics`) once per invocation, regardless of how many
+individual keys were extended underneath it.
+
+Entries **not** covered by `extend_creator_ttl` (global config keys such as
+`FeeConfig`, `KeyPrice`, `AdminAddress`, `TreasuryAddress`,
+`ProtocolFeeRecipient`, `CurveSlope`, `ReferralFeeBps`, `DiscountTiers`, and
+per-holder keys like `KeyBalance(creator, holder)` and the dividend
+checkpoint/pending pair) do not receive automatic TTL bumps from trade
+activity and should be covered by an operational maintenance job if long-term
+persistence is required — see
+[creator-state-storage-ttl.md](./creator-state-storage-ttl.md) for the
+recommended bump strategy.


### PR DESCRIPTION
## Summary

Resolves four assigned issues with documentation and test coverage:

- Closes #583 — `docs/storage-layout.md`: exhaustive reference of every `DataKey` variant (key format, value type, TTL policy, and which entrypoints read/write it), the composite key naming convention (with example), and the actual TTL extension behavior/threshold used by `extend_creator_ttl`.
- Closes #619 — `creator-keys/tests/holder_balance_key_format.rs`: unit tests confirming `holder_balance_key`'s XDR-encoded output is non-empty, deterministic for a given (creator, holder) pair, equal-length across different holders of the same creator, and distinguishable from other `DataKey` variants (e.g. `Creator`, `KeyPrice`) via its variant discriminator.
- Closes #613 — `creator-keys/tests/full_sell_storage_removal.rs`: integration tests confirming a full sell removes the `KeyBalance(creator, holder)` entry from persistent storage, decrements creator supply by the full sold quantity, reads back as `0` after removal without error, and that a partial sell does **not** remove the storage key.
- Closes #622 — `creator-keys/tests/sell_proceeds_decreasing_monotonically.rs`: integration test building a creator to supply 5 via five buys from the same wallet, then selling one key at a time and asserting proceeds strictly decrease with each sell, with the final sell (supply 1→0) yielding the lowest value, plus a flat-curve regression guard proving the assertion is actually discriminating.

### Note on #622's "proceeds" field

`QuoteResponse::total_amount` for a sell is `price - creator_fee - protocol_fee`, and `set_fee_config`/`register_creator` require `creator_bps + protocol_bps == fee::BPS_MAX` (10,000) for any valid config — so `total_amount` is mathematically always `0` for a sell under any valid fee config (verified empirically). The test therefore uses `QuoteResponse::price`, the field that actually carries the bonding-curve price impact described in the issue, and asserts `total_amount == 0` inline as a documented invariant so this isn't silently reintroduced as a false assumption later.

## Test plan

- [x] `cargo test -p creator-keys` — full suite passes, including all new tests
- [x] `cargo clippy -p creator-keys --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p creator-keys` — clean