### PR TITLE
feat: add assert event unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
+      - name: Rust versions
+        run: |
+          rustc --version
+          cargo fmt --version
+
       - name: Format check
         run: cargo fmt --all -- --check
 

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -143,8 +143,7 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
     assert_eq!(
         actual_topic, expected_topic,
         "event topic mismatch: expected {:?}, got {:?}",
-        expected_topic,
-        actual_topic
+        expected_topic, actual_topic
     );
 }
 
@@ -452,15 +451,21 @@ fn test_assert_event_topic_matches_panics_on_buy_vs_sell_mismatch() {
     fixture.register_creator(&env, "alice");
     fixture.buy_key(&buyer, KEY_PRICE);
 
-    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
-        topics
-            .get(events::TOPIC_EVENT_NAME_INDEX)
-            .map(|v| {
-                let name: Symbol = v.into_val(&env);
-                name == events::BUY_EVENT_NAME
-            })
-            .unwrap_or(false)
-    }).expect("buy event should be present");
+    let buy_event = env
+        .events()
+        .all()
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .map(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    name == events::BUY_EVENT_NAME
+                })
+                .unwrap_or(false)
+        })
+        .expect("buy event should be present");
 
     assert_event_topic_matches(&env, &buy_event, events::SELL_EVENT_NAME);
 }
@@ -475,15 +480,21 @@ fn test_assert_event_topic_matches_passes_on_matching_topic() {
     fixture.register_creator(&env, "alice");
     fixture.buy_key(&buyer, KEY_PRICE);
 
-    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
-        topics
-            .get(events::TOPIC_EVENT_NAME_INDEX)
-            .map(|v| {
-                let name: Symbol = v.into_val(&env);
-                name == events::BUY_EVENT_NAME
-            })
-            .unwrap_or(false)
-    }).expect("buy event should be present");
+    let buy_event = env
+        .events()
+        .all()
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .map(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    name == events::BUY_EVENT_NAME
+                })
+                .unwrap_or(false)
+        })
+        .expect("buy event should be present");
 
     assert_event_topic_matches(&env, &buy_event, events::BUY_EVENT_NAME);
 }
@@ -509,15 +520,21 @@ fn test_assert_event_topic_mismatch_message_identifies_topics() {
     fixture.register_creator(&env, "alice");
     fixture.buy_key(&buyer, KEY_PRICE);
 
-    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
-        topics
-            .get(events::TOPIC_EVENT_NAME_INDEX)
-            .map(|v| {
-                let name: Symbol = v.into_val(&env);
-                name == events::BUY_EVENT_NAME
-            })
-            .unwrap_or(false)
-    }).expect("buy event should be present");
+    let buy_event = env
+        .events()
+        .all()
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(events::TOPIC_EVENT_NAME_INDEX)
+                .map(|v| {
+                    let name: Symbol = v.into_val(&env);
+                    name == events::BUY_EVENT_NAME
+                })
+                .unwrap_or(false)
+        })
+        .expect("buy event should be present");
 
     let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         assert_event_topic_matches(&env, &buy_event, events::SELL_EVENT_NAME);
@@ -527,7 +544,10 @@ fn test_assert_event_topic_mismatch_message_identifies_topics() {
     let message = err
         .downcast_ref::<std::string::String>()
         .cloned()
-        .or_else(|| err.downcast_ref::<&str>().map(|s| std::string::String::from(*s)))
+        .or_else(|| {
+            err.downcast_ref::<&str>()
+                .map(|s| std::string::String::from(*s))
+        })
         .unwrap_or_default();
     assert!(
         message.contains("event topic mismatch"),

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -142,7 +142,9 @@ fn assert_event_topic_matches(env: &Env, event: &(Address, Vec<Val>, Val), expec
 
     assert_eq!(
         actual_topic, expected_topic,
-        "event topic should match expected contract identifier"
+        "event topic mismatch: expected {:?}, got {:?}",
+        expected_topic,
+        actual_topic
     );
 }
 
@@ -301,7 +303,7 @@ fn test_register_creator_event_fires_once() {
 }
 
 #[test]
-#[should_panic(expected = "event topic should match expected contract identifier")]
+#[should_panic(expected = "event topic mismatch")]
 fn test_assert_event_topic_matches_rejects_unexpected_identifier() {
     let env = Env::default();
     env.mock_all_auths();
@@ -436,5 +438,110 @@ fn test_sell_key_event_payload_field_order_is_documented() {
     assert_eq!(
         events::SELL_EVENT_DATA_FIELDS,
         ["seller", "creator_id", "quantity", "proceeds", "ledger"]
+    );
+}
+
+#[test]
+#[should_panic(expected = "event topic mismatch")]
+fn test_assert_event_topic_matches_panics_on_buy_vs_sell_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fixture = EventFixture::new(&env);
+    let buyer = Address::generate(&env);
+
+    fixture.register_creator(&env, "alice");
+    fixture.buy_key(&buyer, KEY_PRICE);
+
+    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
+        topics
+            .get(events::TOPIC_EVENT_NAME_INDEX)
+            .map(|v| {
+                let name: Symbol = v.into_val(&env);
+                name == events::BUY_EVENT_NAME
+            })
+            .unwrap_or(false)
+    }).expect("buy event should be present");
+
+    assert_event_topic_matches(&env, &buy_event, events::SELL_EVENT_NAME);
+}
+
+#[test]
+fn test_assert_event_topic_matches_passes_on_matching_topic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fixture = EventFixture::new(&env);
+    let buyer = Address::generate(&env);
+
+    fixture.register_creator(&env, "alice");
+    fixture.buy_key(&buyer, KEY_PRICE);
+
+    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
+        topics
+            .get(events::TOPIC_EVENT_NAME_INDEX)
+            .map(|v| {
+                let name: Symbol = v.into_val(&env);
+                name == events::BUY_EVENT_NAME
+            })
+            .unwrap_or(false)
+    }).expect("buy event should be present");
+
+    assert_event_topic_matches(&env, &buy_event, events::BUY_EVENT_NAME);
+}
+
+#[test]
+#[should_panic(expected = "event topic should be present")]
+fn test_assert_event_topic_matches_panics_when_no_topics() {
+    let env = Env::default();
+    let addr = Address::generate(&env);
+    let empty_topics: Vec<Val> = Vec::new(&env);
+    let event = (addr, empty_topics, 0_i32.into_val(&env));
+
+    assert_event_topic_matches(&env, &event, events::BUY_EVENT_NAME);
+}
+
+#[test]
+fn test_assert_event_topic_mismatch_message_identifies_topics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fixture = EventFixture::new(&env);
+    let buyer = Address::generate(&env);
+
+    fixture.register_creator(&env, "alice");
+    fixture.buy_key(&buyer, KEY_PRICE);
+
+    let buy_event = env.events().all().iter().rev().find(|(_, topics, _)| {
+        topics
+            .get(events::TOPIC_EVENT_NAME_INDEX)
+            .map(|v| {
+                let name: Symbol = v.into_val(&env);
+                name == events::BUY_EVENT_NAME
+            })
+            .unwrap_or(false)
+    }).expect("buy event should be present");
+
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_event_topic_matches(&env, &buy_event, events::SELL_EVENT_NAME);
+    }))
+    .unwrap_err();
+
+    let message = err
+        .downcast_ref::<std::string::String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| std::string::String::from(*s)))
+        .unwrap_or_default();
+    assert!(
+        message.contains("event topic mismatch"),
+        "message should indicate topic mismatch, got: {}",
+        message
+    );
+    assert!(
+        message.contains(&format!("{:?}", events::BUY_EVENT_NAME)),
+        "message should identify actual topic, got: {}",
+        message
+    );
+    assert!(
+        message.contains(&format!("{:?}", events::SELL_EVENT_NAME)),
+        "message should identify expected topic, got: {}",
+        message
     );
 }


### PR DESCRIPTION
## Add unit tests for `assert_event_topic_matches` helper

### Changes

**`creator-keys/tests/events.rs`**

- Updated `assert_event_topic_matches` panic message to include expected and actual topic values: `"event topic mismatch: expected {:?}, got {:?}"` so topic mismatches are immediately diagnosable.
- Updated existing `test_assert_event_topic_matches_rejects_unexpected_identifier` to match the new panic message format.
- Added 4 new unit tests:
  - `test_assert_event_topic_matches_panics_on_buy_vs_sell_mismatch` — emits a buy event and calls helper with sell topic, asserts panic.
  - `test_assert_event_topic_matches_passes_on_matching_topic` — emits a buy event and calls helper with buy topic, asserts no panic.
  - `test_assert_event_topic_matches_panics_when_no_topics` — passes an event with empty topics, asserts panic with "event topic should be present".
  - `test_assert_event_topic_mismatch_message_identifies_topics` — uses `catch_unwind` to verify the panic message contains both expected and actual topic names.


Closes #648 