### PR TITLE
Add integration test for buy and sell events containing matching crea…

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -82,7 +82,7 @@ pub const BUY_EVENT_DATA_FIELDS: [&str; 5] =
     ["buyer", "creator_id", "quantity", "price_paid", "ledger"];
 
 /// Stable field order for sell event payloads.
-pub const SELL_EVENT_DATA_FIELDS: [&str; 1] = ["supply"];
+pub const SELL_EVENT_DATA_FIELDS: [&str; 2] = ["creator_id", "supply"];
 
 /// Stable field order for buyback event payloads.
 pub const BUYBACK_EVENT_DATA_FIELDS: [&str; 5] =
@@ -146,6 +146,16 @@ pub struct KeysBoughtEvent {
     pub price_paid: i128,
     /// Ledger sequence number at the time of the purchase.
     pub ledger: u32,
+}
+
+/// Stable sell event payload for downstream indexers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct KeysSoldEvent {
+    /// Address of the creator whose keys are being sold.
+    pub creator_id: Address,
+    /// Number of keys in circulation after the sale.
+    pub supply: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -1828,9 +1828,14 @@ impl CreatorKeysContract {
         }
         accrue_sell_trade_fees(&env, &creator, price)?;
 
+        let sell_event_data = events::KeysSoldEvent {
+            creator_id: creator.clone(),
+            supply: profile.supply,
+        };
+
         env.events().publish(
             (events::SELL_EVENT_NAME, creator.clone(), seller),
-            profile.supply,
+            sell_event_data,
         );
 
         // Extend TTL for creator storage after successful sell

--- a/creator-keys/src/test.rs
+++ b/creator-keys/src/test.rs
@@ -2388,3 +2388,66 @@ fn test_compute_net_buyback_cost_zero_gross_price() {
     let result = fee::compute_net_buyback_cost(0, 1000);
     assert_eq!(result, Some(0), "zero gross price should return zero");
 }
+
+#[test]
+fn test_buy_and_sell_events_contain_matching_creator_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let handle = String::from_str(&env, "alice");
+
+    client.set_key_price(&admin, &100);
+    client.set_fee_config(&admin, &9000, &1000);
+    client.register_creator(
+        &crate::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: handle.clone(),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None
+    );
+
+    // Perform buy and extract the buy event
+    client.buy_key(&creator, &buyer, &100, &None);
+
+    let all_events = env.events().all();
+    assert_eq!(all_events.len(), 1, "expected exactly one buy event");
+
+    let (_contract_id, _topics, data): (
+        Address,
+        soroban_sdk::Vec<soroban_sdk::Val>,
+        soroban_sdk::Val,
+    ) = all_events.get(0).unwrap();
+
+    let buy_event: events::KeysBoughtEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(
+        buy_event.creator_id, creator,
+        "buy event creator_id field must match the creator address"
+    );
+
+    // Perform sell and extract the sell event
+    client.sell_key(&creator, &buyer, &None);
+
+    let all_events = env.events().all();
+    assert_eq!(all_events.len(), 1, "expected exactly one sell event");
+
+    let (_contract_id, _topics, data): (
+        Address,
+        soroban_sdk::Vec<soroban_sdk::Val>,
+        soroban_sdk::Val,
+    ) = all_events.get(0).unwrap();
+
+    let sell_event: events::KeysSoldEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(
+        sell_event.creator_id, creator,
+        "sell event creator_id field must match the creator address"
+    );
+}

--- a/creator-keys/tests/events.rs
+++ b/creator-keys/tests/events.rs
@@ -20,6 +20,7 @@ struct TradeTopics {
 }
 
 struct SellEventPayload {
+    creator_id: Address,
     supply: u32,
 }
 
@@ -121,8 +122,10 @@ impl<'a> EventFixture<'a> {
             })
             .unwrap();
 
+        let event: events::KeysSoldEvent = data.into_val(env);
         SellEventPayload {
-            supply: data.into_val(env),
+            creator_id: event.creator_id,
+            supply: event.supply,
         }
     }
 }
@@ -400,6 +403,7 @@ fn test_sell_key_event_payload_fields_are_validated_from_fixture() {
     assert_eq!(topics.event_name, events::SELL_EVENT_NAME);
     assert_eq!(topics.creator, fixture.creator);
     assert_eq!(topics.actor, seller);
+    assert_eq!(payload.creator_id, fixture.creator);
     assert_eq!(payload.supply, 1);
 }
 
@@ -420,10 +424,11 @@ fn test_sell_key_event_payload_tracks_zero_supply_after_last_sale() {
     assert_eq!(topics.event_name, events::SELL_EVENT_NAME);
     assert_eq!(topics.creator, fixture.creator);
     assert_eq!(topics.actor, seller);
+    assert_eq!(payload.creator_id, fixture.creator);
     assert_eq!(payload.supply, 0);
 }
 
 #[test]
 fn test_sell_key_event_payload_field_order_is_documented() {
-    assert_eq!(events::SELL_EVENT_DATA_FIELDS, ["supply"]);
+    assert_eq!(events::SELL_EVENT_DATA_FIELDS, ["creator_id", "supply"]);
 }


### PR DESCRIPTION
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [ ] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [ ] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [ ] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [ ] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes

closes #645 