### PR TITLE
test: add unit tests for schema version guard

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -84,6 +84,8 @@ pub enum ContractError {
     WalletCapExceeded = 35,
     DiscountTierLimitExceeded = 36,
     WalletBlacklisted = 37,
+    SchemaVersionTooOld = 38,
+    SchemaVersionUnsupported = 39,
 }
 
 pub mod fee {
@@ -549,6 +551,39 @@ pub mod ttl {
     pub fn should_extend(current_ttl: u32, threshold: u32) -> bool {
         current_ttl < threshold
     }
+}
+
+/// Current client-facing schema version of this contract.
+///
+/// Increment this constant whenever the contract's ABI or on-chain data layout
+/// changes in a way that is incompatible with older clients.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Minimum schema version that clients must present.
+///
+/// Calls that supply a version strictly below this value are rejected with
+/// [`ContractError::SchemaVersionTooOld`] so stale clients are forced to
+/// upgrade before interacting with the contract.
+pub const MIN_SCHEMA_VERSION: u32 = 1;
+
+/// Schema version compatibility guard.
+///
+/// Pure function — no Soroban `Env` required — so it is easily unit-testable
+/// and reusable across any entrypoint that wants version gating.
+///
+/// # Rules
+/// - `client_version == 0`            → `SchemaVersionTooOld`
+/// - `client_version < MIN_SCHEMA_VERSION` → `SchemaVersionTooOld`
+/// - `client_version > CURRENT_SCHEMA_VERSION` → `SchemaVersionUnsupported`
+/// - otherwise                        → `Ok(())`
+pub fn assert_schema_version(client_version: u32) -> Result<(), ContractError> {
+    if client_version == 0 || client_version < MIN_SCHEMA_VERSION {
+        return Err(ContractError::SchemaVersionTooOld);
+    }
+    if client_version > CURRENT_SCHEMA_VERSION {
+        return Err(ContractError::SchemaVersionUnsupported);
+    }
+    Ok(())
 }
 
 pub const HANDLE_LEN_MIN: u32 = 3;
@@ -1866,6 +1901,24 @@ impl CreatorKeysContract {
         extend_creator_ttl(&env, &creator);
 
         Ok(profile.supply)
+    }
+
+    /// Validates that `client_schema_version` is compatible with this deployment.
+    ///
+    /// Returns `Ok(())` when the version matches the contract's current schema.
+    /// Returns an error when the client is too old or too new:
+    /// - [`ContractError::SchemaVersionTooOld`] — version is `0` or below the
+    ///   minimum supported version; the client must upgrade.
+    /// - [`ContractError::SchemaVersionUnsupported`] — version exceeds the
+    ///   current schema; this contract deployment does not understand it yet.
+    ///
+    /// No state is read or written; the check is pure and can be called without
+    /// authorization.
+    pub fn check_schema_version(
+        _env: Env,
+        client_schema_version: u32,
+    ) -> Result<(), ContractError> {
+        assert_schema_version(client_schema_version)
     }
 
     pub fn sell_key(

--- a/creator-keys/tests/schema_version_guard.rs
+++ b/creator-keys/tests/schema_version_guard.rs
@@ -1,0 +1,198 @@
+//! Unit tests for the schema version guard (issue #707).
+//!
+//! Tests that `check_schema_version` (and the underlying `assert_schema_version`
+//! pure function) reject calls whose client schema version is outdated or from
+//! the future, and accept only the current supported version.
+
+mod contract_test_env;
+
+use contract_test_env::test_env_with_auths;
+use creator_keys::{
+    assert_schema_version, ContractError, CreatorKeysContract, CreatorKeysContractClient,
+    CURRENT_SCHEMA_VERSION, MIN_SCHEMA_VERSION,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ---------------------------------------------------------------------------
+// Pure guard – no Soroban Env needed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pure_guard_current_version_succeeds() {
+    assert_eq!(
+        assert_schema_version(CURRENT_SCHEMA_VERSION),
+        Ok(()),
+        "current schema version must be accepted"
+    );
+}
+
+#[test]
+fn pure_guard_version_zero_is_too_old() {
+    assert_eq!(
+        assert_schema_version(0),
+        Err(ContractError::SchemaVersionTooOld),
+        "version 0 must be rejected as too old"
+    );
+}
+
+#[test]
+fn pure_guard_below_min_is_too_old() {
+    if MIN_SCHEMA_VERSION > 1 {
+        // Only meaningful when there is a range of outdated versions.
+        assert_eq!(
+            assert_schema_version(MIN_SCHEMA_VERSION - 1),
+            Err(ContractError::SchemaVersionTooOld),
+            "version below MIN_SCHEMA_VERSION must be rejected as too old"
+        );
+    } else {
+        // MIN_SCHEMA_VERSION == 1: version 0 is the only sub-minimum case,
+        // covered by the zero test above.
+        assert_eq!(
+            assert_schema_version(0),
+            Err(ContractError::SchemaVersionTooOld)
+        );
+    }
+}
+
+#[test]
+fn pure_guard_future_version_is_unsupported() {
+    assert_eq!(
+        assert_schema_version(CURRENT_SCHEMA_VERSION + 1),
+        Err(ContractError::SchemaVersionUnsupported),
+        "version beyond CURRENT_SCHEMA_VERSION must be rejected as unsupported"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Contract entrypoint – via Soroban test client
+// ---------------------------------------------------------------------------
+
+// AC-1: current schema version is accepted
+#[test]
+fn contract_current_version_succeeds() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    let result = client.try_check_schema_version(&CURRENT_SCHEMA_VERSION);
+    assert!(result.is_ok(), "current schema version must succeed");
+}
+
+// AC-2: current_version - 1 panics with schema_version_too_old
+#[test]
+fn contract_one_below_current_is_too_old() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    // When MIN_SCHEMA_VERSION == CURRENT_SCHEMA_VERSION == 1, version 0 is the
+    // one-below-current case and must be rejected with SchemaVersionTooOld.
+    let outdated = if CURRENT_SCHEMA_VERSION > 1 {
+        CURRENT_SCHEMA_VERSION - 1
+    } else {
+        0
+    };
+
+    let result = client.try_check_schema_version(&outdated);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SchemaVersionTooOld)),
+        "version below current must be rejected as schema_version_too_old"
+    );
+}
+
+// AC-3: schema version 0 panics with schema_version_too_old
+#[test]
+fn contract_version_zero_is_too_old() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    let result = client.try_check_schema_version(&0u32);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SchemaVersionTooOld)),
+        "version 0 must be rejected as schema_version_too_old"
+    );
+}
+
+// AC-4: future version (current + 1) panics with schema_version_unsupported
+#[test]
+fn contract_future_version_is_unsupported() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    let future = CURRENT_SCHEMA_VERSION + 1;
+    let result = client.try_check_schema_version(&future);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::SchemaVersionUnsupported)),
+        "version beyond current must be rejected as schema_version_unsupported"
+    );
+}
+
+// AC-5: no state mutation on any rejected call
+//
+// The contract stores no state during `check_schema_version`. We verify this by
+// calling a state-reading entrypoint before and after a rejected version check
+// and asserting the observable state (key supply for an unregistered creator) is
+// unchanged.
+#[test]
+fn contract_no_state_mutation_on_too_old_rejection() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    let creator = Address::generate(&env);
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let _ = client.try_check_schema_version(&0u32);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        supply_before, supply_after,
+        "rejected schema version check must not mutate contract state"
+    );
+}
+
+#[test]
+fn contract_no_state_mutation_on_unsupported_rejection() {
+    let env = test_env_with_auths();
+    let id = env.register(CreatorKeysContract, ());
+    let client = CreatorKeysContractClient::new(&env, &id);
+
+    let creator = Address::generate(&env);
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let _ = client.try_check_schema_version(&(CURRENT_SCHEMA_VERSION + 1));
+    let supply_after = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        supply_before, supply_after,
+        "rejected schema version check must not mutate contract state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pure_guard_max_u32_version_is_unsupported() {
+    assert_eq!(
+        assert_schema_version(u32::MAX),
+        Err(ContractError::SchemaVersionUnsupported),
+        "u32::MAX must be rejected as unsupported"
+    );
+}
+
+#[test]
+fn pure_guard_min_version_constant_is_accepted() {
+    // MIN_SCHEMA_VERSION itself must always be accepted (it is the lowest valid version).
+    assert_eq!(
+        assert_schema_version(MIN_SCHEMA_VERSION),
+        Ok(()),
+        "MIN_SCHEMA_VERSION itself must be accepted"
+    );
+}

--- a/creator-keys/tests/schema_version_guard.rs
+++ b/creator-keys/tests/schema_version_guard.rs
@@ -11,7 +11,7 @@ use creator_keys::{
     assert_schema_version, ContractError, CreatorKeysContract, CreatorKeysContractClient,
     CURRENT_SCHEMA_VERSION, MIN_SCHEMA_VERSION,
 };
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address};
 
 // ---------------------------------------------------------------------------
 // Pure guard – no Soroban Env needed
@@ -85,13 +85,9 @@ fn contract_one_below_current_is_too_old() {
     let id = env.register(CreatorKeysContract, ());
     let client = CreatorKeysContractClient::new(&env, &id);
 
-    // When MIN_SCHEMA_VERSION == CURRENT_SCHEMA_VERSION == 1, version 0 is the
-    // one-below-current case and must be rejected with SchemaVersionTooOld.
-    let outdated = if CURRENT_SCHEMA_VERSION > 1 {
-        CURRENT_SCHEMA_VERSION - 1
-    } else {
-        0
-    };
+    // When CURRENT_SCHEMA_VERSION == 1, saturating_sub gives 0, which is the
+    // correct "one below current" value and must still be rejected as too old.
+    let outdated = CURRENT_SCHEMA_VERSION.saturating_sub(1);
 
     let result = client.try_check_schema_version(&outdated);
     assert_eq!(


### PR DESCRIPTION
Closes #707

## Summary

Implements the schema version guard and accompanying unit tests so clients presenting an outdated or unsupported schema version are rejected before they can interact with the contract.

**Contract changes (`creator-keys/src/lib.rs`)**:
- Two new error variants appended to `ContractError` (ABI-safe, never inserted mid-enum):
  - `SchemaVersionTooOld = 38` — client version is `0` or below `MIN_SCHEMA_VERSION`
  - `SchemaVersionUnsupported = 39` — client version exceeds `CURRENT_SCHEMA_VERSION`
- `CURRENT_SCHEMA_VERSION: u32 = 1` — the contract's current schema
- `MIN_SCHEMA_VERSION: u32 = 1` — lowest version clients may present
- `assert_schema_version(client_version: u32) -> Result<(), ContractError>` — pure guard function; no `Env` required, fully unit-testable in isolation
- `check_schema_version(_env, client_schema_version)` contract entrypoint — thin wrapper over the pure guard; writes no state, requires no authorization

**Tests (`creator-keys/tests/schema_version_guard.rs`)** — 11 tests covering all acceptance criteria:
- AC-1: current schema version succeeds (pure + via contract client)
- AC-2: `current_version - 1` returns `SchemaVersionTooOld`
- AC-3: version `0` returns `SchemaVersionTooOld`
- AC-4: `current_version + 1` returns `SchemaVersionUnsupported`
- AC-5: no state mutation on either rejection path (supply checked before/after)
- Edge: `u32::MAX` rejected as unsupported
- Edge: `MIN_SCHEMA_VERSION` itself is always accepted