### PR TITLE
test: add unit tests for holder count increment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/creator-keys/tests/buy_holder_count.rs
+++ b/creator-keys/tests/buy_holder_count.rs
@@ -1,0 +1,59 @@
+//! Integration tests for buy operations correctly incrementing/updating the holder count.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use soroban_sdk::{testutils::Address as _, Address};
+
+#[test]
+fn test_buy_holder_count_behavior() {
+    let env = test_env_with_auths();
+    let (client, _contract_id) = register_creator_keys(&env);
+    let base_price = 100i128;
+    set_key_price_for_tests(&env, &client, base_price);
+
+    let creator = register_test_creator(&env, &client, "alice");
+
+    // 1. First buy increments holder count by 1 (and matches expected contract state)
+    let buyer1 = Address::generate(&env);
+    // Buy 1 key (with sufficient payment)
+    client.buy_key(&creator, &buyer1, &base_price, &None);
+
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &buyer1), 1);
+    assert_eq!(client.get_creator(&creator).holder_count, 1);
+
+    // 2. Repeat buy by same wallet does not increment count
+    client.buy_key(&creator, &buyer1, &base_price, &None);
+
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &buyer1), 2);
+    assert_eq!(client.get_creator(&creator).holder_count, 1);
+
+    // 3. Two new wallets buying increments count by 2 (total +2)
+    let buyer2 = Address::generate(&env);
+    let buyer3 = Address::generate(&env);
+
+    client.buy_key(&creator, &buyer2, &base_price, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 2);
+    assert_eq!(client.get_creator(&creator).holder_count, 2);
+
+    client.buy_key(&creator, &buyer3, &base_price, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 3);
+    assert_eq!(client.get_creator(&creator).holder_count, 3);
+
+    // 4. Selling all keys and rebuying increments count again (wallet re-enters as a holder)
+    // Sell first key of buyer3
+    client.sell_key(&creator, &buyer3, &None);
+    // buyer3 has 0 keys left, holder count decrements
+    assert_eq!(client.get_key_balance(&creator, &buyer3), 0);
+    assert_eq!(client.get_creator_holder_count(&creator), 2);
+    assert_eq!(client.get_creator(&creator).holder_count, 2);
+
+    // Rebuy by buyer3 increments holder count back to 3
+    client.buy_key(&creator, &buyer3, &base_price, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 3);
+    assert_eq!(client.get_creator(&creator).holder_count, 3);
+}


### PR DESCRIPTION

## Summary

- Adds buy_holder_count.rs covering first buy, repeat buy, multiple wallets, and sell-then-rebuy scenarios for holder_count, verified against both get_creator_holder_count and CreatorProfile::holder_count state. Bumps ethnum to 1.5.3 in Cargo.lock to fix a compiler incompatibility. 
Closes #673

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`


## Checklist

- [x] Linked issue or backlog item
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes *(Lockfile update was strictly required to fix standard library type layout errors in compile-time dependency `ethnum`)*