### PR TITLE
Add contract events for TTL extension and protocol fee recipient updates

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -258,11 +258,16 @@ pub struct AllocationClaimedEvent {
     pub ledger: u32,
 }
 
+/// Stable field order for protocol fee recipient updated event payloads.
+pub const PROTOCOL_FEE_RECIPIENT_UPDATED_DATA_FIELDS: [&str; 3] =
+    ["old_recipient", "new_recipient", "updated_at_ledger"];
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct ProtocolFeeRecipientUpdatedEvent {
     pub old_recipient: Address,
     pub new_recipient: Address,
+    pub updated_at_ledger: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -429,6 +434,23 @@ pub fn treasury_withdrawal_event_topics(recipient: &Address) -> (Symbol, Address
 /// Shared TTL extension event topics tuple.
 pub fn ttl_extended_topics(creator: &Address) -> (Symbol, Address) {
     (TTL_EXTENDED_EVENT_NAME, creator.clone())
+}
+
+/// Stable field order for TTL extension event payloads.
+pub const TTL_EXTENDED_DATA_FIELDS: [&str; 3] =
+    ["creator_id", "extended_at_ledger", "new_expiry_ledger"];
+
+/// Stable TTL extension event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(TTL_EXTENDED_EVENT_NAME, creator_id)`
+/// - data: `TtlExtendedEvent`
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct TtlExtendedEvent {
+    pub creator_id: Address,
+    pub extended_at_ledger: u32,
+    pub new_expiry_ledger: u32,
 }
 
 #[contracterror]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1392,8 +1392,14 @@ fn extend_creator_ttl(env: &Env, creator: &Address) {
         }
     }
 
-    env.events()
-        .publish(events::ttl_extended_topics(creator), extend_to);
+    env.events().publish(
+        events::ttl_extended_topics(creator),
+        events::TtlExtendedEvent {
+            creator_id: creator.clone(),
+            extended_at_ledger: current_ledger,
+            new_expiry_ledger: extend_to,
+        },
+    );
 }
 
 #[contract]
@@ -2618,6 +2624,7 @@ impl CreatorKeysContract {
                 events::ProtocolFeeRecipientUpdatedEvent {
                     old_recipient: old,
                     new_recipient: recipient,
+                    updated_at_ledger: env.ledger().sequence(),
                 },
             );
         }
@@ -3019,6 +3026,7 @@ impl CreatorKeysContract {
             events::ProtocolFeeRecipientUpdatedEvent {
                 old_recipient,
                 new_recipient,
+                updated_at_ledger: env.ledger().sequence(),
             },
         );
 

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_field_is_non_zero.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_buy_event_buyer_address_matches_caller.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_includes_payment_amount.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_payload_tracks_new_supply_across_purchases.1.json
@@ -914,7 +914,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_present_after_purchase.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_event_topics_include_creator_and_buyer.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_positive_payment_succeeds.1.json
@@ -693,7 +693,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_succeeds_after_unpause.1.json
@@ -930,7 +930,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_large_safe_amount_succeeds.1.json
@@ -636,7 +636,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
+++ b/creator-keys/test_snapshots/test_buy_key_with_maximum_safe_i128_succeeds.1.json
@@ -636,7 +636,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
+++ b/creator-keys/test_snapshots/test_buy_slippage_succeeds_when_price_at_or_below_max_price.1.json
@@ -1211,7 +1211,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_after_buy_succeeds_without_underflow_error.1.json
@@ -654,7 +654,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_field_is_non_zero.1.json
@@ -654,7 +654,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
+++ b/creator-keys/test_snapshots/test_sell_event_seller_address_matches_caller.1.json
@@ -654,7 +654,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_fields_are_validated_from_fixture.1.json
@@ -767,7 +767,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
+++ b/creator-keys/test_snapshots/test_sell_key_event_payload_tracks_zero_supply_after_last_sale.1.json
@@ -654,7 +654,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
+++ b/creator-keys/test_snapshots/test_sell_slippage_succeeds_when_proceeds_meet_or_exceed_min_proceeds.1.json
@@ -1179,7 +1179,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
+++ b/creator-keys/test_snapshots/test_sell_two_keys_succeeds_without_underflow_error.1.json
@@ -772,7 +772,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
+++ b/creator-keys/test_snapshots/test_slippage_none_passthrough_preserves_existing_behavior.1.json
@@ -941,7 +941,32 @@
               }
             ],
             "data": {
-              "u32": 6311520
+              "map": [
+                {
+                  "key": {
+                    "symbol": "creator_id"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "extended_at_ledger"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "new_expiry_ledger"
+                  },
+                  "val": {
+                    "u32": 6311520
+                  }
+                }
+              ]
             }
           }
         }

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -12,8 +12,8 @@
 
 use creator_keys::{constants, CreatorKeysContract, CreatorKeysContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
-    Address, Env, IntoVal, String, Val,
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, IntoVal, String, Val, Vec,
 };
 use std::string::String as StdString;
 
@@ -504,4 +504,41 @@ pub fn compute_expected_holder_dividend(
     let net_amount = amount - protocol_amount;
     let per_key = net_amount / total_supply as i128;
     per_key * holder_balance as i128
+}
+
+/// Finds the most recent event emitted by `contract_id` matching `topics` and asserts
+/// its decoded data equals `expected_data`.
+///
+/// Filtering by contract id and topics (rather than just topics) keeps assertions
+/// correct in tests that register more than one contract instance. Panics with a
+/// message naming the contract, topics, and the expected/actual payloads when no
+/// matching event exists or the decoded data doesn't match, so a field-level
+/// regression on any event is easy to diagnose from the test output alone.
+pub fn assert_event<T, Topics>(env: &Env, contract_id: &Address, topics: Topics, expected_data: T)
+where
+    Topics: IntoVal<Env, Vec<Val>> + core::fmt::Debug,
+    T: PartialEq + core::fmt::Debug,
+    Val: IntoVal<Env, T>,
+{
+    let expected_topics: Vec<Val> = topics.into_val(env);
+
+    let all_events = env.events().all();
+    let matching = all_events
+        .iter()
+        .rev()
+        .find(|(id, event_topics, _)| id == contract_id && *event_topics == expected_topics);
+
+    let (_, _, data) = matching.unwrap_or_else(|| {
+        panic!(
+            "no event found for contract={contract_id:?} topics={expected_topics:?}; \
+             recorded events={all_events:?}"
+        )
+    });
+
+    let actual_data: T = data.into_val(env);
+    assert_eq!(
+        actual_data, expected_data,
+        "event data mismatch for contract={contract_id:?} topics={expected_topics:?}: \
+         expected {expected_data:?}, got {actual_data:?}"
+    );
 }

--- a/creator-keys/tests/protocol_fee_recipient_updated_event.rs
+++ b/creator-keys/tests/protocol_fee_recipient_updated_event.rs
@@ -5,11 +5,11 @@
 //!
 //! Event shape emitted by `update_protocol_fee_recipient`:
 //! - topics: `(PROTOCOL_FEE_RECIPIENT_UPDATED_EVENT_NAME, admin)`
-//! - data:   `ProtocolFeeRecipientUpdatedEvent { old_recipient, new_recipient }`
+//! - data:   `ProtocolFeeRecipientUpdatedEvent { old_recipient, new_recipient, updated_at_ledger }`
 
 mod contract_test_env;
 
-use contract_test_env::{register_creator_keys, test_env_with_auths};
+use contract_test_env::{assert_event, register_creator_keys, test_env_with_auths};
 use creator_keys::events;
 use soroban_sdk::{
     testutils::{Address as _, Events},
@@ -23,8 +23,9 @@ fn setup_update(
     Address,
     Address,
     Address,
+    Address,
 ) {
-    let (client, _) = register_creator_keys(env);
+    let (client, contract_id) = register_creator_keys(env);
     let admin = Address::generate(env);
     let old_recipient = Address::generate(env);
     let new_recipient = Address::generate(env);
@@ -33,7 +34,7 @@ fn setup_update(
     client.set_protocol_fee_recipient(&admin, &old_recipient);
     client.update_protocol_fee_recipient(&admin, &new_recipient);
 
-    (client, admin, old_recipient, new_recipient)
+    (client, contract_id, admin, old_recipient, new_recipient)
 }
 
 fn last_event_data(env: &Env) -> events::ProtocolFeeRecipientUpdatedEvent {
@@ -45,7 +46,7 @@ fn last_event_data(env: &Env) -> events::ProtocolFeeRecipientUpdatedEvent {
 #[test]
 fn test_protocol_fee_recipient_updated_event_old_recipient_field() {
     let env = test_env_with_auths();
-    let (_, _, old_recipient, _) = setup_update(&env);
+    let (_, _, _, old_recipient, _) = setup_update(&env);
 
     let payload = last_event_data(&env);
     assert_eq!(
@@ -57,7 +58,7 @@ fn test_protocol_fee_recipient_updated_event_old_recipient_field() {
 #[test]
 fn test_protocol_fee_recipient_updated_event_new_recipient_field() {
     let env = test_env_with_auths();
-    let (_, _, _, new_recipient) = setup_update(&env);
+    let (_, _, _, _, new_recipient) = setup_update(&env);
 
     let payload = last_event_data(&env);
     assert_eq!(
@@ -67,9 +68,30 @@ fn test_protocol_fee_recipient_updated_event_new_recipient_field() {
 }
 
 #[test]
+fn test_protocol_fee_recipient_updated_event_updated_at_ledger_field() {
+    let env = test_env_with_auths();
+    let ledger_before_update = env.ledger().sequence();
+    let (_, contract_id, admin, old_recipient, new_recipient) = setup_update(&env);
+
+    assert_event(
+        &env,
+        &contract_id,
+        (
+            events::PROTOCOL_FEE_RECIPIENT_UPDATED_EVENT_NAME,
+            admin.clone(),
+        ),
+        events::ProtocolFeeRecipientUpdatedEvent {
+            old_recipient,
+            new_recipient,
+            updated_at_ledger: ledger_before_update,
+        },
+    );
+}
+
+#[test]
 fn test_protocol_fee_recipient_updated_event_emitted_once_per_update() {
     let env = test_env_with_auths();
-    let (_, _, old_recipient, _) = setup_update(&env);
+    let (_, _, _, old_recipient, _) = setup_update(&env);
 
     let all_events = env.events().all();
     let update_event_count = all_events

--- a/creator-keys/tests/ttl_extension_on_buy.rs
+++ b/creator-keys/tests/ttl_extension_on_buy.rs
@@ -5,7 +5,9 @@
 
 mod contract_test_env;
 
-use contract_test_env::{register_creator_keys, register_test_creator, set_key_price_for_tests};
+use contract_test_env::{
+    assert_event, register_creator_keys, register_test_creator, set_key_price_for_tests,
+};
 use creator_keys::constants::storage;
 use creator_keys::events::{self, ttl_extended_topics};
 use creator_keys::CREATOR_TTL_LEDGERS;
@@ -90,7 +92,7 @@ fn test_ttl_extension_event_topics_and_payload() {
     assert_eq!(result, Ok(Ok(1)), "buy should succeed");
 
     let events = env.events().all();
-    let (topics, data) = events
+    let (topics, _) = events
         .iter()
         .rev()
         .find_map(|(_, topics, data)| {
@@ -109,9 +111,17 @@ fn test_ttl_extension_event_topics_and_payload() {
     let topic1: Address = topics.get(1).unwrap().into_val(&env);
     assert_eq!(topic1, creator);
 
-    let extend_to: u32 = data.into_val(&env);
-    let expected_extend_to = ledger_before_buy + CREATOR_TTL_LEDGERS;
-    assert_eq!(extend_to, expected_extend_to);
+    let expected_new_expiry_ledger = ledger_before_buy + CREATOR_TTL_LEDGERS;
+    assert_event(
+        &env,
+        &contract_id,
+        ttl_extended_topics(&creator),
+        events::TtlExtendedEvent {
+            creator_id: creator.clone(),
+            extended_at_ledger: ledger_before_buy,
+            new_expiry_ledger: expected_new_expiry_ledger,
+        },
+    );
 }
 
 /// Second buy on the same ledger does NOT further extend TTL


### PR DESCRIPTION
## Summary
- Emit a `TtlExtendedEvent` on TTL extension with `creator_id`, `extended_at_ledger`, and `new_expiry_ledger` fields (previously the event carried only a bare `u32` expiry value).
- Add an `updated_at_ledger` field to `ProtocolFeeRecipientUpdatedEvent`, emitted from both `set_protocol_fee_recipient` and `update_protocol_fee_recipient`.
- Add a shared `assert_event(env, contract_id, topics, expected_data)` test helper in `contract_test_env` that finds the most recent event matching a contract id + topics tuple and asserts the decoded data, with a clear mismatch message naming the contract, topics, and expected/actual payloads.
- Update TTL and fee-recipient event tests to use the new helper and assert the new fields.
- Regenerate affected `test_snapshots` fixtures to reflect the new event payload shapes.

## Test plan
- [x] `cargo test --workspace` (143 test result blocks, all passing)
- [x] `cargo fmt --all -- --check`

Closes #573