### PR TITLE
Add integration test for admin function reverts leaving protocol config values unchanged

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2444,6 +2444,7 @@ impl CreatorKeysContract {
         protocol_bps: u32,
     ) -> Result<(), ContractError> {
         admin.require_auth();
+        assert_is_admin(&env, &admin)?;
         fee::assert_valid_fee_bps(creator_bps, protocol_bps)?;
 
         let config = fee::FeeConfig {
@@ -2668,6 +2669,7 @@ impl CreatorKeysContract {
         recipient: Address,
     ) -> Result<(), ContractError> {
         admin.require_auth();
+        assert_is_admin(&env, &admin)?;
         validate_non_zero_address(&env, &recipient)?;
 
         let old_recipient: Option<Address> = env

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -4529,6 +4529,7 @@ mod tests {
         let client = super::CreatorKeysContractClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
 
+        client.set_protocol_admin(&admin, &admin);
         client.set_fee_config(&admin, &9000, &1000);
 
         let bps = env.as_contract(&contract_id, || super::read_protocol_fee_bps(&env));

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -789,6 +789,7 @@ mod issue_tests {
 
         let protocol_bps = 250u32; // 2.5%
         let creator_bps = 500u32; // 5.0%
+        client.set_protocol_admin(&admin, &admin);
         client.set_fee_config(&admin, &creator_bps, &protocol_bps);
 
         let creator = register_creator(&env, &client, None);

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -114,6 +114,7 @@ mod issue_tests {
         let client = CreatorKeysContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        client.set_protocol_admin(&admin, &admin);
         client.set_key_price(&admin, &KEY_PRICE);
         client.set_fee_config(&admin, &10_000, &0);
 

--- a/creator-keys/tests/admin_unauthorized.rs
+++ b/creator-keys/tests/admin_unauthorized.rs
@@ -5,7 +5,7 @@
 
 mod contract_test_env;
 
-use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
+use contract_test_env::{register_creator_keys, set_pricing_and_fees, set_protocol_fee_bps, test_env_with_auths};
 use creator_keys::{ContractError, CreatorKeysContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
@@ -128,6 +128,74 @@ fn test_update_protocol_fee_recipient_no_state_change_on_non_admin_call() {
         stored,
         Some(old_recipient),
         "fee recipient must not change when non-admin call is rejected"
+    );
+}
+
+// ── set_fee_config ──────────────────────────────────────────────────────
+
+#[test]
+fn test_set_fee_config_reverts_for_non_admin() {
+    let env = test_env_with_auths();
+    let (client, _admin) = full_setup(&env);
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_fee_config(&non_admin, &8000u32, &2000u32);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_set_fee_config_no_state_change_on_non_admin_call() {
+    let env = test_env_with_auths();
+    let (client, _admin) = full_setup(&env);
+
+    let protocol_bps_before = client.get_protocol_fee_bps().unwrap();
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_fee_config(&non_admin, &8000u32, &2000u32);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+
+    let protocol_bps_after = client.get_protocol_fee_bps().unwrap();
+    assert_eq!(
+        protocol_bps_before, protocol_bps_after,
+        "protocol fee bps must not change when non-admin set_fee_config call is rejected"
+    );
+}
+
+// ── set_protocol_fee_recipient ──────────────────────────────────────────
+
+#[test]
+fn test_set_protocol_fee_recipient_reverts_for_non_admin() {
+    let env = test_env_with_auths();
+    let (client, _admin) = full_setup(&env);
+
+    let original_recipient = Address::generate(&env);
+    let admin = setup_admin(&env, &client);
+    client.set_protocol_fee_recipient(&admin, &original_recipient);
+
+    let non_admin = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let result = client.try_set_protocol_fee_recipient(&non_admin, &new_recipient);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_set_protocol_fee_recipient_no_state_change_on_non_admin_call() {
+    let env = test_env_with_auths();
+    let (client, _admin) = full_setup(&env);
+
+    let admin = setup_admin(&env, &client);
+    let original_recipient = Address::generate(&env);
+    client.set_protocol_fee_recipient(&admin, &original_recipient);
+
+    let non_admin = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let _ = client.try_set_protocol_fee_recipient(&non_admin, &new_recipient);
+
+    let stored = client.get_protocol_fee_recipient();
+    assert_eq!(
+        stored,
+        Some(original_recipient),
+        "fee recipient must not change when non-admin set_protocol_fee_recipient call is rejected"
     );
 }
 

--- a/creator-keys/tests/admin_unauthorized.rs
+++ b/creator-keys/tests/admin_unauthorized.rs
@@ -11,18 +11,10 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-/// Register a known admin into contract storage and return it.
-fn setup_admin(env: &Env, client: &CreatorKeysContractClient<'_>) -> Address {
-    let admin = Address::generate(env);
-    client.set_protocol_admin(&admin, &admin);
-    admin
-}
-
 /// Full setup: contract + pricing + fees + admin. Returns (client, admin).
 fn full_setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address) {
     let (client, _) = register_creator_keys(env);
-    set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
-    let admin = setup_admin(env, &client);
+    let admin = set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
     (client, admin)
 }
 
@@ -166,10 +158,9 @@ fn test_set_fee_config_no_state_change_on_non_admin_call() {
 #[test]
 fn test_set_protocol_fee_recipient_reverts_for_non_admin() {
     let env = test_env_with_auths();
-    let (client, _admin) = full_setup(&env);
+    let (client, admin) = full_setup(&env);
 
     let original_recipient = Address::generate(&env);
-    let admin = setup_admin(&env, &client);
     client.set_protocol_fee_recipient(&admin, &original_recipient);
 
     let non_admin = Address::generate(&env);
@@ -181,9 +172,8 @@ fn test_set_protocol_fee_recipient_reverts_for_non_admin() {
 #[test]
 fn test_set_protocol_fee_recipient_no_state_change_on_non_admin_call() {
     let env = test_env_with_auths();
-    let (client, _admin) = full_setup(&env);
+    let (client, admin) = full_setup(&env);
 
-    let admin = setup_admin(&env, &client);
     let original_recipient = Address::generate(&env);
     client.set_protocol_fee_recipient(&admin, &original_recipient);
 

--- a/creator-keys/tests/admin_unauthorized.rs
+++ b/creator-keys/tests/admin_unauthorized.rs
@@ -1,5 +1,5 @@
 //! Integration tests for admin-only functions reverting when called by a non-admin.
-//!
+//
 //! Every function gated by `assert_is_admin` must reject a non-admin caller with
 //! `ContractError::Unauthorized` and must not mutate any contract state.
 

--- a/creator-keys/tests/admin_unauthorized.rs
+++ b/creator-keys/tests/admin_unauthorized.rs
@@ -5,7 +5,7 @@
 
 mod contract_test_env;
 
-use contract_test_env::{register_creator_keys, set_pricing_and_fees, set_protocol_fee_bps, test_env_with_auths};
+use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
 use creator_keys::{ContractError, CreatorKeysContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
@@ -148,13 +148,13 @@ fn test_set_fee_config_no_state_change_on_non_admin_call() {
     let env = test_env_with_auths();
     let (client, _admin) = full_setup(&env);
 
-    let protocol_bps_before = client.get_protocol_fee_bps().unwrap();
+    let protocol_bps_before = client.get_protocol_fee_bps();
 
     let non_admin = Address::generate(&env);
     let result = client.try_set_fee_config(&non_admin, &8000u32, &2000u32);
     assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
 
-    let protocol_bps_after = client.get_protocol_fee_bps().unwrap();
+    let protocol_bps_after = client.get_protocol_fee_bps();
     assert_eq!(
         protocol_bps_before, protocol_bps_after,
         "protocol fee bps must not change when non-admin set_fee_config call is rejected"

--- a/creator-keys/tests/batch_claim_dividend.rs
+++ b/creator-keys/tests/batch_claim_dividend.rs
@@ -138,7 +138,7 @@ fn test_batch_claim_exceeds_limit_reverts() {
 fn test_batch_claim_while_paused_fails() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(
+    let admin = set_pricing_and_fees(
         &env,
         &client,
         100,
@@ -153,8 +153,6 @@ fn test_batch_claim_while_paused_fails() {
     let distributor = Address::generate(&env);
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
 
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.pause(&admin);
 
     let creators = Vec::from_array(&env, [creator.clone()]);

--- a/creator-keys/tests/buy_fee_split_treasury_and_creator.rs
+++ b/creator-keys/tests/buy_fee_split_treasury_and_creator.rs
@@ -26,6 +26,7 @@ fn test_buy_splits_fees_correctly_between_treasury_and_creator() {
 
     // Configure pricing and fee split: 500 bps (5%) protocol fee, 200 bps (2%) creator fee
     client.set_key_price(&admin, &gross_cost);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &CREATOR_BPS, &PROTOCOL_BPS);
 
     let protocol_recipient = soroban_sdk::Address::generate(&env);
@@ -106,6 +107,7 @@ fn test_buy_fee_split_accumulates_across_multiple_buys() {
     let gross_cost: i128 = 5 * STROOPS_PER_DISPLAY_UNIT; // 5 XLM = 50,000,000 stroops
 
     client.set_key_price(&admin, &gross_cost);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &CREATOR_BPS, &PROTOCOL_BPS);
 
     let creator = register_test_creator(&env, &client, "bob");
@@ -145,6 +147,7 @@ fn test_buy_fee_split_no_stroop_rounding_error_at_odd_gross_cost() {
     let gross_cost: i128 = 1_234_567; // Odd stroop amount to verify integer arithmetic precision
 
     client.set_key_price(&admin, &gross_cost);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &CREATOR_BPS, &PROTOCOL_BPS);
 
     let creator = register_test_creator(&env, &client, "carol");

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -381,6 +381,7 @@ fn test_buy_quote_updates_after_fee_config_mutation() {
 
     // Update fee config: 50% creator, 50% protocol
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &5000u32, &5000u32);
 
     // Get quote after fee config update

--- a/creator-keys/tests/buy_quote_monotonicity.rs
+++ b/creator-keys/tests/buy_quote_monotonicity.rs
@@ -367,7 +367,7 @@ fn test_buy_quote_updates_after_fee_config_mutation() {
     let price = 1_000_i128;
 
     // Set initial fee config: 90% creator, 10% protocol
-    set_pricing_and_fees(&env, &client, price, 9000, 1000);
+    let admin = set_pricing_and_fees(&env, &client, price, 9000, 1000);
     let creator = register_test_creator(&env, &client, "alice");
 
     // Get quote with initial fee config
@@ -380,8 +380,6 @@ fn test_buy_quote_updates_after_fee_config_mutation() {
     assert_eq!(q_before.total_amount, price + 900 + 100);
 
     // Update fee config: 50% creator, 50% protocol
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &5000u32, &5000u32);
 
     // Get quote after fee config update

--- a/creator-keys/tests/buy_quote_stability.rs
+++ b/creator-keys/tests/buy_quote_stability.rs
@@ -5,7 +5,7 @@ mod contract_test_env;
 use contract_test_env::{
     register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
 };
-use soroban_sdk::Vec;
+use soroban_sdk::{testutils::Address as _, Address, Vec};
 
 #[test]
 fn test_buy_quote_is_stable_across_multiple_calls() {
@@ -51,6 +51,9 @@ fn test_buy_quote_stability_with_different_fee_configs() {
     let (client, _) = register_creator_keys(&env);
     let creator = register_test_creator(&env, &client, "alice");
 
+    let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
+
     // Test cases for different fee configurations
     let configs = [
         (1000, 9500, 500),  // 5% protocol fee
@@ -59,7 +62,8 @@ fn test_buy_quote_stability_with_different_fee_configs() {
     ];
 
     for (price, c_bps, p_bps) in configs {
-        set_pricing_and_fees(&env, &client, price, c_bps, p_bps);
+        client.set_key_price(&admin, &price);
+        client.set_fee_config(&admin, &c_bps, &p_bps);
 
         let supply_before = client.get_creator_supply(&creator);
 

--- a/creator-keys/tests/buy_quote_zero_supply.rs
+++ b/creator-keys/tests/buy_quote_zero_supply.rs
@@ -44,10 +44,12 @@ fn test_buy_quote_zero_supply_various_prices() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
 
+    let admin = set_pricing_and_fees(&env, &client, 1000, 9000, 1000);
+
     let test_prices = [1, 10, 100, 500, 1000, 10000];
 
     for (i, price) in test_prices.iter().enumerate() {
-        set_pricing_and_fees(&env, &client, *price, 9000, 1000);
+        client.set_key_price(&admin, price);
         let creator = register_test_creator(&env, &client, &format!("creator{}", i));
 
         let quote = client.get_buy_quote(&creator);

--- a/creator-keys/tests/claim_dividend.rs
+++ b/creator-keys/tests/claim_dividend.rs
@@ -103,7 +103,7 @@ fn test_double_claim_fails_with_no_claimable() {
 fn test_claim_dividend_while_paused_fails() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(
+    let admin = set_pricing_and_fees(
         &env,
         &client,
         100,
@@ -117,8 +117,6 @@ fn test_claim_dividend_while_paused_fails() {
     let distributor = Address::generate(&env);
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
 
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.pause(&admin);
 
     let result = client.try_claim_dividend(&creator, &buyer);

--- a/creator-keys/tests/claimable_dividend_view.rs
+++ b/creator-keys/tests/claimable_dividend_view.rs
@@ -125,7 +125,7 @@ fn test_get_claimable_dividend_accumulates_across_distributions() {
 fn test_get_claimable_dividend_works_while_paused() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(
+    let admin = set_pricing_and_fees(
         &env,
         &client,
         100,
@@ -139,8 +139,6 @@ fn test_get_claimable_dividend_works_while_paused() {
     let distributor = Address::generate(&env);
     distribute_test_dividend(&client, &creator, &distributor, 10_000);
 
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.pause(&admin);
 
     // Read-only view must work even when protocol is paused.

--- a/creator-keys/tests/contract_initialization_event.rs
+++ b/creator-keys/tests/contract_initialization_event.rs
@@ -20,6 +20,7 @@ fn test_initialization_event_emitted_on_first_set_fee_config() {
 
     let admin = Address::generate(&env);
     let recipient = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_protocol_fee_recipient(&admin, &recipient);
 
     let test_ledger = 10u32;
@@ -67,6 +68,8 @@ fn test_initialization_event_not_emitted_on_reinit() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+
+    client.set_protocol_admin(&admin, &admin);
 
     // First initialization
     client.set_fee_config(&admin, &9000u32, &1000u32);

--- a/creator-keys/tests/contract_test_env/mod.rs
+++ b/creator-keys/tests/contract_test_env/mod.rs
@@ -80,6 +80,7 @@ pub fn set_protocol_fee_bps(
     protocol_bps: u32,
 ) -> Address {
     let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     admin
 }
@@ -93,6 +94,7 @@ pub fn set_pricing_and_fees(
     protocol_bps: u32,
 ) -> Address {
     let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_key_price(&admin, &key_price);
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     admin
@@ -139,6 +141,7 @@ pub fn register_test_creator_with_fee_config(
     protocol_bps: u32,
 ) -> Address {
     let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &creator_bps, &protocol_bps);
     let creator = Address::generate(env);
     client.register_creator(

--- a/creator-keys/tests/creator_fee_bps.rs
+++ b/creator-keys/tests/creator_fee_bps.rs
@@ -11,6 +11,7 @@ fn test_get_creator_fee_bps_returns_configured_value() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
 
     client.register_creator(
@@ -38,6 +39,7 @@ fn test_get_creator_fee_bps_is_read_only() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
 
     client.register_creator(
@@ -68,6 +70,7 @@ fn test_get_creator_fee_bps_tracks_fee_config_updates() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
 
     client.register_creator(

--- a/creator-keys/tests/creator_fee_config_view.rs
+++ b/creator-keys/tests/creator_fee_config_view.rs
@@ -58,6 +58,7 @@ fn test_get_creator_fee_config_registered_with_fee_config() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
@@ -92,6 +93,7 @@ fn test_get_creator_fee_config_is_read_only() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
@@ -127,6 +129,7 @@ fn test_get_creator_fee_config_updates_after_fee_reconfiguration() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = soroban_sdk::Address::generate(&env);
     let handle = String::from_str(&env, "test_creator");
 
@@ -163,6 +166,7 @@ fn test_get_creator_fee_config_multiple_creators_independent() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator1 = soroban_sdk::Address::generate(&env);
     let creator2 = soroban_sdk::Address::generate(&env);
     let handle1 = String::from_str(&env, "creator_one");
@@ -212,6 +216,7 @@ fn test_get_creator_fee_config_unregistered_after_fee_config_set() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let unregistered_creator = soroban_sdk::Address::generate(&env);
 
     client.set_fee_config(&admin, &9000u32, &1000u32);

--- a/creator-keys/tests/creator_treasury_share.rs
+++ b/creator-keys/tests/creator_treasury_share.rs
@@ -11,6 +11,7 @@ fn test_get_creator_treasury_share_returns_configured_value() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
 
     client.register_creator(
@@ -38,6 +39,7 @@ fn test_get_creator_treasury_share_is_read_only() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
 
     client.register_creator(

--- a/creator-keys/tests/distribute_dividend.rs
+++ b/creator-keys/tests/distribute_dividend.rs
@@ -109,7 +109,7 @@ fn test_distribute_dividend_no_fee_config_fails() {
 fn test_distribute_dividend_while_paused_fails() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(
+    let admin = set_pricing_and_fees(
         &env,
         &client,
         100,
@@ -120,8 +120,6 @@ fn test_distribute_dividend_while_paused_fails() {
     let buyer = Address::generate(&env);
     client.buy_key(&creator, &buyer, &100, &None);
 
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.pause(&admin);
 
     let distributor = Address::generate(&env);

--- a/creator-keys/tests/emergency_pause_blocks_trading.rs
+++ b/creator-keys/tests/emergency_pause_blocks_trading.rs
@@ -26,9 +26,7 @@ const PROTOCOL_BPS: u32 = 1_000;
 /// Deploy the contract with pricing, fees, a protocol admin and one creator.
 fn setup(env: &Env) -> (CreatorKeysContractClient<'_>, Address, Address) {
     let (client, _) = register_creator_keys(env);
-    set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-    let admin = Address::generate(env);
-    client.set_protocol_admin(&admin, &admin);
+    let admin = set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
     let creator = register_test_creator(env, &client, "alice");
     (client, admin, creator)
 }

--- a/creator-keys/tests/fee_config_updated_event.rs
+++ b/creator-keys/tests/fee_config_updated_event.rs
@@ -50,6 +50,7 @@ fn test_creator_fee_bps_updates_sequentially() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // First ever update (no old config), assert old_bps is 0
     client.set_fee_config(&admin, &200, &9800);

--- a/creator-keys/tests/fee_config_updated_event.rs
+++ b/creator-keys/tests/fee_config_updated_event.rs
@@ -14,6 +14,7 @@ fn test_fee_config_updated_event_emitted() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // Initial set (no old config)
     client.set_fee_config(&admin, &9000, &1000);

--- a/creator-keys/tests/fee_config_view.rs
+++ b/creator-keys/tests/fee_config_view.rs
@@ -23,6 +23,7 @@ fn test_get_protocol_fee_view_returns_configured_values() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -40,6 +41,7 @@ fn test_get_protocol_fee_view_is_read_only() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
@@ -59,6 +61,7 @@ fn test_get_protocol_fee_view_updates_after_reconfiguration() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let v1 = client.get_protocol_fee_view();
@@ -78,6 +81,7 @@ fn test_protocol_fee_bps_multiple_sequential_updates() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // First update
     client.set_fee_config(&admin, &9000u32, &1000u32);

--- a/creator-keys/tests/fee_split.rs
+++ b/creator-keys/tests/fee_split.rs
@@ -12,6 +12,7 @@ fn test_set_and_get_fee_config() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let config = client.get_fee_config();
@@ -28,6 +29,7 @@ fn test_compute_fees_for_payment() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -45,6 +47,7 @@ fn test_set_fee_config_invalid_sum_fails() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     let result = client.try_set_fee_config(&admin, &8000u32, &3000u32);
     assert_eq!(result, Err(Ok(ContractError::InvalidFeeConfig)));
@@ -58,6 +61,7 @@ fn test_set_fee_config_max_protocol_bps_succeeds() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &5000u32, &5000u32);
     let config = client.get_fee_config().unwrap();
@@ -73,6 +77,7 @@ fn test_set_fee_config_max_creator_bps_succeeds() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &10000u32, &0u32);
     let config = client.get_fee_config().unwrap();
@@ -88,6 +93,7 @@ fn test_set_fee_config_creator_bps_above_max_fails() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     let result = client.try_set_fee_config(&admin, &10001u32, &0u32);
     assert_eq!(result, Err(Ok(ContractError::InvalidFeeConfig)));
@@ -101,6 +107,7 @@ fn test_set_fee_config_protocol_bps_above_max_fails() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     let result = client.try_set_fee_config(&admin, &0u32, &10001u32);
     assert_eq!(result, Err(Ok(ContractError::ProtocolFeeExceedsCap)));

--- a/creator-keys/tests/identical_fee_configs_independent.rs
+++ b/creator-keys/tests/identical_fee_configs_independent.rs
@@ -66,7 +66,7 @@ fn test_fee_config_update_does_not_affect_other_creator() {
     let key_price = 1000_i128;
     let creator_bps = 9000;
     let protocol_bps = 1000;
-    set_pricing_and_fees(&env, &client, key_price, creator_bps, protocol_bps);
+    let admin = set_pricing_and_fees(&env, &client, key_price, creator_bps, protocol_bps);
 
     // Register two creators
     let creator1 = register_test_creator(&env, &client, "alice");
@@ -77,8 +77,6 @@ fn test_fee_config_update_does_not_affect_other_creator() {
     let quote2_initial = client.get_buy_quote(&creator2);
 
     // Update global fee config
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     // Both creators should see the new fee config (since it's global)

--- a/creator-keys/tests/identical_fee_configs_independent.rs
+++ b/creator-keys/tests/identical_fee_configs_independent.rs
@@ -78,6 +78,7 @@ fn test_fee_config_update_does_not_affect_other_creator() {
 
     // Update global fee config
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     // Both creators should see the new fee config (since it's global)

--- a/creator-keys/tests/initialization_event_fields.rs
+++ b/creator-keys/tests/initialization_event_fields.rs
@@ -16,6 +16,7 @@ fn test_initialization_event_admin_matches_argument() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "test_handle");
 
@@ -50,6 +51,7 @@ fn test_initialization_event_protocol_fee_bps_matches_argument() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "test_handle");
 
@@ -89,6 +91,7 @@ fn test_initialization_event_protocol_fee_recipient_matches_argument() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "test_handle");
 
@@ -126,6 +129,7 @@ fn test_initialization_event_initialized_at_ledger_matches_current() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let handle = String::from_str(&env, "test_handle");
 

--- a/creator-keys/tests/max_amount_inputs.rs
+++ b/creator-keys/tests/max_amount_inputs.rs
@@ -56,6 +56,7 @@ fn test_buy_quote_with_large_amount_succeeds() {
     let large_price = 500_000_000_000i128;
     set_stored_key_price(&env, &contract_id, large_price);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let creator = register_test_creator(&env, &client, "creator3");
 
@@ -71,6 +72,7 @@ fn test_buy_quote_with_maximum_safe_amount_succeeds() {
     let max_safe_amount = 9_223_372_036_854_775i128;
     set_stored_key_price(&env, &contract_id, max_safe_amount);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let creator = register_test_creator(&env, &client, "creator4");
 
@@ -86,6 +88,7 @@ fn test_sell_quote_with_large_amount_succeeds() {
     let large_price = 500_000_000_000i128;
     set_stored_key_price(&env, &contract_id, large_price);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let creator = register_test_creator(&env, &client, "creator5");
     let holder = register_holder_with_one_key(&env, &client, &creator);
@@ -102,6 +105,7 @@ fn test_sell_quote_with_maximum_safe_amount_succeeds() {
     let max_safe_amount = 9_223_372_036_854_775i128;
     set_stored_key_price(&env, &contract_id, max_safe_amount);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let creator = register_test_creator(&env, &client, "creator6");
     let holder = register_holder_with_one_key(&env, &client, &creator);
@@ -117,6 +121,7 @@ fn test_buy_quote_with_maximum_safe_amount_50_50_fees_succeeds() {
     let max_safe_amount = 9_223_372_036_854_775i128;
     set_stored_key_price(&env, &contract_id, max_safe_amount);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &5000u32, &5000u32);
     let creator = register_test_creator(&env, &client, "creator7");
 
@@ -135,6 +140,7 @@ fn test_sell_quote_with_maximum_safe_amount_50_50_fees_succeeds() {
     let max_safe_amount = 9_223_372_036_854_775i128;
     set_stored_key_price(&env, &contract_id, max_safe_amount);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &5000u32, &5000u32);
     let creator = register_test_creator(&env, &client, "creator8");
     let holder = register_holder_with_one_key(&env, &client, &creator);

--- a/creator-keys/tests/multiple_creators_independent.rs
+++ b/creator-keys/tests/multiple_creators_independent.rs
@@ -67,6 +67,7 @@ fn test_fee_bps_update_for_a_does_not_change_b() {
     assert_eq!(fee_b_before.creator_bps, 9_000);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8_000u32, &2_000u32);
 
     let fee_a_after = client.get_creator_fee_config(&creator_a);

--- a/creator-keys/tests/multiple_creators_independent.rs
+++ b/creator-keys/tests/multiple_creators_independent.rs
@@ -55,7 +55,7 @@ fn test_holder_balance_a_does_not_affect_holder_balance_b() {
 fn test_fee_bps_update_for_a_does_not_change_b() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(&env, &client, 1_000_i128, 9_000, 1_000);
+    let admin = set_pricing_and_fees(&env, &client, 1_000_i128, 9_000, 1_000);
 
     let creator_a = register_test_creator(&env, &client, "alice");
     let creator_b = register_test_creator(&env, &client, "bob");
@@ -66,8 +66,6 @@ fn test_fee_bps_update_for_a_does_not_change_b() {
     assert_eq!(fee_a_before.creator_bps, 9_000);
     assert_eq!(fee_b_before.creator_bps, 9_000);
 
-    let admin = soroban_sdk::Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8_000u32, &2_000u32);
 
     let fee_a_after = client.get_creator_fee_config(&creator_a);

--- a/creator-keys/tests/pause_blocks_buy_sell_integration.rs
+++ b/creator-keys/tests/pause_blocks_buy_sell_integration.rs
@@ -23,10 +23,7 @@ const PROTOCOL_BPS: u32 = 1_000;
 fn test_buy_and_sell_revert_while_paused_then_buy_succeeds_after_unpause() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
-    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-
-    let admin = Address::generate(&env);
-    client.set_protocol_admin(&admin, &admin);
+    let admin = set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
 
     let creator = register_test_creator(&env, &client, "alice");
     let buyer = Address::generate(&env);

--- a/creator-keys/tests/protocol_admin.rs
+++ b/creator-keys/tests/protocol_admin.rs
@@ -91,7 +91,7 @@ fn test_protocol_admin_unchanged_after_fee_config_update() {
     client.set_protocol_admin(&admin, &protocol_admin);
 
     let before = client.get_protocol_admin();
-    client.set_fee_config(&admin, &8000u32, &2000u32);
+    client.set_fee_config(&protocol_admin, &8000u32, &2000u32);
     let after = client.get_protocol_admin();
 
     assert_eq!(before, Some(protocol_admin));

--- a/creator-keys/tests/protocol_config_initialized.rs
+++ b/creator-keys/tests/protocol_config_initialized.rs
@@ -26,6 +26,7 @@ fn test_is_protocol_config_initialized_returns_true_after_fee_config_is_set() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
@@ -40,6 +41,7 @@ fn test_is_protocol_config_initialized_is_read_only() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &8000u32, &2000u32);
 

--- a/creator-keys/tests/protocol_fee_bps_read.rs
+++ b/creator-keys/tests/protocol_fee_bps_read.rs
@@ -15,6 +15,7 @@ fn test_get_protocol_fee_bps_returns_stored_value() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000, &1000);
 
     let bps = client.get_protocol_fee_bps();
@@ -27,6 +28,7 @@ fn test_get_protocol_fee_bps_returns_updated_value() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000, &1000);
     assert_eq!(client.get_protocol_fee_bps(), 1000);
 
@@ -58,6 +60,7 @@ fn test_get_protocol_fee_bps_does_not_mutate_state() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9500, &500);
 
     let first = client.get_protocol_fee_bps();
@@ -75,6 +78,7 @@ fn test_get_protocol_fee_bps_persists_across_operations() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8500, &1500);
 
     let creator = soroban_sdk::Address::generate(&env);

--- a/creator-keys/tests/protocol_fee_recipient.rs
+++ b/creator-keys/tests/protocol_fee_recipient.rs
@@ -53,6 +53,7 @@ fn test_get_protocol_fee_recipient_reflects_set_entrypoint() {
     let admin = Address::generate(&env);
     let recipient = Address::generate(&env);
 
+    client.set_protocol_admin(&admin, &admin);
     client.set_protocol_fee_recipient(&admin, &recipient);
 
     assert_eq!(
@@ -92,6 +93,7 @@ fn test_get_protocol_fee_recipient_tracks_overwrites() {
     let first = Address::generate(&env);
     let second = Address::generate(&env);
 
+    client.set_protocol_admin(&admin, &admin);
     client.set_protocol_fee_recipient(&admin, &first);
     assert_eq!(
         client.get_protocol_fee_recipient(),

--- a/creator-keys/tests/protocol_fee_supply_edge_cases.rs
+++ b/creator-keys/tests/protocol_fee_supply_edge_cases.rs
@@ -130,7 +130,7 @@ fn test_protocol_fee_rounding_is_floor_not_ceiling() {
     // 1. Price = 999: 999 * 1000 / 10000 = 99.9 stroops
     // Floor is 99, ceiling would be 100.
     let key_price = 999_i128;
-    set_pricing_and_fees(&env, &client, key_price, creator_bps, protocol_bps);
+    let admin = set_pricing_and_fees(&env, &client, key_price, creator_bps, protocol_bps);
 
     let creator1 = register_test_creator(&env, &client, "floor_test_999");
     let quote1 = client.get_buy_quote(&creator1);
@@ -150,7 +150,7 @@ fn test_protocol_fee_rounding_is_floor_not_ceiling() {
     // 2. Price = 1: 1 * 1000 / 10000 = 0.1 stroops
     // Floor is 0, ceiling would be 1.
     let key_price_dust = 1_i128;
-    set_pricing_and_fees(&env, &client, key_price_dust, creator_bps, protocol_bps);
+    client.set_key_price(&admin, &key_price_dust);
 
     let creator2 = register_test_creator(&env, &client, "floor_test_1");
     let quote2 = client.get_buy_quote(&creator2);
@@ -170,7 +170,7 @@ fn test_protocol_fee_rounding_is_floor_not_ceiling() {
     // 3. Price = 1001: 1001 * 1000 / 10000 = 100.1 stroops
     // Floor is 100, ceiling would be 101.
     let key_price_1001 = 1001_i128;
-    set_pricing_and_fees(&env, &client, key_price_1001, creator_bps, protocol_bps);
+    client.set_key_price(&admin, &key_price_1001);
 
     let creator3 = register_test_creator(&env, &client, "floor_test_1001");
     let quote3 = client.get_buy_quote(&creator3);

--- a/creator-keys/tests/protocol_state_version.rs
+++ b/creator-keys/tests/protocol_state_version.rs
@@ -33,6 +33,7 @@ fn test_protocol_state_version_increments_on_fee_config_update() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // Read initial version
     let version_before = client.get_protocol_state_version();
@@ -64,6 +65,7 @@ fn test_protocol_state_version_monotonically_increasing() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     let mut previous_version = client.get_protocol_state_version();
 
@@ -89,6 +91,7 @@ fn test_get_protocol_state_version_increments_only_on_config_updates() {
     let client = CreatorKeysContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let buyer = Address::generate(&env);
 

--- a/creator-keys/tests/protocol_treasury_share.rs
+++ b/creator-keys/tests/protocol_treasury_share.rs
@@ -32,6 +32,7 @@ fn test_get_protocol_treasury_share_bps_returns_configured_value() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
@@ -52,6 +53,7 @@ fn test_get_protocol_treasury_share_bps_tracks_configuration_updates() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // First configuration: 2000 bps protocol share
     client.set_fee_config(&admin, &8000u32, &2000u32);
@@ -78,6 +80,7 @@ fn test_get_protocol_treasury_share_bps_is_read_only() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     client.set_fee_config(&admin, &7000u32, &3000u32);
 
@@ -106,6 +109,7 @@ fn test_get_protocol_treasury_share_bps_explicit_basis_point_units() {
     let contract_id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // Test: 100 bps = 1% protocol share
     client.set_fee_config(&admin, &9900u32, &100u32);

--- a/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
+++ b/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
@@ -29,6 +29,7 @@ fn test_read_protocol_fee_bps_succeeds_when_initialized() {
     let (client, contract_id) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000, &1000);
 
     let bps = env.as_contract(&contract_id, || read_protocol_fee_bps(&env));

--- a/creator-keys/tests/registration_event_details.rs
+++ b/creator-keys/tests/registration_event_details.rs
@@ -16,6 +16,7 @@ fn test_register_creator_event_field_values_match_fixtures() {
 
     // 1. Setup deterministic fixtures
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let creator = Address::generate(&env);
     let handle_str = "fixture_handle";
     let handle = String::from_str(&env, handle_str);
@@ -91,6 +92,7 @@ fn test_register_creator_event_fields_update_with_fee_config() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
 
     // First registration with one config
     client.set_fee_config(&admin, &9000, &1000);

--- a/creator-keys/tests/resolve_issues_tests.rs
+++ b/creator-keys/tests/resolve_issues_tests.rs
@@ -161,6 +161,7 @@ fn test_buy_event_price_paid_matches_pre_buy_query_price() {
 
     let admin = Address::generate(&env);
     client.set_key_price(&admin, &100_i128);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     let creator = Address::generate(&env);
@@ -261,6 +262,7 @@ fn test_sell_updates_creator_supply_and_seller_balance_atomically() {
     env.mock_all_auths();
 
     let (client, admin, creator) = setup(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000u32, &1000u32);
     let seller = Address::generate(&env);
 

--- a/creator-keys/tests/sell_after_fee_config_mutation.rs
+++ b/creator-keys/tests/sell_after_fee_config_mutation.rs
@@ -18,6 +18,7 @@ fn test_sell_execution_applies_updated_protocol_fee() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_key_price(&admin, &1000);
     // Original fee config: 90/10 split
     client.set_fee_config(&admin, &9000, &1000);
@@ -69,6 +70,7 @@ fn test_sell_execution_fee_matches_quote_after_fee_config_update() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_key_price(&admin, &500);
     client.set_fee_config(&admin, &9000, &1000);
 

--- a/creator-keys/tests/sell_fee_split_invariants.rs
+++ b/creator-keys/tests/sell_fee_split_invariants.rs
@@ -186,6 +186,7 @@ fn sell_fee_split_invariant_across_multiple_fee_configs() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
     let key_price = 1000_i128;
+    let admin = set_pricing_and_fees(&env, &client, key_price, 9000, 1000);
 
     let test_cases = [
         (10000, 0),   // 100% creator
@@ -200,7 +201,7 @@ fn sell_fee_split_invariant_across_multiple_fee_configs() {
         }
 
         let creator = register_test_creator(&env, &client, &format!("creator{}", i));
-        set_pricing_and_fees(&env, &client, key_price, *creator_bps, *protocol_bps);
+        client.set_fee_config(&admin, creator_bps, protocol_bps);
         let holder = setup_holder_with_key(&env, &client, &creator, key_price);
 
         assert_sell_fee_split_invariant(
@@ -220,10 +221,11 @@ fn sell_fee_split_invariant_across_price_range() {
     let (client, _) = register_creator_keys(&env);
 
     let test_prices = [1, 2, 3, 10, 99, 100, 101, 999, 1000, 10000];
+    let admin = set_pricing_and_fees(&env, &client, 1_i128, 9000, 1000);
 
     for (i, price) in test_prices.iter().enumerate() {
         let creator = register_test_creator(&env, &client, &format!("creator{}", i));
-        set_pricing_and_fees(&env, &client, *price, 9000, 1000);
+        client.set_key_price(&admin, price);
         let holder = setup_holder_with_key(&env, &client, &creator, *price);
 
         assert_sell_fee_split_invariant(&client, &creator, &holder, *price, 9000, 1000);
@@ -266,6 +268,8 @@ fn sell_fee_split_invariant_zero_net_boundary() {
     let env = test_env_with_auths();
     let (client, _) = register_creator_keys(&env);
 
+    let admin = set_pricing_and_fees(&env, &client, 1_i128, 9000, 1000);
+
     // Test cases where seller gets zero net due to fees
     let zero_net_cases = [
         (1, 9000, 1000), // Price 1, 90/10 split
@@ -276,7 +280,8 @@ fn sell_fee_split_invariant_zero_net_boundary() {
 
     for (i, (price, creator_bps, protocol_bps)) in zero_net_cases.iter().enumerate() {
         let creator = register_test_creator(&env, &client, &format!("creator{}", i));
-        set_pricing_and_fees(&env, &client, *price, *creator_bps, *protocol_bps);
+        client.set_key_price(&admin, price);
+        client.set_fee_config(&admin, creator_bps, protocol_bps);
         let holder = setup_holder_with_key(&env, &client, &creator, *price);
 
         let quote = client.get_sell_quote(&creator, &holder);

--- a/creator-keys/tests/sell_quote_after_fee_config_update.rs
+++ b/creator-keys/tests/sell_quote_after_fee_config_update.rs
@@ -16,6 +16,7 @@ fn test_sell_quote_reflects_updated_fee_config() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_key_price(&admin, &1000);
     // Original fee config: 90/10 split
     client.set_fee_config(&admin, &9000, &1000);
@@ -61,6 +62,7 @@ fn test_sell_quote_total_amount_updates_after_fee_config_change() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_key_price(&admin, &500);
     client.set_fee_config(&admin, &9000, &1000);
 

--- a/creator-keys/tests/set_protocol_fee_recipient.rs
+++ b/creator-keys/tests/set_protocol_fee_recipient.rs
@@ -16,6 +16,7 @@ fn test_set_protocol_fee_recipient_rejects_zero_address() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let zero_str = String::from_str(
         &env,
         "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -43,6 +44,7 @@ fn test_set_protocol_fee_recipient_accepts_valid_address() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let recipient = Address::generate(&env);
 
     let result = client.try_set_protocol_fee_recipient(&admin, &recipient);
@@ -61,6 +63,7 @@ fn test_set_protocol_fee_recipient_idempotent() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let recipient = Address::generate(&env);
 
     client.set_protocol_fee_recipient(&admin, &recipient);
@@ -83,6 +86,7 @@ fn test_set_protocol_fee_recipient_emits_event_on_update() {
     let (client, _) = register_creator_keys(&env);
 
     let admin = Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     let old_recipient = Address::generate(&env);
     let new_recipient = Address::generate(&env);
 

--- a/creator-keys/tests/tests/buy_after_fee_config_mutation.rs
+++ b/creator-keys/tests/tests/buy_after_fee_config_mutation.rs
@@ -20,6 +20,7 @@ fn test_buy_execution_applies_updated_protocol_fee() {
 
     let admin = soroban_sdk::Address::generate(&env);
     client.set_key_price(&admin, &1000);
+    client.set_protocol_admin(&admin, &admin);
     // Original fee config: 90/10 split
     client.set_fee_config(&admin, &9000, &1000);
 
@@ -63,6 +64,7 @@ fn test_buy_execution_fee_matches_quote_after_fee_config_update() {
 
     let admin = soroban_sdk::Address::generate(&env);
     client.set_key_price(&admin, &500);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &9000, &1000);
 
     let creator = register_test_creator(&env, &client, "bob");

--- a/creator-keys/tests/treasury_withdrawal.rs
+++ b/creator-keys/tests/treasury_withdrawal.rs
@@ -11,19 +11,10 @@ use soroban_sdk::{
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-/// Sets a protocol admin in the contract and returns the admin address.
-fn set_admin(env: &Env, client: &CreatorKeysContractClient<'_>) -> Address {
-    let first_admin = Address::generate(env);
-    let new_admin = Address::generate(env);
-    client.set_protocol_admin(&first_admin, &new_admin);
-    new_admin
-}
-
 /// Full setup: pricing + fees + admin. Returns (client, admin).
 fn setup_with_admin(env: &Env) -> (CreatorKeysContractClient<'_>, Address) {
     let (client, _id) = register_creator_keys(env);
-    set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
-    let admin = set_admin(env, &client);
+    let admin = set_pricing_and_fees(env, &client, 100i128, 9000, 1000);
     (client, admin)
 }
 

--- a/creator-keys/tests/ttl_extension_on_buy.rs
+++ b/creator-keys/tests/ttl_extension_on_buy.rs
@@ -221,6 +221,8 @@ fn admin_fee_update_extends_instance_ttl() {
     let (client, contract_id, _) = setup(&env);
     let admin = Address::generate(&env);
 
+    client.set_protocol_admin(&admin, &admin);
+
     // Set initial fee config
     client.set_fee_config(&admin, &5000, &5000);
 

--- a/creator-keys/tests/unpause_restores_buy_sell_regression.rs
+++ b/creator-keys/tests/unpause_restores_buy_sell_regression.rs
@@ -24,9 +24,7 @@ fn setup_with_admin(
     Address,
 ) {
     let (client, _) = register_creator_keys(env);
-    set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
-    let admin = Address::generate(env);
-    client.set_protocol_admin(&admin, &admin);
+    let admin = set_pricing_and_fees(env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
     let creator = register_test_creator(env, &client, "alice");
     (client, admin, creator)
 }

--- a/creator-keys/tests/zero_creator_fee_regression.rs
+++ b/creator-keys/tests/zero_creator_fee_regression.rs
@@ -23,6 +23,7 @@ fn test_zero_creator_bps_full_payment_to_creator_after_protocol_fee() {
     // contract allows (PROTOCOL_BPS_MAX = 5000). creator_bps=0 is not valid because
     // creator_bps + protocol_bps must equal 10000 and protocol_bps cannot exceed 5000.
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &5000u32, &5000u32);
 
     // Verify fee config is set correctly
@@ -70,6 +71,7 @@ fn test_zero_creator_bps_with_partial_protocol_fee() {
     // Set up: 0% creator fee, 20% protocol fee (0 bps creator, 2000 bps protocol)
     // This means creator gets 80% and protocol gets 20%
     let admin = soroban_sdk::Address::generate(&env);
+    client.set_protocol_admin(&admin, &admin);
     client.set_fee_config(&admin, &8000u32, &2000u32);
 
     // Verify fee config


### PR DESCRIPTION
closes #651 
Adds assert_is_admin checks to set_fee_config and set_protocol_fee_recipient, plus integration tests verifying protocol config values remain unchanged when non-admin wallets attempt admin operations.