### PR TITLE
feat: add read_protocol_fee_bps helper with panic on uninitialized st…

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1006,7 +1006,6 @@ pub fn read_protocol_fee_bps(env: &Env) -> u32 {
         .protocol_bps
 }
 
-
 /// Validates that an address is not the Stellar zero address.
 ///
 /// The zero address (`GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF`)
@@ -4239,7 +4238,9 @@ mod tests {
     // --- read_protocol_fee_bps uninitialized panic unit tests (#646) ---
 
     #[test]
-    #[should_panic(expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")]
+    #[should_panic(
+        expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)"
+    )]
     fn test_read_protocol_fee_bps_panics_when_uninitialized() {
         let env = Env::default();
         let contract_id = env.register(super::CreatorKeysContract, ());

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -994,6 +994,19 @@ fn read_protocol_fee_config(env: &Env) -> Option<fee::FeeConfig> {
         .get(&constants::storage::FEE_CONFIG)
 }
 
+/// Reads the protocol fee basis points from storage, panicking if uninitialized.
+///
+/// # Panics
+///
+/// Panics with a descriptive message if called before contract initialization
+/// (when no fee configuration has been stored).
+pub fn read_protocol_fee_bps(env: &Env) -> u32 {
+    read_protocol_fee_config(env)
+        .expect("read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")
+        .protocol_bps
+}
+
+
 /// Validates that an address is not the Stellar zero address.
 ///
 /// The zero address (`GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF`)
@@ -4221,6 +4234,33 @@ mod tests {
             supply, 0,
             "overwriting a non-zero supply with 0 should read back as 0, not the stale value 5"
         );
+    }
+
+    // --- read_protocol_fee_bps uninitialized panic unit tests (#646) ---
+
+    #[test]
+    #[should_panic(expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")]
+    fn test_read_protocol_fee_bps_panics_when_uninitialized() {
+        let env = Env::default();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+
+        env.as_contract(&contract_id, || {
+            super::read_protocol_fee_bps(&env);
+        });
+    }
+
+    #[test]
+    fn test_read_protocol_fee_bps_succeeds_when_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(super::CreatorKeysContract, ());
+        let client = super::CreatorKeysContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.set_fee_config(&admin, &9000, &1000);
+
+        let bps = env.as_contract(&contract_id, || super::read_protocol_fee_bps(&env));
+        assert_eq!(bps, 1000, "must return stored protocol_fee_bps");
     }
 }
 

--- a/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
+++ b/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
@@ -11,7 +11,9 @@ use creator_keys::{read_protocol_fee_bps, CreatorKeysContract};
 use soroban_sdk::{testutils::Address as _, Env};
 
 #[test]
-#[should_panic(expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")]
+#[should_panic(
+    expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)"
+)]
 fn test_read_protocol_fee_bps_panics_when_uninitialized() {
     let env = Env::default();
     let contract_id = env.register(CreatorKeysContract, ());
@@ -30,5 +32,8 @@ fn test_read_protocol_fee_bps_succeeds_when_initialized() {
     client.set_fee_config(&admin, &9000, &1000);
 
     let bps = env.as_contract(&contract_id, || read_protocol_fee_bps(&env));
-    assert_eq!(bps, 1000, "must return stored protocol fee bps when initialized");
+    assert_eq!(
+        bps, 1000,
+        "must return stored protocol fee bps when initialized"
+    );
 }

--- a/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
+++ b/creator-keys/tests/read_protocol_fee_bps_uninitialized.rs
@@ -1,0 +1,34 @@
+//! Integration tests for `read_protocol_fee_bps` helper on uninitialized and initialized contract environments.
+//!
+//! Verifies that calling `read_protocol_fee_bps` panics with a descriptive message
+//! containing 'uninitialized' and identifying terms when called prior to initialization,
+//! and returns the stored protocol fee basis points when initialized.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, test_env_with_auths};
+use creator_keys::{read_protocol_fee_bps, CreatorKeysContract};
+use soroban_sdk::{testutils::Address as _, Env};
+
+#[test]
+#[should_panic(expected = "read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")]
+fn test_read_protocol_fee_bps_panics_when_uninitialized() {
+    let env = Env::default();
+    let contract_id = env.register(CreatorKeysContract, ());
+
+    env.as_contract(&contract_id, || {
+        read_protocol_fee_bps(&env);
+    });
+}
+
+#[test]
+fn test_read_protocol_fee_bps_succeeds_when_initialized() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.set_fee_config(&admin, &9000, &1000);
+
+    let bps = env.as_contract(&contract_id, || read_protocol_fee_bps(&env));
+    assert_eq!(bps, 1000, "must return stored protocol fee bps when initialized");
+}


### PR DESCRIPTION
#closes #646 
# PR Description: Add unit tests for `read_protocol_fee_bps` panicking when uninitialized (#646)

## Summary

This PR adds `read_protocol_fee_bps` helper function and unit/integration test coverage ensuring it panics with a descriptive message when invoked on an uninitialized contract environment. It also verifies that an initialized contract returns the stored protocol fee basis points without panicking.

## Scope & Acceptance Criteria Coverage

- [x] **Uninitialized Contract Panic**: `read_protocol_fee_bps` panics when called on an uninitialized contract.
- [x] **Descriptive Panic Message**: The panic message explicitly includes `"uninitialized"` and identifies the helper/field (`"read_protocol_fee_bps"` / `"protocol_fee_bps"`).
- [x] **Initialized Contract Behavior**: An initialized contract returns the configured `protocol_bps` without panicking.
- [x] **Test Coverage**: Unit tests added to `creator-keys/src/lib.rs` and integration test added in `creator-keys/tests/read_protocol_fee_bps_uninitialized.rs`.

## Changes Made

1. **`creator-keys/src/lib.rs`**:
   - Added `pub fn read_protocol_fee_bps(env: &Env) -> u32` helper function using `.expect("read_protocol_fee_bps: contract is uninitialized (protocol_fee_bps not set)")`.
   - Added unit tests `test_read_protocol_fee_bps_panics_when_uninitialized` and `test_read_protocol_fee_bps_succeeds_when_initialized`.

2. **`creator-keys/tests/read_protocol_fee_bps_uninitialized.rs`**:
   - Added integration test suite verifying panicking on uninitialized state and success on initialized state.

## Verification

- `cargo test -p creator-keys`
- `cargo test --test read_protocol_fee_bps_uninitialized`
#closes 