### PR TITLE
Add sell holder count unit tests 675

### DIFF
--- a/creator-keys/tests/sell_key.rs
+++ b/creator-keys/tests/sell_key.rs
@@ -159,3 +159,32 @@ fn test_holder_count_returns_to_zero_after_last_holder_exit_and_rebuy() {
     assert_eq!(supply_after_rebuy, 1);
     assert_eq!(client.get_creator_holder_count(&creator), 1);
 }
+
+#[test]
+fn test_multi_key_full_exit_decrements_holder_count_only_on_last_sell() {
+    let env = test_env_with_auths();
+    let (client, creator) = setup(&env);
+    let seller = Address::generate(&env);
+
+    // Seller buys 3 keys.
+    client.buy_key(&creator, &seller, &100_i128, &None);
+    client.buy_key(&creator, &seller, &100_i128, &None);
+    client.buy_key(&creator, &seller, &100_i128, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &seller), 3);
+
+    // Sell 2 keys — holder count stays unchanged.
+    client.sell_key(&creator, &seller, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &seller), 2);
+
+    client.sell_key(&creator, &seller, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 1);
+    assert_eq!(client.get_key_balance(&creator, &seller), 1);
+
+    // Sell the last key — holder count decrements.
+    client.sell_key(&creator, &seller, &None);
+    assert_eq!(client.get_creator_holder_count(&creator), 0);
+    assert_eq!(client.get_key_balance(&creator, &seller), 0);
+    assert_eq!(client.get_total_key_supply(&creator), 0);
+}


### PR DESCRIPTION
## Summary

Adds a unit test for the sell function correctly decrementing the holder count when a wallet sells all its keys.

## Changes

- **`creator-keys/tests/sell_key.rs`**: Added `test_multi_key_full_exit_decrements_holder_count_only_on_last_sell` — a wallet holding 3 keys sells 2 (holder count unchanged), then sells the last key (holder count decrements to 0). This fills the gap where no existing test verified holder count only decrements on the final sale when a wallet holds more than one key.

## Acceptance criteria coverage

The following scenarios were already covered by existing tests and remain passing:

| Criterion | Existing test |
|---|---|
| Selling all keys decrements holder count by 1 | `test_sell_key_removes_holder_when_last_key_is_sold` |
| Selling partial keys does not change holder count | `test_sell_key_preserves_holder_count_when_seller_still_has_keys` |
| Two wallets selling all keys decrements count by 2 | `test_holder_count_reflects_mixed_trade_correctly` in `supply_invariants.rs` |
| Holder count reaches 0 when the last holder sells all keys | Covered by full-exit tests above |
| State correct after each scenario | All tests assert state after each operation |

The new test covers the previously untested scenario of a multi-key wallet fully exiting.


Closes #675 