### PR TITLE
feat(test):  Add authorization guard and zero-address validation to set_protocol_admin with unit tests

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -2575,20 +2575,32 @@ impl CreatorKeysContract {
     ///
     /// Only callable by an authorized admin. Stores the admin address used
     /// for protocol administration.
-    pub fn set_protocol_admin(env: Env, admin: Address, new_admin: Address) {
+    pub fn set_protocol_admin(
+        env: Env,
+        admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
         admin.require_auth();
-        if env
+        validate_non_zero_address(&env, &new_admin)?;
+
+        let current_admin: Option<Address> = env
             .storage()
             .persistent()
-            .get::<DataKey, Address>(&constants::storage::ADMIN_ADDRESS)
-            .as_ref()
-            == Some(&new_admin)
-        {
-            return;
+            .get(&constants::storage::ADMIN_ADDRESS);
+
+        if let Some(ref current) = current_admin {
+            if admin != *current {
+                return Err(ContractError::Unauthorized);
+            }
+            if *current == new_admin {
+                return Ok(());
+            }
         }
+
         env.storage()
             .persistent()
             .set(&constants::storage::ADMIN_ADDRESS, &new_admin);
+        Ok(())
     }
 
     /// Read-only view: returns the current protocol admin address.

--- a/creator-keys/test_snapshots/test_get_protocol_admin_overwrite_returns_latest.1.json
+++ b/creator-keys/test_snapshots/test_get_protocol_admin_overwrite_returns_latest.1.json
@@ -30,7 +30,7 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -38,7 +38,7 @@
               "function_name": "set_protocol_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
@@ -169,7 +169,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -184,7 +184,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/creator-keys/tests/admin_transfer.rs
+++ b/creator-keys/tests/admin_transfer.rs
@@ -1,0 +1,106 @@
+//! Tests for admin role transfer via `set_protocol_admin`.
+//!
+//! Verifies that:
+//! - Admin role transfers to a new address and is persisted in storage
+//! - The old admin loses admin privileges after transfer
+//! - The new admin gains admin privileges after transfer
+//! - A non-admin caller is rejected with `ContractError::Unauthorized`
+//! - Transfer to the zero address is rejected with `ContractError::ZeroAddress`
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, test_env_with_auths};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+#[test]
+fn test_admin_transfer_updates_stored_admin() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let old_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    assert_eq!(client.get_protocol_admin(), None);
+
+    client.set_protocol_admin(&old_admin, &old_admin);
+    assert_eq!(client.get_protocol_admin(), Some(old_admin.clone()));
+
+    let result = client.try_set_protocol_admin(&old_admin, &new_admin);
+    assert_eq!(result, Ok(Ok(())));
+
+    assert_eq!(client.get_protocol_admin(), Some(new_admin));
+}
+
+#[test]
+fn test_old_admin_cannot_pause_after_transfer() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let old_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_protocol_admin(&old_admin, &old_admin);
+    client.set_protocol_admin(&old_admin, &new_admin);
+
+    let result = client.try_pause(&old_admin);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_new_admin_can_pause_after_transfer() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let old_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_protocol_admin(&old_admin, &old_admin);
+    client.set_protocol_admin(&old_admin, &new_admin);
+
+    let result = client.try_pause(&new_admin);
+    assert_eq!(result, Ok(Ok(())));
+    assert!(client.get_is_paused());
+}
+
+#[test]
+fn test_non_admin_cannot_transfer_admin_role() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_protocol_admin(&admin, &admin);
+
+    let result = client.try_set_protocol_admin(&non_admin, &new_admin);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+
+    assert_eq!(client.get_protocol_admin(), Some(admin));
+}
+
+#[test]
+fn test_transfer_to_zero_address_rejected() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+
+    let admin = Address::generate(&env);
+
+    client.set_protocol_admin(&admin, &admin);
+
+    let zero_str = String::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+    let zero_addr = Address::from_string(&zero_str);
+
+    let result = client.try_set_protocol_admin(&admin, &zero_addr);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ZeroAddress)),
+        "zero address must be rejected"
+    );
+
+    assert_eq!(client.get_protocol_admin(), Some(admin));
+}

--- a/creator-keys/tests/protocol_admin.rs
+++ b/creator-keys/tests/protocol_admin.rs
@@ -73,9 +73,9 @@ fn test_get_protocol_admin_overwrite_returns_latest() {
     let second_admin = Address::generate(&env);
 
     client.set_protocol_admin(&admin, &first_admin);
-    assert_eq!(client.get_protocol_admin(), Some(first_admin));
+    assert_eq!(client.get_protocol_admin(), Some(first_admin.clone()));
 
-    client.set_protocol_admin(&admin, &second_admin);
+    client.set_protocol_admin(&first_admin, &second_admin);
     assert_eq!(client.get_protocol_admin(), Some(second_admin));
 }
 


### PR DESCRIPTION


 Add validate_non_zero_address check to set_protocol_admin to reject the Stellar zero address with ContractError::ZeroAddress
- Require the caller to match the stored admin when one exists (first-time initialization remains unguarded), preventing unauthorized admin transfers
- Change return type to Result<(), ContractError> so callers can use try_set_protocol_admin for error handling
- Create admin_transfer.rs with 5 tests verifying: state persistence after transfer, old admin loses privileges, new admin gains privileges, non-admin rejection with Unauthorized, zero-address rejection with ZeroAddress
- Update test_get_protocol_admin_overwrite_returns_latest in protocol_admin.rs to pass the current stored admin as the caller for the second transfer

Closes #672
 

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
