### PR TITLE
test: add holder_balance_key argument order and storage isolation tes…

### DIFF
--- a/creator-keys/tests/holder_balance_key_format.rs
+++ b/creator-keys/tests/holder_balance_key_format.rs
@@ -1,13 +1,22 @@
-//! Unit tests for the `holder_balance_key` helper (Issue #619).
+//! Unit tests for the `holder_balance_key` helper (Issue #619, #652).
 //!
 //! `holder_balance_key` builds the composite `DataKey::KeyBalance(creator, holder)`
 //! storage key. These tests confirm the encoded key has a consistent format:
 //! non-empty, deterministic for a given (creator, holder) pair, equal length
 //! across different holders of the same creator, and distinguishable from
 //! other `DataKey` variants.
+//!
+//! Issue #652 additionally verifies:
+//! - Argument order matters, even when the two addresses are nearly identical
+//!   (differing by only 2 characters — the minimum achievable with Stellar's
+//!   base32 encoding of 35-byte account payloads).
+//! - Storage isolation: a balance written under (A, B) is not readable under (B, A).
 
+mod contract_test_env;
+
+use contract_test_env::register_creator_keys;
 use creator_keys::constants;
-use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, Env};
+use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, Env, String};
 
 #[test]
 fn test_holder_balance_key_is_non_empty() {
@@ -56,6 +65,98 @@ fn test_holder_balance_keys_for_different_holders_have_equal_length() {
         bytes_b.len(),
         "keys for the same creator with different holders must have equal encoded length"
     );
+}
+
+/// Two Stellar addresses whose string representation differs by only 2 characters.
+///
+/// The **underlying 32-byte public keys differ by exactly one byte** (byte 11 is
+/// `0` vs `14`), which satisfies the requirement of stressing the key derivation
+/// with near-identical binary inputs. However, Stellar account addresses are
+/// base32-encoded 35-byte payloads (1 byte version + 32 bytes public key + 2
+/// bytes CRC16 checksum). Because base32 maps 5 bits per character, a single-byte
+/// change always propagates to **at least 2 characters** in the output string
+/// (8 input bits ÷ 5 bits/char).
+///
+/// These two addresses share an all-zero key except byte 11. The resulting
+/// strings differ at character positions 20 and 55 — the closest achievable
+/// edit distance.
+const ADDR_A_STR: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const ADDR_B_STR: &str = "GAAAAAAAAAAAAAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHW";
+
+#[test]
+fn test_holder_balance_key_argument_order_near_identical_addresses() {
+    let env = Env::default();
+
+    let addr_a = Address::from_string(&String::from_str(&env, ADDR_A_STR));
+    let addr_b = Address::from_string(&String::from_str(&env, ADDR_B_STR));
+
+    // Sanity check: confirm the two addresses are indeed very close.
+    let str_a: std::string::String = ADDR_A_STR.into();
+    let str_b: std::string::String = ADDR_B_STR.into();
+    let diff_count = str_a.chars().zip(str_b.chars()).filter(|(a, b)| a != b).count();
+    assert_eq!(
+        diff_count, 2,
+        "test invariant: ADDR_A and ADDR_B must differ by exactly 2 characters (the \
+         minimum achievable with Stellar base32 encoding), but found {diff_count}"
+    );
+
+    let key_ab = constants::storage::holder_balance_key(&addr_a, &addr_b);
+    let key_ba = constants::storage::holder_balance_key(&addr_b, &addr_a);
+
+    assert_ne!(
+        key_ab, key_ba,
+        "swapping creator and holder must produce different keys even when the \
+         two addresses differ by only 2 characters in their string representation"
+    );
+
+    // Confirm the keys also differ at the XDR encoding level.
+    let bytes_ab: std::vec::Vec<u8> = key_ab.to_xdr(&env).iter().collect();
+    let bytes_ba: std::vec::Vec<u8> = key_ba.to_xdr(&env).iter().collect();
+    assert_ne!(
+        bytes_ab, bytes_ba,
+        "swapped argument keys must differ at the XDR encoding level"
+    );
+}
+
+#[test]
+fn test_holder_balance_key_storage_isolation_swapped_args() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, contract_id) = register_creator_keys(&env);
+
+    // Use two addresses with minimal edit distance (2 characters apart).
+    let addr_a = Address::from_string(&String::from_str(&env, ADDR_A_STR));
+    let addr_b = Address::from_string(&String::from_str(&env, ADDR_B_STR));
+
+    let key_ab = constants::storage::holder_balance_key(&addr_a, &addr_b);
+    let key_ba = constants::storage::holder_balance_key(&addr_b, &addr_a);
+
+    // Write a value under the (A, B) key.
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key_ab, &42u32);
+    });
+
+    // Reading under (B, A) must return None — the keys are isolated.
+    env.as_contract(&contract_id, || {
+        let value: Option<u32> = env.storage().persistent().get(&key_ba);
+        assert_eq!(
+            value,
+            None,
+            "reading holder_balance_key(B, A) must not return a value that was \
+             written under holder_balance_key(A, B) — storage keys must be isolated \
+             when arguments are swapped"
+        );
+    });
+
+    // Double-check: the original key still holds the written value.
+    env.as_contract(&contract_id, || {
+        let value: u32 = env.storage().persistent().get(&key_ab).unwrap_or(0);
+        assert_eq!(
+            value, 42,
+            "the value written under holder_balance_key(A, B) must still be readable \
+             under the same key"
+        );
+    });
 }
 
 #[test]

--- a/creator-keys/tests/holder_balance_key_format.rs
+++ b/creator-keys/tests/holder_balance_key_format.rs
@@ -93,7 +93,11 @@ fn test_holder_balance_key_argument_order_near_identical_addresses() {
     // Sanity check: confirm the two addresses are indeed very close.
     let str_a: std::string::String = ADDR_A_STR.into();
     let str_b: std::string::String = ADDR_B_STR.into();
-    let diff_count = str_a.chars().zip(str_b.chars()).filter(|(a, b)| a != b).count();
+    let diff_count = str_a
+        .chars()
+        .zip(str_b.chars())
+        .filter(|(a, b)| a != b)
+        .count();
     assert_eq!(
         diff_count, 2,
         "test invariant: ADDR_A and ADDR_B must differ by exactly 2 characters (the \
@@ -140,8 +144,7 @@ fn test_holder_balance_key_storage_isolation_swapped_args() {
     env.as_contract(&contract_id, || {
         let value: Option<u32> = env.storage().persistent().get(&key_ba);
         assert_eq!(
-            value,
-            None,
+            value, None,
             "reading holder_balance_key(B, A) must not return a value that was \
              written under holder_balance_key(A, B) — storage keys must be isolated \
              when arguments are swapped"


### PR DESCRIPTION
Closes #652

---

…ts (#652)

## Summary

- 

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
