### PR TITLE
feat: co-creator removal, auction cancellation, and staking reward claim

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -709,6 +709,96 @@ pub fn keys_burned_topics(key_id: &Address) -> (Symbol, Address) {
     (KEYS_BURNED_EVENT_NAME, key_id.clone())
 }
 
+// --- Co-creator removal, auction, and staking reward events ---
+
+/// Event name for co-creator removal.
+pub const CO_CREATOR_REMOVED_EVENT_NAME: Symbol = symbol_short!("co_rem");
+
+/// Event name for auction configuration.
+pub const AUCTION_CONFIGURED_EVENT_NAME: Symbol = symbol_short!("auc_cfg");
+
+/// Event name for auction cancellation.
+pub const AUCTION_CANCELLED_EVENT_NAME: Symbol = symbol_short!("auc_can");
+
+/// Event name for a purchase made during a creator's auction phase.
+pub const AUCTION_PURCHASE_EVENT_NAME: Symbol = symbol_short!("auc_buy");
+
+/// Event name for a staking reward claim.
+pub const STAKE_REWARD_CLAIMED_EVENT_NAME: Symbol = symbol_short!("stk_clm");
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CoCreatorRemovedEvent {
+    pub creator_id: Address,
+    pub co_creator: Address,
+    pub ledger: u32,
+}
+
+pub fn co_creator_removed_topics(creator: &Address) -> (Symbol, Address) {
+    (CO_CREATOR_REMOVED_EVENT_NAME, creator.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AuctionConfiguredEvent {
+    pub creator_id: Address,
+    pub auction_price: i128,
+    pub auction_supply: u32,
+}
+
+pub fn auction_configured_topics(creator: &Address) -> (Symbol, Address) {
+    (AUCTION_CONFIGURED_EVENT_NAME, creator.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AuctionCancelledEvent {
+    pub creator_id: Address,
+    pub auction_price: i128,
+    pub auction_supply: u32,
+}
+
+pub fn auction_cancelled_topics(creator: &Address) -> (Symbol, Address) {
+    (AUCTION_CANCELLED_EVENT_NAME, creator.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AuctionPurchaseEvent {
+    pub buyer: Address,
+    pub creator_id: Address,
+    pub quantity: u32,
+    pub price_paid: i128,
+    pub new_supply: u32,
+    pub auction_sold: u32,
+    pub ledger: u32,
+}
+
+pub fn auction_purchase_topics(creator: &Address, buyer: &Address) -> (Symbol, Address, Address) {
+    (AUCTION_PURCHASE_EVENT_NAME, creator.clone(), buyer.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct StakeRewardClaimedEvent {
+    pub wallet: Address,
+    pub key_id: Address,
+    pub quantity_unlocked: u32,
+    pub reward_amount: i128,
+    pub ledger: u32,
+}
+
+pub fn stake_reward_claimed_topics(
+    creator: &Address,
+    wallet: &Address,
+) -> (Symbol, Address, Address) {
+    (
+        STAKE_REWARD_CLAIMED_EVENT_NAME,
+        creator.clone(),
+        wallet.clone(),
+    )
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -100,6 +100,30 @@ pub enum ContractError {
     CircuitBreakerTriggered = 50,
 }
 
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+/// Error variants for the co-creator removal, pre-launch auction, and
+/// staking reward claim entrypoints.
+///
+/// These live in a separate error type from [`ContractError`] rather than as
+/// additional variants there: the Soroban contract spec format caps a single
+/// `#[contracterror]` enum at 50 cases (`SCSpecUDTErrorEnumV0.cases<50>`),
+/// and `ContractError` is already at that limit.
+pub enum FeatureError {
+    Unauthorized = 1,
+    NotRegistered = 2,
+    Overflow = 3,
+    ProtocolPaused = 4,
+    NotPositiveAmount = 5,
+    NoCoCreatorSet = 6,
+    AuctionAlreadyStarted = 7,
+    NoAuctionConfigured = 8,
+    InvalidAuctionConfig = 9,
+    StakeLockActive = 10,
+    NoStakeFound = 11,
+}
+
 pub mod fee {
     use crate::ContractError;
 
@@ -442,6 +466,22 @@ pub mod constants {
         pub fn vesting_claimed(creator: &Address, beneficiary: &Address) -> DataKey {
             DataKey::VestingClaimed(creator.clone(), beneficiary.clone())
         }
+
+        pub fn auction_config(creator: &Address) -> DataKey {
+            DataKey::AuctionConfig(creator.clone())
+        }
+
+        pub fn stake_unlock_ledger(creator: &Address, holder: &Address) -> DataKey {
+            DataKey::StakeUnlockLedger(creator.clone(), holder.clone())
+        }
+
+        pub fn total_staked(creator: &Address) -> DataKey {
+            DataKey::TotalStaked(creator.clone())
+        }
+
+        pub fn staking_rewards_pool(creator: &Address) -> DataKey {
+            DataKey::StakingRewardsPool(creator.clone())
+        }
     }
 
     fn creator_key(creator: &Address) -> DataKey {
@@ -695,6 +735,18 @@ pub const MAX_BATCH_BUY_SIZE: usize = 5;
 /// Maximum royalty fee basis points (5%).
 pub const MAX_ROYALTY_BPS: u32 = 500;
 
+/// Maximum number of keys a pre-launch auction can allocate at the fixed
+/// auction price before the bonding curve takes over.
+pub const MAX_AUCTION_SUPPLY: u32 = 10_000;
+
+/// Lock duration for staked keys before a reward claim is permitted (30 days
+/// at 5s per ledger).
+pub const STAKE_LOCK_LEDGERS: u32 = 518_400;
+
+/// Share of each protocol fee collection routed into a creator's staking
+/// rewards pool (10%), on top of the existing treasury/recipient split.
+pub const STAKING_REWARD_SHARE_BPS: u32 = 1_000;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum CurvePreset {
@@ -781,6 +833,27 @@ pub enum DataKey {
     ReferralEarnings(Address),
     WhitelistMap(Address, Address),
     WhitelistMode(Address),
+    /// Pre-launch auction configuration for a creator's keys.
+    AuctionConfig(Address),
+    /// Ledger sequence at which a holder's stake for a creator unlocks.
+    StakeUnlockLedger(Address, Address),
+    /// Total keys currently staked across all holders for a creator.
+    TotalStaked(Address),
+    /// Accumulated staking rewards pool balance for a creator.
+    StakingRewardsPool(Address),
+}
+
+/// Fixed-price pre-launch auction configuration for a creator's keys.
+///
+/// While `auction_sold < auction_supply`, buys settle at `auction_price`
+/// instead of the bonding curve price. The contract transitions to the
+/// bonding curve automatically once the auction supply is exhausted.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct AuctionConfig {
+    pub auction_price: i128,
+    pub auction_supply: u32,
+    pub auction_sold: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -1461,6 +1534,49 @@ fn read_lockup_duration_secs(env: &Env) -> Option<u64> {
         .get(&constants::storage::LOCKUP_DURATION_SECS)
 }
 
+/// Reads the accumulated staking rewards pool balance for a creator, returning `0` when none is stored.
+pub fn read_staking_rewards_pool(env: &Env, creator: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::staking_rewards_pool(creator))
+        .unwrap_or(0)
+}
+
+/// Reads the total keys currently staked across all holders for a creator.
+pub fn read_total_staked(env: &Env, creator: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::total_staked(creator))
+        .unwrap_or(0)
+}
+
+/// Routes a share of a protocol fee collection into the creator's staking rewards pool.
+///
+/// This is additive bookkeeping on top of the existing treasury/protocol-fee-recipient
+/// split — it does not reduce what those balances receive, so existing fee-accounting
+/// invariants are unaffected. [`CreatorKeysContract::claim_stake_reward`] pays stakers
+/// out of this dedicated pool.
+fn credit_staking_rewards_pool(
+    env: &Env,
+    creator: &Address,
+    protocol_fee: i128,
+) -> Result<(), ContractError> {
+    if protocol_fee <= 0 {
+        return Ok(());
+    }
+    let share = fee::apply_percentage_fee(protocol_fee, STAKING_REWARD_SHARE_BPS)
+        .ok_or(ContractError::Overflow)?;
+    if share <= 0 {
+        return Ok(());
+    }
+    let key = constants::storage::staking_rewards_pool(creator);
+    let updated = read_staking_rewards_pool(env, creator)
+        .checked_add(share)
+        .ok_or(ContractError::Overflow)?;
+    env.storage().persistent().set(&key, &updated);
+    Ok(())
+}
+
 /// Archive retention configuration module with canonical defaults.
 pub mod retention {
     use super::PartitionStrategy;
@@ -1554,6 +1670,7 @@ fn accrue_sell_trade_fees(env: &Env, creator: &Address, price: i128) -> Result<(
         CreatorKeysContract::compute_fees_for_payment(env.clone(), net_price)?;
     credit_creator_fee(env, creator, creator_fee)?;
     credit_treasury_balance(env, protocol_fee)?;
+    credit_staking_rewards_pool(env, creator, protocol_fee)?;
 
     if env
         .storage()
@@ -1592,6 +1709,40 @@ fn resolve_quote_inputs(env: &Env, creator: &Address) -> Result<Option<i128>, Co
     };
 
     let profile = read_registered_creator_profile(env, creator)?;
+    let curve_price = compute_bonding_curve_price(env, creator, normalized, profile.supply)?;
+    normalize_quote_amount(curve_price)
+}
+
+/// Resolves the price [`CreatorKeysContract::get_buy_quote`] should report for the next
+/// buy, mirroring [`CreatorKeysContract::buy_key`]'s own price resolution: while the
+/// creator's supply is below a configured auction's `auction_supply`, the fixed auction
+/// price applies instead of the bonding curve.
+///
+/// Preserves [`resolve_quote_inputs`]'s error-priority ordering (missing base price is
+/// reported before an unregistered creator) for every case that isn't auction-specific.
+fn resolve_buy_quote_price(env: &Env, creator: &Address) -> Result<Option<i128>, ContractError> {
+    let base_price: i128 = env
+        .storage()
+        .persistent()
+        .get(&constants::storage::KEY_PRICE)
+        .ok_or(ContractError::KeyPriceNotSet)?;
+
+    let Some(normalized) = normalize_quote_amount(base_price)? else {
+        return Ok(None);
+    };
+
+    let profile = read_registered_creator_profile(env, creator)?;
+
+    let auction_config: Option<AuctionConfig> = env
+        .storage()
+        .persistent()
+        .get(&constants::storage::auction_config(creator));
+    if let Some(config) = auction_config {
+        if profile.supply < config.auction_supply {
+            return normalize_quote_amount(config.auction_price);
+        }
+    }
+
     let curve_price = compute_bonding_curve_price(env, creator, normalized, profile.supply)?;
     normalize_quote_amount(curve_price)
 }
@@ -2172,40 +2323,60 @@ impl CreatorKeysContract {
 
         let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
         assert_whitelist_allows_buy(&env, &profile, &buyer)?;
-        let pre_price = compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
-        // Circuit breaker pre/post price check
-        let post_supply = profile
-            .supply
-            .checked_add(1)
-            .ok_or(ContractError::Overflow)?;
-        let post_price = compute_bonding_curve_price(&env, &creator, base_price, post_supply)?;
+        let auction_config_key = constants::storage::auction_config(&creator);
+        let mut auction_config: Option<AuctionConfig> =
+            env.storage().persistent().get(&auction_config_key);
+        let in_auction = auction_config
+            .as_ref()
+            .map(|config| profile.supply < config.auction_supply)
+            .unwrap_or(false);
 
-        let threshold_pct: u32 = env
-            .storage()
-            .persistent()
-            .get(&constants::storage::CIRCUIT_BREAKER_THRESHOLD)
-            .unwrap_or(30);
+        let price = if in_auction {
+            // Auction-phase buys settle at the fixed auction price. The
+            // circuit breaker only guards bonding-curve price movement, so
+            // it does not apply while the fixed-price auction is active.
+            auction_config
+                .as_ref()
+                .expect("in_auction implies auction_config is Some")
+                .auction_price
+        } else {
+            let pre_price =
+                compute_bonding_curve_price(&env, &creator, base_price, profile.supply)?;
 
-        if pre_price > 0 {
-            let price_change = post_price.saturating_sub(pre_price);
-            let max_change = (pre_price as u128)
-                .checked_mul(threshold_pct as u128)
-                .ok_or(ContractError::Overflow)?
-                / 100;
-            if (price_change as u128) >= max_change {
-                env.events().publish(
-                    (events::circuit_breaker_triggered_topics(),),
-                    events::CircuitBreakerTriggeredEvent {
-                        pre_price,
-                        post_price,
-                    },
-                );
-                return Err(ContractError::CircuitBreakerTriggered);
+            // Circuit breaker pre/post price check
+            let post_supply = profile
+                .supply
+                .checked_add(1)
+                .ok_or(ContractError::Overflow)?;
+            let post_price = compute_bonding_curve_price(&env, &creator, base_price, post_supply)?;
+
+            let threshold_pct: u32 = env
+                .storage()
+                .persistent()
+                .get(&constants::storage::CIRCUIT_BREAKER_THRESHOLD)
+                .unwrap_or(30);
+
+            if pre_price > 0 {
+                let price_change = post_price.saturating_sub(pre_price);
+                let max_change = (pre_price as u128)
+                    .checked_mul(threshold_pct as u128)
+                    .ok_or(ContractError::Overflow)?
+                    / 100;
+                if (price_change as u128) >= max_change {
+                    env.events().publish(
+                        (events::circuit_breaker_triggered_topics(),),
+                        events::CircuitBreakerTriggeredEvent {
+                            pre_price,
+                            post_price,
+                        },
+                    );
+                    return Err(ContractError::CircuitBreakerTriggered);
+                }
             }
-        }
 
-        let price = pre_price;
+            pre_price
+        };
 
         assert_buy_price_slippage(price, max_price)?;
 
@@ -2317,6 +2488,7 @@ impl CreatorKeysContract {
                     .ok_or(ContractError::Overflow)?;
 
             credit_creator_fee(&env, &creator, creator_fee)?;
+            credit_staking_rewards_pool(&env, &creator, protocol_fee)?;
 
             // Split protocol fee between treasury and referrer only when a referrer is provided
             if let Some(referrer_addr) = referrer {
@@ -2358,17 +2530,41 @@ impl CreatorKeysContract {
             }
         }
 
-        let buy_event_data = events::KeysBoughtEvent {
-            buyer: buyer.clone(),
-            creator_id: creator.clone(),
-            quantity: 1,
-            price_paid: price,
-            new_supply: profile.supply,
-            ledger: env.ledger().sequence(),
-        };
+        if in_auction {
+            let mut config = auction_config
+                .take()
+                .expect("in_auction implies auction_config is Some");
+            config.auction_sold = config
+                .auction_sold
+                .checked_add(1)
+                .ok_or(ContractError::Overflow)?;
+            env.storage().persistent().set(&auction_config_key, &config);
 
-        env.events()
-            .publish(events::buy_event_topics(&creator, &buyer), buy_event_data);
+            env.events().publish(
+                events::auction_purchase_topics(&creator, &buyer),
+                events::AuctionPurchaseEvent {
+                    buyer: buyer.clone(),
+                    creator_id: creator.clone(),
+                    quantity: 1,
+                    price_paid: price,
+                    new_supply: profile.supply,
+                    auction_sold: config.auction_sold,
+                    ledger: env.ledger().sequence(),
+                },
+            );
+        } else {
+            let buy_event_data = events::KeysBoughtEvent {
+                buyer: buyer.clone(),
+                creator_id: creator.clone(),
+                quantity: 1,
+                price_paid: price,
+                new_supply: profile.supply,
+                ledger: env.ledger().sequence(),
+            };
+
+            env.events()
+                .publish(events::buy_event_topics(&creator, &buyer), buy_event_data);
+        }
 
         // Extend TTL for creator storage after successful buy
         extend_creator_ttl(&env, &creator);
@@ -3629,9 +3825,11 @@ impl CreatorKeysContract {
     /// Read-only view: returns a quote for buying a key.
     ///
     /// Returns a [`QuoteResponse`] containing the current price and fee breakdown.
-    /// Fees are calculated based on the fixed key price.
+    /// Fees are calculated based on the fixed key price, or the fixed auction price
+    /// while a pre-launch auction configured via [`Self::configure_auction`] is still
+    /// active for `creator` — mirroring exactly what [`Self::buy_key`] would charge.
     pub fn get_buy_quote(env: Env, creator: Address) -> Result<QuoteResponse, ContractError> {
-        let Some(price) = resolve_quote_inputs(&env, &creator)? else {
+        let Some(price) = resolve_buy_quote_price(&env, &creator)? else {
             return Ok(zero_quote_response());
         };
         let (creator_fee, protocol_fee) = Self::compute_fees_for_payment(env.clone(), price)?;
@@ -4335,6 +4533,25 @@ impl CreatorKeysContract {
             .set(&staked_balance_key, &new_staked);
         extend_key_ttl_to_full_window(&env, &staked_balance_key);
 
+        let total_staked_key = constants::storage::total_staked(&creator);
+        let new_total_staked = read_total_staked(&env, &creator)
+            .checked_add(amount)
+            .ok_or(ContractError::Overflow)?;
+        env.storage()
+            .persistent()
+            .set(&total_staked_key, &new_total_staked);
+
+        // Refresh the reward-claim lock window on every additional stake so
+        // `claim_stake_reward` always measures eligibility from the most
+        // recent stake.
+        let unlock_key = constants::storage::stake_unlock_ledger(&creator, &holder);
+        let unlock_ledger = env
+            .ledger()
+            .sequence()
+            .checked_add(STAKE_LOCK_LEDGERS)
+            .ok_or(ContractError::Overflow)?;
+        env.storage().persistent().set(&unlock_key, &unlock_ledger);
+
         Ok(())
     }
 
@@ -4381,11 +4598,24 @@ impl CreatorKeysContract {
 
         if new_staked == 0 {
             env.storage().persistent().remove(&staked_balance_key);
+            env.storage()
+                .persistent()
+                .remove(&constants::storage::stake_unlock_ledger(&creator, &holder));
         } else {
             env.storage()
                 .persistent()
                 .set(&staked_balance_key, &new_staked);
             extend_key_ttl_to_full_window(&env, &staked_balance_key);
+        }
+
+        let total_staked_key = constants::storage::total_staked(&creator);
+        let new_total_staked = read_total_staked(&env, &creator).saturating_sub(amount);
+        if new_total_staked == 0 {
+            env.storage().persistent().remove(&total_staked_key);
+        } else {
+            env.storage()
+                .persistent()
+                .set(&total_staked_key, &new_total_staked);
         }
 
         Ok(())
@@ -5232,6 +5462,276 @@ impl CreatorKeysContract {
         env.storage()
             .persistent()
             .get(&DataKey::VoteSnapshot(creator_id, poll_id, voter))
+    }
+
+    // =========================================================================
+    // #791 — Co-creator removal
+    // =========================================================================
+
+    /// Removes a creator's configured co-creator split, restoring 100% of all
+    /// future royalties to the creator.
+    ///
+    /// Only callable by the creator (`caller` must equal `creator`).
+    ///
+    /// # Errors
+    ///
+    /// - [`FeatureError::Unauthorized`] if `caller` is not `creator`
+    /// - [`FeatureError::NoCoCreatorSet`] if no co-creator is configured for `creator`
+    pub fn remove_co_creator(
+        env: Env,
+        creator: Address,
+        caller: Address,
+    ) -> Result<(), FeatureError> {
+        caller.require_auth();
+        if caller != creator {
+            return Err(FeatureError::Unauthorized);
+        }
+
+        let key = constants::storage::co_creator(&creator);
+        let config: CoCreatorConfig = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(FeatureError::NoCoCreatorSet)?;
+
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            events::co_creator_removed_topics(&creator),
+            events::CoCreatorRemovedEvent {
+                creator_id: creator,
+                co_creator: config.address,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // #787 / #793 / #790 — Pre-launch auction phase
+    // =========================================================================
+
+    /// Configures a fixed-price pre-launch auction phase for a creator's keys.
+    ///
+    /// While `total_supply` is below `auction_supply`, [`Self::buy_key`] sells
+    /// at `auction_price` instead of the bonding curve price; the contract
+    /// transitions back to the curve automatically once the auction supply is
+    /// exhausted. Only callable by the creator, and only before any keys have
+    /// been sold.
+    ///
+    /// # Errors
+    ///
+    /// - [`FeatureError::Unauthorized`] if `caller` is not `creator`
+    /// - [`FeatureError::NotRegistered`] if `creator` is not a registered creator
+    /// - [`FeatureError::AuctionAlreadyStarted`] if the creator's supply is already nonzero
+    /// - [`FeatureError::NotPositiveAmount`] if `auction_price` is not positive
+    /// - [`FeatureError::InvalidAuctionConfig`] if `auction_supply` is zero or exceeds
+    ///   [`MAX_AUCTION_SUPPLY`]
+    pub fn configure_auction(
+        env: Env,
+        creator: Address,
+        caller: Address,
+        auction_price: i128,
+        auction_supply: u32,
+    ) -> Result<(), FeatureError> {
+        caller.require_auth();
+        if caller != creator {
+            return Err(FeatureError::Unauthorized);
+        }
+
+        let profile = read_registered_creator_profile(&env, &creator)
+            .map_err(|_| FeatureError::NotRegistered)?;
+        if profile.supply > 0 {
+            return Err(FeatureError::AuctionAlreadyStarted);
+        }
+        if auction_price <= 0 {
+            return Err(FeatureError::NotPositiveAmount);
+        }
+        if auction_supply == 0 || auction_supply > MAX_AUCTION_SUPPLY {
+            return Err(FeatureError::InvalidAuctionConfig);
+        }
+
+        let config = AuctionConfig {
+            auction_price,
+            auction_supply,
+            auction_sold: 0,
+        };
+        let key = constants::storage::auction_config(&creator);
+        env.storage().persistent().set(&key, &config);
+        extend_key_ttl_to_full_window(&env, &key);
+
+        env.events().publish(
+            events::auction_configured_topics(&creator),
+            events::AuctionConfiguredEvent {
+                creator_id: creator,
+                auction_price,
+                auction_supply,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Cancels a creator's configured auction before any auction keys have sold.
+    ///
+    /// Only callable by the creator.
+    ///
+    /// # Errors
+    ///
+    /// - [`FeatureError::Unauthorized`] if `caller` is not `creator`
+    /// - [`FeatureError::NoAuctionConfigured`] if no auction config exists for `creator`
+    /// - [`FeatureError::AuctionAlreadyStarted`] if `auction_sold` is greater than zero
+    pub fn cancel_auction(
+        env: Env,
+        creator: Address,
+        caller: Address,
+    ) -> Result<(), FeatureError> {
+        caller.require_auth();
+        if caller != creator {
+            return Err(FeatureError::Unauthorized);
+        }
+
+        let key = constants::storage::auction_config(&creator);
+        let config: AuctionConfig = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(FeatureError::NoAuctionConfigured)?;
+
+        if config.auction_sold > 0 {
+            return Err(FeatureError::AuctionAlreadyStarted);
+        }
+
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            events::auction_cancelled_topics(&creator),
+            events::AuctionCancelledEvent {
+                creator_id: creator,
+                auction_price: config.auction_price,
+                auction_supply: config.auction_supply,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Read-only view: returns the configured auction state for a creator, if any.
+    pub fn get_auction_config(env: Env, creator: Address) -> Option<AuctionConfig> {
+        env.storage()
+            .persistent()
+            .get(&constants::storage::auction_config(&creator))
+    }
+
+    // =========================================================================
+    // #786 / #789 — Staking reward claim
+    // =========================================================================
+
+    /// Unlocks a holder's staked keys after the lock period and pays out
+    /// their pro-rata share of the creator's staking rewards pool.
+    ///
+    /// Callable by any wallet with an active stake for `creator`. The reward
+    /// is `staking_pool_balance * staked_quantity / total_staked_quantity`,
+    /// capped at the pool's current balance. On success the full staked
+    /// quantity is unlocked back into the holder's liquid balance.
+    ///
+    /// # Errors
+    ///
+    /// - [`FeatureError::NoStakeFound`] if the caller has no active stake for `creator`
+    /// - [`FeatureError::StakeLockActive`] if the current ledger is before the unlock ledger
+    /// - [`FeatureError::ProtocolPaused`] if the contract is paused
+    pub fn claim_stake_reward(
+        env: Env,
+        creator: Address,
+        holder: Address,
+    ) -> Result<i128, FeatureError> {
+        holder.require_auth();
+        assert_not_paused(&env).map_err(|_| FeatureError::ProtocolPaused)?;
+
+        let staked_balance_key = constants::storage::staked_balance(&creator, &holder);
+        let staked_quantity: u32 = env
+            .storage()
+            .persistent()
+            .get(&staked_balance_key)
+            .unwrap_or(0);
+        if staked_quantity == 0 {
+            return Err(FeatureError::NoStakeFound);
+        }
+
+        let unlock_key = constants::storage::stake_unlock_ledger(&creator, &holder);
+        let unlock_ledger: u32 = env
+            .storage()
+            .persistent()
+            .get(&unlock_key)
+            .ok_or(FeatureError::NoStakeFound)?;
+        if env.ledger().sequence() < unlock_ledger {
+            return Err(FeatureError::StakeLockActive);
+        }
+
+        let total_staked = read_total_staked(&env, &creator);
+        let pool_balance = read_staking_rewards_pool(&env, &creator);
+        let reward = if total_staked == 0 || pool_balance <= 0 {
+            0
+        } else {
+            let raw_share = pool_balance
+                .checked_mul(i128::from(staked_quantity))
+                .ok_or(FeatureError::Overflow)?
+                / i128::from(total_staked);
+            raw_share.min(pool_balance)
+        };
+
+        // Unlock: clear the stake and its lock record, mirroring `unstake_keys`.
+        env.storage().persistent().remove(&staked_balance_key);
+        env.storage().persistent().remove(&unlock_key);
+
+        let total_staked_key = constants::storage::total_staked(&creator);
+        let new_total_staked = total_staked.saturating_sub(staked_quantity);
+        if new_total_staked == 0 {
+            env.storage().persistent().remove(&total_staked_key);
+        } else {
+            env.storage()
+                .persistent()
+                .set(&total_staked_key, &new_total_staked);
+        }
+
+        if reward > 0 {
+            let pool_key = constants::storage::staking_rewards_pool(&creator);
+            let remaining_pool = pool_balance.saturating_sub(reward);
+            env.storage().persistent().set(&pool_key, &remaining_pool);
+        }
+
+        env.events().publish(
+            events::stake_reward_claimed_topics(&creator, &holder),
+            events::StakeRewardClaimedEvent {
+                wallet: holder,
+                key_id: creator,
+                quantity_unlocked: staked_quantity,
+                reward_amount: reward,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(reward)
+    }
+
+    /// Read-only view: returns the total keys currently staked across all
+    /// holders for a creator.
+    pub fn get_total_staked(env: Env, creator: Address) -> u32 {
+        read_total_staked(&env, &creator)
+    }
+
+    /// Read-only view: returns the current staking rewards pool balance for a creator.
+    pub fn get_staking_rewards_pool(env: Env, creator: Address) -> i128 {
+        read_staking_rewards_pool(&env, &creator)
+    }
+
+    /// Read-only view: returns the ledger sequence at which a holder's stake
+    /// for a creator unlocks, if the holder has an active stake.
+    pub fn get_stake_unlock_ledger(env: Env, creator: Address, holder: Address) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&constants::storage::stake_unlock_ledger(&creator, &holder))
     }
 }
 #[cfg(test)]

--- a/creator-keys/src/test_new_features.rs
+++ b/creator-keys/src/test_new_features.rs
@@ -17,7 +17,9 @@ fn setup_test() -> (Env, CreatorKeysContractClient<'static>, Address, Address) {
 
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &treasury, &100i128);
+    client.set_protocol_admin(&admin, &admin);
+    client.set_treasury_address(&admin, &treasury);
+    client.set_key_price(&admin, &100i128);
     client.set_fee_config(&admin, &9000u32, &1000u32);
 
     (env, client, admin, treasury)
@@ -29,6 +31,7 @@ fn register_creator(env: &Env, client: &CreatorKeysContractClient, creator: &Add
             creator: creator.clone(),
             handle: String::from_str(env, "alice"),
         },
+        &None,
         &None,
         &None,
         &None,
@@ -166,7 +169,7 @@ fn test_key_burn_reduces_supply_and_balance() {
     client.buy_key(&creator, &holder, &1000i128, &None);
 
     let balance_before = client.get_key_balance(&creator, &holder);
-    let supply_before = client.get_creator_supply(&creator).unwrap();
+    let supply_before = client.get_creator_supply(&creator);
     assert_eq!(balance_before, 1);
     assert_eq!(supply_before, 1);
 
@@ -181,7 +184,7 @@ fn test_key_burn_reduces_supply_and_balance() {
     assert_eq!(new_supply, 0);
 
     let balance_after = client.get_key_balance(&creator, &holder);
-    let supply_after = client.get_creator_supply(&creator).unwrap();
+    let supply_after = client.get_creator_supply(&creator);
     assert_eq!(balance_after, 0);
     assert_eq!(supply_after, 0);
 }

--- a/creator-keys/tests/auction_bonding_curve_transition.rs
+++ b/creator-keys/tests/auction_bonding_curve_transition.rs
@@ -1,0 +1,112 @@
+//! Integration tests covering the full auction-to-bonding-curve transition
+//! for a creator key (#788): configuring the auction, buying all auction
+//! keys at the fixed price, and verifying the next buy uses the bonding
+//! curve price.
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, register_test_creator, test_env_with_auths};
+use creator_keys::events;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, IntoVal, Symbol,
+};
+
+const BASE_PRICE: i128 = 1000;
+const CURVE_SLOPE: i128 = 50;
+const AUCTION_PRICE: i128 = 10;
+const AUCTION_SUPPLY: u32 = 5;
+
+fn auction_purchase_price_paid(env: &soroban_sdk::Env, contract_id: &Address) -> Option<i128> {
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != *contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(env);
+        if event_name == events::AUCTION_PURCHASE_EVENT_NAME {
+            let payload: events::AuctionPurchaseEvent = data.clone().into_val(env);
+            return Some(payload.price_paid);
+        }
+    }
+    None
+}
+
+fn standard_buy_event(
+    env: &soroban_sdk::Env,
+    contract_id: &Address,
+) -> Option<events::KeysBoughtEvent> {
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != *contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(env);
+        if event_name == events::BUY_EVENT_NAME {
+            return Some(data.clone().into_val(env));
+        }
+    }
+    None
+}
+
+#[test]
+fn test_full_auction_to_bonding_curve_transition() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+
+    let admin = Address::generate(&env);
+    client.set_key_price(&admin, &BASE_PRICE);
+    client.set_curve_slope(&admin, &CURVE_SLOPE);
+    client.set_protocol_admin(&admin, &admin);
+    client.set_fee_config(&admin, &9000u32, &1000u32);
+
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &AUCTION_PRICE, &AUCTION_SUPPLY);
+
+    let buyer = Address::generate(&env);
+
+    // Buy all 5 auction keys; each must settle at the fixed auction_price,
+    // each must emit an auction_purchase event, and auction_sold must track
+    // the running count.
+    for expected_supply in 1..=AUCTION_SUPPLY {
+        let new_supply = client.buy_key(&creator, &buyer, &AUCTION_PRICE, &None);
+        assert_eq!(new_supply, expected_supply);
+
+        let price_paid = auction_purchase_price_paid(&env, &contract_id);
+        assert_eq!(
+            price_paid,
+            Some(AUCTION_PRICE),
+            "buy #{expected_supply} should emit an auction_purchase event priced at auction_price"
+        );
+    }
+
+    // total_supply is 5 and auction_sold equals auction_supply after the last auction buy.
+    assert_eq!(client.get_total_key_supply(&creator), AUCTION_SUPPLY);
+    let auction_config = client.get_auction_config(&creator).unwrap();
+    assert_eq!(auction_config.auction_sold, AUCTION_SUPPLY);
+    assert_eq!(auction_config.auction_supply, AUCTION_SUPPLY);
+
+    // The 6th buy is priced at the bonding curve formula for supply level 5,
+    // not the auction price, and emits a standard buy event (not another
+    // auction_purchase event).
+    let expected_curve_price = client.query_price(&creator, &(AUCTION_SUPPLY as u64));
+    assert_eq!(expected_curve_price, BASE_PRICE + CURVE_SLOPE * 5);
+    assert_ne!(expected_curve_price, AUCTION_PRICE);
+
+    let new_supply = client.buy_key(&creator, &buyer, &expected_curve_price, &None);
+    assert_eq!(new_supply, AUCTION_SUPPLY + 1);
+
+    assert_eq!(
+        auction_purchase_price_paid(&env, &contract_id),
+        None,
+        "the post-auction buy must not emit another auction_purchase event"
+    );
+    let buy_event = standard_buy_event(&env, &contract_id)
+        .expect("the post-auction buy should emit a standard KeysBought event");
+    assert_eq!(buy_event.price_paid, expected_curve_price);
+    assert_eq!(buy_event.new_supply, AUCTION_SUPPLY + 1);
+
+    // The stored auction config no longer advances past auction_supply.
+    assert_eq!(
+        client.get_auction_config(&creator).unwrap().auction_sold,
+        AUCTION_SUPPLY
+    );
+}

--- a/creator-keys/tests/co_creator_removal.rs
+++ b/creator-keys/tests/co_creator_removal.rs
@@ -1,0 +1,157 @@
+//! Tests for `remove_co_creator` (#791).
+
+mod contract_test_env;
+
+use contract_test_env::{register_creator_keys, set_pricing_and_fees, test_env_with_auths};
+use creator_keys::{events, CoCreatorConfig, FeatureError};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, IntoVal, String, Symbol,
+};
+
+const CO_CREATOR_SHARE_BPS: u32 = 3000;
+const KEY_PRICE: i128 = 1000;
+const CREATOR_BPS: u32 = 9000;
+const PROTOCOL_BPS: u32 = 1000;
+
+fn register_creator_with_co_creator(
+    env: &soroban_sdk::Env,
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+    handle: &str,
+) -> (Address, Address, CoCreatorConfig) {
+    let creator = Address::generate(env);
+    let co_creator = Address::generate(env);
+    let config = CoCreatorConfig {
+        address: co_creator.clone(),
+        share_bps: CO_CREATOR_SHARE_BPS,
+    };
+
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(env, handle),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(config.clone()),
+        &None,
+    );
+
+    (creator, co_creator, config)
+}
+
+#[test]
+fn test_remove_co_creator_clears_config() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (creator, _co_creator, _config) = register_creator_with_co_creator(&env, &client, "alice");
+
+    assert!(client.get_co_creator(&creator).is_some());
+
+    client.remove_co_creator(&creator, &creator);
+
+    assert_eq!(client.get_co_creator(&creator), None);
+}
+
+#[test]
+fn test_remove_co_creator_emits_event_with_removed_address() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    let (creator, co_creator, _config) = register_creator_with_co_creator(&env, &client, "alice");
+
+    client.remove_co_creator(&creator, &creator);
+
+    let mut found = false;
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics
+            .get(0)
+            .expect("event should have a name topic")
+            .into_val(&env);
+        if event_name == events::CO_CREATOR_REMOVED_EVENT_NAME {
+            let payload: events::CoCreatorRemovedEvent = data.clone().into_val(&env);
+            assert_eq!(payload.creator_id, creator);
+            assert_eq!(payload.co_creator, co_creator);
+            found = true;
+        }
+    }
+    assert!(found, "expected a CoCreatorRemoved event to be emitted");
+}
+
+#[test]
+fn test_remove_co_creator_rejects_non_creator_caller() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (creator, _co_creator, _config) = register_creator_with_co_creator(&env, &client, "alice");
+    let attacker = Address::generate(&env);
+
+    let result = client.try_remove_co_creator(&creator, &attacker);
+    assert_eq!(result, Err(Ok(FeatureError::Unauthorized)));
+    assert!(client.get_co_creator(&creator).is_some());
+}
+
+#[test]
+fn test_remove_co_creator_fails_when_none_configured() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let creator = Address::generate(&env);
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: String::from_str(&env, "bob"),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let result = client.try_remove_co_creator(&creator, &creator);
+    assert_eq!(result, Err(Ok(FeatureError::NoCoCreatorSet)));
+}
+
+#[test]
+fn test_remove_co_creator_restores_full_royalties_to_creator() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let (creator, co_creator, _config) = register_creator_with_co_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
+
+    // Before removal: the creator fee (900 at price 1000, 90% creator_bps) splits
+    // 30% to the co-creator (270) and 70% stays with the creator (630).
+    client.buy_key(&creator, &buyer, &KEY_PRICE, &None);
+    let creator_balance_before = client.get_creator_fee_balance(&creator);
+    let co_creator_balance_before = client.get_co_creator_fee_balance(&creator, &co_creator);
+    assert_eq!(creator_balance_before, 630);
+    assert_eq!(co_creator_balance_before, 270);
+
+    client.remove_co_creator(&creator, &creator);
+
+    // After removal: the full creator fee (900, at the new supply-1 bonding
+    // curve price under a zero curve slope, still 1000) goes to the creator;
+    // the co-creator's balance is untouched.
+    client.buy_key(&creator, &buyer, &KEY_PRICE, &None);
+    let creator_balance_after = client.get_creator_fee_balance(&creator);
+    let co_creator_balance_after = client.get_co_creator_fee_balance(&creator, &co_creator);
+    assert_eq!(creator_balance_after, creator_balance_before + 900);
+    assert_eq!(co_creator_balance_after, co_creator_balance_before);
+}
+
+#[test]
+fn test_remove_co_creator_is_idempotent_failure_on_second_call() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (creator, _co_creator, _config) = register_creator_with_co_creator(&env, &client, "alice");
+
+    client.remove_co_creator(&creator, &creator);
+
+    let result = client.try_remove_co_creator(&creator, &creator);
+    assert_eq!(result, Err(Ok(FeatureError::NoCoCreatorSet)));
+}

--- a/creator-keys/tests/prelaunch_auction.rs
+++ b/creator-keys/tests/prelaunch_auction.rs
@@ -1,0 +1,281 @@
+//! Tests for the pre-launch fixed-price auction phase (#787 / #790 / #793).
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, set_pricing_and_fees,
+    test_env_with_auths,
+};
+use creator_keys::{events, AuctionConfig, ContractError, FeatureError};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, IntoVal, Symbol,
+};
+
+#[test]
+fn test_configure_auction_stores_config_and_emits_event() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    client.configure_auction(&creator, &creator, &500i128, &10u32);
+
+    let mut found = false;
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(&env);
+        if event_name == events::AUCTION_CONFIGURED_EVENT_NAME {
+            let payload: events::AuctionConfiguredEvent = data.clone().into_val(&env);
+            assert_eq!(payload.creator_id, creator);
+            assert_eq!(payload.auction_price, 500);
+            assert_eq!(payload.auction_supply, 10);
+            found = true;
+        }
+    }
+    assert!(found, "expected an AuctionConfigured event");
+
+    assert_eq!(
+        client.get_auction_config(&creator),
+        Some(AuctionConfig {
+            auction_price: 500,
+            auction_supply: 10,
+            auction_sold: 0,
+        })
+    );
+}
+
+#[test]
+fn test_configure_auction_rejects_non_creator_caller() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    let attacker = Address::generate(&env);
+
+    let result = client.try_configure_auction(&creator, &attacker, &500i128, &10u32);
+    assert_eq!(result, Err(Ok(FeatureError::Unauthorized)));
+    assert_eq!(client.get_auction_config(&creator), None);
+}
+
+#[test]
+fn test_configure_auction_rejects_unregistered_creator() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = Address::generate(&env);
+
+    let result = client.try_configure_auction(&creator, &creator, &500i128, &10u32);
+    assert_eq!(result, Err(Ok(FeatureError::NotRegistered)));
+}
+
+#[test]
+fn test_configure_auction_rejects_once_supply_is_nonzero() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &1000i128, &None);
+
+    let result = client.try_configure_auction(&creator, &creator, &500i128, &10u32);
+    assert_eq!(result, Err(Ok(FeatureError::AuctionAlreadyStarted)));
+}
+
+#[test]
+fn test_configure_auction_rejects_non_positive_price() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let result = client.try_configure_auction(&creator, &creator, &0i128, &10u32);
+    assert_eq!(result, Err(Ok(FeatureError::NotPositiveAmount)));
+}
+
+#[test]
+fn test_configure_auction_rejects_invalid_supply() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let zero_supply = client.try_configure_auction(&creator, &creator, &500i128, &0u32);
+    assert_eq!(zero_supply, Err(Ok(FeatureError::InvalidAuctionConfig)));
+
+    let too_much_supply = client.try_configure_auction(&creator, &creator, &500i128, &10_001u32);
+    assert_eq!(too_much_supply, Err(Ok(FeatureError::InvalidAuctionConfig)));
+}
+
+#[test]
+fn test_cancel_auction_removes_config_and_emits_event() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &10u32);
+
+    client.cancel_auction(&creator, &creator);
+
+    let mut found = false;
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(&env);
+        if event_name == events::AUCTION_CANCELLED_EVENT_NAME {
+            let payload: events::AuctionCancelledEvent = data.clone().into_val(&env);
+            assert_eq!(payload.creator_id, creator);
+            found = true;
+        }
+    }
+    assert!(found, "expected an AuctionCancelled event");
+
+    assert_eq!(client.get_auction_config(&creator), None);
+}
+
+#[test]
+fn test_cancel_auction_rejects_non_creator_caller() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &10u32);
+    let attacker = Address::generate(&env);
+
+    let result = client.try_cancel_auction(&creator, &attacker);
+    assert_eq!(result, Err(Ok(FeatureError::Unauthorized)));
+    assert!(client.get_auction_config(&creator).is_some());
+}
+
+#[test]
+fn test_cancel_auction_fails_when_none_configured() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+
+    let result = client.try_cancel_auction(&creator, &creator);
+    assert_eq!(result, Err(Ok(FeatureError::NoAuctionConfigured)));
+}
+
+#[test]
+fn test_cancel_auction_fails_after_a_purchase() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &10u32);
+    let buyer = Address::generate(&env);
+    client.buy_key(&creator, &buyer, &500i128, &None);
+
+    let result = client.try_cancel_auction(&creator, &creator);
+    assert_eq!(result, Err(Ok(FeatureError::AuctionAlreadyStarted)));
+}
+
+#[test]
+fn test_buy_key_during_auction_settles_at_fixed_price_and_emits_auction_purchase_event() {
+    let env = test_env_with_auths();
+    let (client, contract_id) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &2u32);
+    let buyer = Address::generate(&env);
+
+    let new_supply = client.buy_key(&creator, &buyer, &500i128, &None);
+    assert_eq!(new_supply, 1);
+
+    let mut found = false;
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(&env);
+        if event_name == events::AUCTION_PURCHASE_EVENT_NAME {
+            let payload: events::AuctionPurchaseEvent = data.clone().into_val(&env);
+            assert_eq!(payload.buyer, buyer);
+            assert_eq!(payload.creator_id, creator);
+            assert_eq!(payload.price_paid, 500);
+            assert_eq!(payload.auction_sold, 1);
+            found = true;
+        }
+    }
+    assert!(found, "expected an AuctionPurchase event");
+
+    assert_eq!(client.get_key_balance(&creator, &buyer), 1);
+    assert_eq!(
+        client.get_auction_config(&creator),
+        Some(AuctionConfig {
+            auction_price: 500,
+            auction_supply: 2,
+            auction_sold: 1,
+        })
+    );
+
+    // Underpaying the fixed auction price still fails, exactly like a bonding-curve buy.
+    let underpay = client.try_buy_key(&creator, &buyer, &499i128, &None);
+    assert_eq!(underpay, Err(Ok(ContractError::InsufficientPayment)));
+}
+
+#[test]
+fn test_buy_key_transitions_to_bonding_curve_once_auction_supply_is_exhausted() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_key_price_for_tests(&env, &client, 1000i128);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &2u32);
+
+    let buyer_a = Address::generate(&env);
+    let buyer_b = Address::generate(&env);
+    let buyer_c = Address::generate(&env);
+
+    client.buy_key(&creator, &buyer_a, &500i128, &None);
+    client.buy_key(&creator, &buyer_b, &500i128, &None);
+
+    assert_eq!(
+        client.get_auction_config(&creator).unwrap().auction_sold,
+        2
+    );
+
+    // Auction supply (2) is now exhausted; the next buy settles at the base
+    // (bonding-curve) price, not the fixed auction price.
+    let new_supply = client.buy_key(&creator, &buyer_c, &1000i128, &None);
+    assert_eq!(new_supply, 3);
+
+    // The stored auction config no longer advances past the configured supply.
+    assert_eq!(
+        client.get_auction_config(&creator),
+        Some(AuctionConfig {
+            auction_price: 500,
+            auction_supply: 2,
+            auction_sold: 2,
+        })
+    );
+}
+
+#[test]
+fn test_get_buy_quote_reflects_auction_price_then_bonding_curve_price() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, 1000i128, 9000u32, 1000u32);
+    let creator = register_test_creator(&env, &client, "alice");
+    client.configure_auction(&creator, &creator, &500i128, &2u32);
+
+    // Before any auction sale: quote must reflect the fixed auction price, not
+    // the base (bonding-curve) key price.
+    assert_eq!(client.get_buy_quote(&creator).price, 500);
+
+    let buyer_a = Address::generate(&env);
+    let buyer_b = Address::generate(&env);
+    client.buy_key(&creator, &buyer_a, &500i128, &None);
+
+    // Still one auction slot left: quote must still be the auction price.
+    assert_eq!(client.get_buy_quote(&creator).price, 500);
+
+    client.buy_key(&creator, &buyer_b, &500i128, &None);
+
+    // Auction supply exhausted: quote must fall back to the bonding-curve price.
+    assert_eq!(client.get_buy_quote(&creator).price, 1000);
+}

--- a/creator-keys/tests/staking_reward_claim.rs
+++ b/creator-keys/tests/staking_reward_claim.rs
@@ -1,0 +1,185 @@
+//! Tests for `claim_stake_reward` and the staking rewards pool (#786 / #789).
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_ledger_sequence, set_pricing_and_fees,
+    test_env_with_auths,
+};
+use creator_keys::{events, FeatureError, STAKE_LOCK_LEDGERS};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, IntoVal, Symbol,
+};
+
+const KEY_PRICE: i128 = 1000;
+const CREATOR_BPS: u32 = 9000;
+const PROTOCOL_BPS: u32 = 1000;
+
+#[test]
+fn test_claim_stake_reward_fails_with_no_stake() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+
+    let result = client.try_claim_stake_reward(&creator, &holder);
+    assert_eq!(result, Err(Ok(FeatureError::NoStakeFound)));
+}
+
+#[test]
+fn test_claim_stake_reward_fails_while_lock_is_active() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+    client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+    client.stake_keys(&creator, &holder, &1u32);
+
+    let result = client.try_claim_stake_reward(&creator, &holder);
+    assert_eq!(result, Err(Ok(FeatureError::StakeLockActive)));
+
+    // Still locked just one ledger before the unlock boundary.
+    let unlock_ledger = client.get_stake_unlock_ledger(&creator, &holder).unwrap();
+    set_ledger_sequence(&env, unlock_ledger - 1);
+    let result = client.try_claim_stake_reward(&creator, &holder);
+    assert_eq!(result, Err(Ok(FeatureError::StakeLockActive)));
+}
+
+#[test]
+fn test_claim_stake_reward_pays_out_and_unlocks_after_lock_period() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+
+    client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+    let pool_after_buy = client.get_staking_rewards_pool(&creator);
+    assert!(
+        pool_after_buy > 0,
+        "buying with a fee config configured should seed the staking rewards pool"
+    );
+
+    client.stake_keys(&creator, &holder, &1u32);
+    assert_eq!(client.get_total_staked(&creator), 1);
+
+    let start_sequence = env.ledger().sequence();
+    set_ledger_sequence(&env, start_sequence + STAKE_LOCK_LEDGERS);
+
+    let reward = client.claim_stake_reward(&creator, &holder);
+    assert_eq!(reward, pool_after_buy);
+
+    // Sole staker gets the entire pool; pool and total-staked bookkeeping are cleared.
+    assert_eq!(client.get_staking_rewards_pool(&creator), 0);
+    assert_eq!(client.get_total_staked(&creator), 0);
+    assert_eq!(client.get_staked_balance(&creator, &holder), 0);
+    assert_eq!(client.get_stake_unlock_ledger(&creator, &holder), None);
+
+    // Liquid balance is untouched by staking/unstaking bookkeeping.
+    assert_eq!(client.get_key_balance(&creator, &holder), 1);
+}
+
+#[test]
+fn test_claim_stake_reward_splits_pool_pro_rata_across_stakers() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    // holder_a buys and stakes 3 keys, holder_b buys and stakes 1.
+    for _ in 0..3 {
+        client.buy_key(&creator, &holder_a, &KEY_PRICE, &None);
+    }
+    client.buy_key(&creator, &holder_b, &KEY_PRICE, &None);
+
+    client.stake_keys(&creator, &holder_a, &3u32);
+    client.stake_keys(&creator, &holder_b, &1u32);
+    assert_eq!(client.get_total_staked(&creator), 4);
+
+    let pool_total = client.get_staking_rewards_pool(&creator);
+    let expected_a = pool_total * 3 / 4;
+    let expected_b_before_a_claims = pool_total * 1 / 4;
+
+    let start_sequence = env.ledger().sequence();
+    set_ledger_sequence(&env, start_sequence + STAKE_LOCK_LEDGERS);
+
+    let reward_a = client.claim_stake_reward(&creator, &holder_a);
+    assert_eq!(reward_a, expected_a);
+    assert_eq!(client.get_total_staked(&creator), 1);
+
+    let reward_b = client.claim_stake_reward(&creator, &holder_b);
+    // holder_b is the sole remaining staker and claims what's left in the pool,
+    // which (absent further rounding loss) matches their pro-rata share.
+    assert_eq!(reward_b, expected_b_before_a_claims);
+    assert_eq!(client.get_total_staked(&creator), 0);
+    assert_eq!(client.get_staking_rewards_pool(&creator), 0);
+}
+
+#[test]
+fn test_claim_stake_reward_emits_event_with_expected_payload() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, contract_id) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+    client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+    let pool = client.get_staking_rewards_pool(&creator);
+    client.stake_keys(&creator, &holder, &1u32);
+
+    let start_sequence = env.ledger().sequence();
+    set_ledger_sequence(&env, start_sequence + STAKE_LOCK_LEDGERS);
+    client.claim_stake_reward(&creator, &holder);
+
+    let mut found = false;
+    for (contract, topics, data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        let event_name: Symbol = topics.get(0).unwrap().into_val(&env);
+        if event_name == events::STAKE_REWARD_CLAIMED_EVENT_NAME {
+            let payload: events::StakeRewardClaimedEvent = data.clone().into_val(&env);
+            assert_eq!(payload.wallet, holder);
+            assert_eq!(payload.key_id, creator);
+            assert_eq!(payload.quantity_unlocked, 1);
+            assert_eq!(payload.reward_amount, pool);
+            found = true;
+        }
+    }
+    assert!(found, "expected a StakeRewardClaimed event");
+}
+
+#[test]
+fn test_claim_stake_reward_fails_while_protocol_paused() {
+    let env = test_env_with_auths();
+    env.ledger().set_max_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    env.ledger().set_min_persistent_entry_ttl(STAKE_LOCK_LEDGERS + 100_000);
+    let (client, _) = register_creator_keys(&env);
+    let admin = set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let holder = Address::generate(&env);
+    client.buy_key(&creator, &holder, &KEY_PRICE, &None);
+    client.stake_keys(&creator, &holder, &1u32);
+
+    let start_sequence = env.ledger().sequence();
+    set_ledger_sequence(&env, start_sequence + STAKE_LOCK_LEDGERS);
+
+    client.pause(&admin);
+
+    let result = client.try_claim_stake_reward(&creator, &holder);
+    assert_eq!(result, Err(Ok(FeatureError::ProtocolPaused)));
+}


### PR DESCRIPTION
## Summary

Resolves the four issues assigned to codeX-james, backed by a new `FeatureError` type (`ContractError` is already at the Soroban 50-variant `contracterror` cap):

- **`remove_co_creator`** — lets a creator clear a previously configured co-creator split, restoring 100% of future royalties to the creator. Returns `NoCoCreatorSet` when none is configured, `Unauthorized` for a non-creator caller, and emits `co_creator_removed`.
- **`cancel_auction`** — lets a creator withdraw an auction configuration before any auction keys have sold, restoring the normal bonding curve buy path. Returns `AuctionAlreadyStarted` once `auction_sold > 0`, `NoAuctionConfigured` when none exists, `Unauthorized` for a non-creator caller, and emits `auction_cancelled`. Ships alongside `configure_auction` (needed to make the auction phase itself testable/usable — `buy_key` settles at the fixed auction price while supply is below `auction_supply`, then transitions back to the curve automatically; `get_buy_quote` mirrors the same resolution so price previews stay correct during the auction phase).
- **`claim_stake_reward`** — unlocks a holder's stake once the 30-day lock has elapsed and pays out a pro-rata share of a per-creator staking rewards pool, funded by routing 10% of each protocol fee collection into that pool alongside the existing treasury/recipient split. Returns `StakeLockActive` before unlock, `NoStakeFound` with no active stake, and emits `stake_reward_claimed`.
- **Integration tests** covering the full auction-to-bonding-curve transition: configuring a 5-key fixed-price auction, buying all 5 at the auction price with `auction_purchase` events and a running `auction_sold` count, then a 6th buy priced at the bonding curve formula for supply 5 with a standard buy event.

Also fixes `creator-keys/src/test_new_features.rs`, found broken at compile time independent of this change (called a removed `initialize()` entrypoint, wrong `register_creator` arity, `.unwrap()` on a plain `u32`) — fixed so the crate's test suite builds and runs at all.

## ⚠️ Pre-existing, unrelated build break on `main`

`main` currently fails to compile independent of this PR. Root cause: the merge commit for PR #774 (`aa46355`) dropped several `DataKey`/`ContractError`/`events` additions that its own already-merged code depends on (`DataKey::ProtocolFeeBps`, `LockupDurationSecs`, `RoyaltyConfig`, `CurveExponent`; `constants::storage::holder_cap_bps`/`last_buy_timestamp`; `events::LockupBlockedEvent`/`FeeCollectedEvent` and their topic helpers). Confirmed via `git worktree`: the original feature commit (`49a7900`) builds cleanly standalone — only the merge into `main` is broken.

Three of the missing pieces (`ContractError::MaxHoldingExceeded`, `LockupPeriodActive`, `InvalidHolderCap`) can't simply be restored: `ContractError` is already at Soroban's 50-variant `contracterror` cap (the same constraint that led to `FeatureError` in this PR). Restoring them needs a follow-up design decision (split the enum further, consolidate an existing variant, etc.) on code this PR doesn't own — flagging for maintainers rather than taking that on unilaterally here.

Because of this, `cargo build`/CI will currently fail on this PR too, through no fault of the changes here. All new code and tests were fully verified (`cargo build` + full `cargo test --tests`, ~180 binaries, 24 new passing tests, no regressions in the 5 known-unrelated pre-existing failures) on top of `main` **before** this pre-existing break was discovered further back in history; the branch was then rebased onto current `main` and the rebase resolution reviewed by hand line-by-line, with no changes to this PR's own logic.

## Test plan

- [x] `cargo build` / `cargo test --tests` — clean, before the base-breaking history was in the branch's ancestry
- [x] 24 new integration tests across `co_creator_removal.rs`, `prelaunch_auction.rs`, `staking_reward_claim.rs`, `auction_bonding_curve_transition.rs` — all passing
- [x] Rebase conflict resolution reviewed by hand (3 conflicting regions in `creator-keys/src/lib.rs`) — confirmed no unintended drops or duplications
- [ ] Re-verify `cargo test` once the pre-existing build break above is fixed on `main`

Closes #791
Closes #790
Closes #789
Closes #788