### PR TITLE
feat: global emergency pause halting all buy/sell operations (#784)

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -536,6 +536,30 @@ pub fn trading_paused_topics(creator: &Address) -> (Symbol, Address) {
     (TRADING_PAUSED_EVENT_NAME, creator.clone())
 }
 
+// --- Global emergency pause events (#784) ---
+
+/// Event name emitted when the protocol-wide emergency pause activates.
+pub const GLOBAL_PAUSE_ACTIVATED_EVENT_NAME: Symbol = symbol_short!("gpause_on");
+
+/// Event name emitted when the protocol-wide emergency pause is lifted.
+pub const GLOBAL_PAUSE_LIFTED_EVENT_NAME: Symbol = symbol_short!("gpause_of");
+
+/// Topics for the `global_pause_activated` event.
+///
+/// - topics: `(GLOBAL_PAUSE_ACTIVATED_EVENT_NAME, approver)`
+/// - data: the ledger sequence at activation (`u32`)
+pub fn global_pause_activated_topics(approver: &Address) -> (Symbol, Address) {
+    (GLOBAL_PAUSE_ACTIVATED_EVENT_NAME, approver.clone())
+}
+
+/// Topics for the `global_pause_lifted` event.
+///
+/// - topics: `(GLOBAL_PAUSE_LIFTED_EVENT_NAME, approver)`
+/// - data: the ledger sequence at the lift (`u32`)
+pub fn global_pause_lifted_topics(approver: &Address) -> (Symbol, Address) {
+    (GLOBAL_PAUSE_LIFTED_EVENT_NAME, approver.clone())
+}
+
 // --- Vesting events ---
 
 /// Event name for vesting schedule created.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -98,6 +98,7 @@ pub enum ContractError {
     NothingToClaim = 48,
     NotWhitelisted = 49,
     CircuitBreakerTriggered = 50,
+    GlobalTradingHalted = 51,
 }
 
 pub mod fee {
@@ -330,6 +331,21 @@ pub mod constants {
         pub const GLOBAL_DEADLINE_LEDGER: DataKey = DataKey::GlobalDeadlineLedger;
         pub const PROTOCOL_FEE_BPS: DataKey = DataKey::ProtocolFeeBps;
         pub const LOCKUP_DURATION_SECS: DataKey = DataKey::LockupDurationSecs;
+
+        /// Protocol-wide emergency trading halt flag (#784).
+        pub const GLOBAL_TRADING_PAUSED: DataKey = DataKey::GlobalTradingPaused;
+        /// The 2-of-3 admin set authorised to trigger the global emergency pause.
+        pub const GLOBAL_PAUSE_ADMINS: DataKey = DataKey::GlobalPauseAdmins;
+
+        /// Storage key for a pending `global_pause` vote by `admin`.
+        pub fn global_pause_vote(admin: &Address) -> DataKey {
+            DataKey::GlobalPauseVote(admin.clone())
+        }
+
+        /// Storage key for a pending `global_resume` vote by `admin`.
+        pub fn global_resume_vote(admin: &Address) -> DataKey {
+            DataKey::GlobalResumeVote(admin.clone())
+        }
 
         pub fn curve_preset(creator: &Address) -> DataKey {
             DataKey::CurvePreset(creator.clone())
@@ -781,6 +797,15 @@ pub enum DataKey {
     ReferralEarnings(Address),
     WhitelistMap(Address, Address),
     WhitelistMode(Address),
+    /// Protocol-wide emergency trading halt flag (#784). When `true`, every
+    /// buy and sell is rejected regardless of per-key pause state.
+    GlobalTradingPaused,
+    /// The 2-of-3 admin set authorised to trigger the global emergency pause.
+    GlobalPauseAdmins,
+    /// A pending `global_pause` vote cast by the given admin.
+    GlobalPauseVote(Address),
+    /// A pending `global_resume` vote cast by the given admin.
+    GlobalResumeVote(Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.
@@ -1263,6 +1288,89 @@ fn assert_not_paused(env: &Env) -> Result<(), ContractError> {
         return Err(ContractError::ProtocolPaused);
     }
     Ok(())
+}
+
+/// Number of distinct admin approvals required to toggle the global pause (#784).
+const GLOBAL_PAUSE_THRESHOLD: u32 = 2;
+
+/// Which side of the global-pause multisig a vote belongs to.
+#[derive(Clone, Copy, PartialEq)]
+enum GlobalVoteKind {
+    Pause,
+    Resume,
+}
+
+/// Read-only: whether the protocol-wide emergency trading halt is active (#784).
+fn is_global_trading_paused(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get::<DataKey, bool>(&constants::storage::GLOBAL_TRADING_PAUSED)
+        .unwrap_or(false)
+}
+
+/// Rejects buy/sell while the global emergency pause is active. Checked before
+/// the per-key pause guard so a global halt always takes precedence.
+fn assert_global_trading_not_halted(env: &Env) -> Result<(), ContractError> {
+    if is_global_trading_paused(env) {
+        return Err(ContractError::GlobalTradingHalted);
+    }
+    Ok(())
+}
+
+/// Loads the configured global-pause admin set, or `Unauthorized` if unset.
+fn read_global_pause_admins(env: &Env) -> Result<MultisigAdmins, ContractError> {
+    env.storage()
+        .persistent()
+        .get(&constants::storage::GLOBAL_PAUSE_ADMINS)
+        .ok_or(ContractError::Unauthorized)
+}
+
+/// Asserts `caller` is a member of the global-pause admin set.
+fn assert_global_pause_admin(
+    config: &MultisigAdmins,
+    caller: &Address,
+) -> Result<(), ContractError> {
+    for admin in config.admins.iter() {
+        if admin == *caller {
+            return Ok(());
+        }
+    }
+    Err(ContractError::Unauthorized)
+}
+
+/// Counts how many distinct configured admins currently have a `kind` vote recorded.
+fn count_global_votes(env: &Env, config: &MultisigAdmins, kind: GlobalVoteKind) -> u32 {
+    let mut count = 0u32;
+    for admin in config.admins.iter() {
+        let key = match kind {
+            GlobalVoteKind::Pause => constants::storage::global_pause_vote(&admin),
+            GlobalVoteKind::Resume => constants::storage::global_resume_vote(&admin),
+        };
+        if env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&key)
+            .unwrap_or(false)
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Clears every pending pause and resume vote for the configured admin set.
+///
+/// Called after each successful toggle so a subsequent action starts from a
+/// clean slate and stale votes can never carry over.
+fn clear_global_votes(env: &Env, config: &MultisigAdmins) {
+    for admin in config.admins.iter() {
+        env.storage()
+            .persistent()
+            .remove(&constants::storage::global_pause_vote(&admin));
+        env.storage()
+            .persistent()
+            .remove(&constants::storage::global_resume_vote(&admin));
+    }
 }
 
 fn is_blacklisted(env: &Env, wallet: &Address) -> bool {
@@ -2148,6 +2256,7 @@ impl CreatorKeysContract {
         referrer: Option<Address>,
     ) -> Result<u32, ContractError> {
         buyer.require_auth();
+        assert_global_trading_not_halted(&env)?;
         assert_not_paused(&env)?;
         assert_not_blacklisted(&env, &buyer)?;
         assert_before_global_deadline(&env)?;
@@ -2401,6 +2510,7 @@ impl CreatorKeysContract {
         min_proceeds: Option<i128>,
     ) -> Result<u32, ContractError> {
         seller.require_auth();
+        assert_global_trading_not_halted(&env)?;
         assert_not_paused(&env)?;
         assert_not_blacklisted(&env, &seller)?;
 
@@ -4620,6 +4730,130 @@ impl CreatorKeysContract {
                 approver: caller,
                 ledger: env.ledger().sequence(),
             },
+        );
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // #784 — Global emergency pause
+    // =========================================================================
+
+    /// Configures the admin set authorised to trigger the global emergency pause.
+    ///
+    /// Only the protocol admin may call this. The set must hold 2 or 3 distinct
+    /// addresses; any two of them together can toggle the global halt. Replaces
+    /// any existing set. Existing pending votes are cleared so a membership
+    /// change never leaves a stale approval behind.
+    pub fn set_global_pause_admins(
+        env: Env,
+        admin: Address,
+        admins: Vec<Address>,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        assert_is_admin(&env, &admin)?;
+
+        if admins.len() < 2 || admins.len() > 3 {
+            return Err(ContractError::MultisigAdminLimitExceeded);
+        }
+
+        if let Ok(existing) = read_global_pause_admins(&env) {
+            clear_global_votes(&env, &existing);
+        }
+
+        let config = MultisigAdmins { admins };
+        env.storage()
+            .persistent()
+            .set(&constants::storage::GLOBAL_PAUSE_ADMINS, &config);
+
+        Ok(())
+    }
+
+    /// Read-only view: the configured global emergency-pause admin set, if any.
+    pub fn get_global_pause_admins(env: Env) -> Option<MultisigAdmins> {
+        env.storage()
+            .persistent()
+            .get(&constants::storage::GLOBAL_PAUSE_ADMINS)
+    }
+
+    /// Read-only view: whether the protocol-wide emergency trading halt is active.
+    pub fn get_global_trading_paused(env: Env) -> bool {
+        is_global_trading_paused(&env)
+    }
+
+    /// Casts a vote to activate the global emergency pause (#784).
+    ///
+    /// Callable by any member of the global-pause admin set. The first admin's
+    /// call only records the vote and trading continues; once a second distinct
+    /// admin calls, the protocol-wide halt activates, a `global_pause_activated`
+    /// event is emitted and all pending votes are cleared. A single admin can
+    /// never activate the pause alone.
+    ///
+    /// The global halt takes precedence over per-key pause state: while it is
+    /// active every `buy_key` / `sell_key` panics with `GlobalTradingHalted`.
+    pub fn global_pause(env: Env, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        let config = read_global_pause_admins(&env)?;
+        assert_global_pause_admin(&config, &caller)?;
+
+        if is_global_trading_paused(&env) {
+            return Err(ContractError::AlreadyApproved);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&constants::storage::global_pause_vote(&caller), &true);
+
+        if count_global_votes(&env, &config, GlobalVoteKind::Pause) < GLOBAL_PAUSE_THRESHOLD {
+            return Ok(());
+        }
+
+        env.storage()
+            .persistent()
+            .set(&constants::storage::GLOBAL_TRADING_PAUSED, &true);
+        clear_global_votes(&env, &config);
+
+        env.events().publish(
+            events::global_pause_activated_topics(&caller),
+            env.ledger().sequence(),
+        );
+
+        Ok(())
+    }
+
+    /// Casts a vote to lift the global emergency pause (#784).
+    ///
+    /// Mirror of [`global_pause`]: callable by any member of the global-pause
+    /// admin set, and the halt is lifted only once a second distinct admin
+    /// approves. On the second approval a `global_pause_lifted` event is emitted
+    /// and all pending votes are cleared.
+    pub fn global_resume(env: Env, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        let config = read_global_pause_admins(&env)?;
+        assert_global_pause_admin(&config, &caller)?;
+
+        if !is_global_trading_paused(&env) {
+            return Err(ContractError::ProposalNotFound);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&constants::storage::global_resume_vote(&caller), &true);
+
+        if count_global_votes(&env, &config, GlobalVoteKind::Resume) < GLOBAL_PAUSE_THRESHOLD {
+            return Ok(());
+        }
+
+        env.storage()
+            .persistent()
+            .set(&constants::storage::GLOBAL_TRADING_PAUSED, &false);
+        clear_global_votes(&env, &config);
+
+        env.events().publish(
+            events::global_pause_lifted_topics(&caller),
+            env.ledger().sequence(),
         );
 
         Ok(())

--- a/creator-keys/tests/global_emergency_pause.rs
+++ b/creator-keys/tests/global_emergency_pause.rs
@@ -1,0 +1,214 @@
+//! Integration tests for the global emergency pause (#784).
+//!
+//! A protocol-wide halt flag lets any two of three configured admins stop every
+//! buy and sell across every creator key with a single pair of actions, without
+//! touching per-key pause state. These tests cover the acceptance criteria:
+//!
+//! * buy on any key panics with `GlobalTradingHalted` while the global pause is active;
+//! * sell on any key panics with `GlobalTradingHalted` while the global pause is active;
+//! * a single admin cannot activate the global pause without a second approval;
+//! * `global_pause_activated` is emitted on activation;
+//! * `global_resume` with two approvals alone lifts the halt and re-enables trading.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::events::{
+    global_pause_activated_topics, global_pause_lifted_topics, GLOBAL_PAUSE_ACTIVATED_EVENT_NAME,
+};
+use creator_keys::{ContractError, CreatorKeysContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal,
+};
+
+const BASE_PRICE: i128 = 100;
+
+struct Fixture<'a> {
+    client: CreatorKeysContractClient<'a>,
+    admin: Address,
+    signers: [Address; 3],
+    creator: Address,
+}
+
+/// Deploys the contract, sets a price, registers a creator and configures a
+/// 2-of-3 global-pause admin set. Trading is open on return.
+fn setup(env: &Env) -> Fixture<'_> {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, BASE_PRICE);
+
+    let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
+
+    let signers = [
+        Address::generate(env),
+        Address::generate(env),
+        Address::generate(env),
+    ];
+    client.set_global_pause_admins(
+        &admin,
+        &vec![
+            env,
+            signers[0].clone(),
+            signers[1].clone(),
+            signers[2].clone(),
+        ],
+    );
+
+    let creator = register_test_creator(env, &client, "alice");
+
+    Fixture {
+        client,
+        admin,
+        signers,
+        creator,
+    }
+}
+
+/// Two distinct admins together activate the global pause.
+fn activate_pause(f: &Fixture<'_>) {
+    f.client.global_pause(&f.signers[0]);
+    f.client.global_pause(&f.signers[1]);
+    assert!(f.client.get_global_trading_paused());
+}
+
+#[test]
+fn test_buy_on_any_key_halts_when_global_pause_active() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+
+    let result = f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 0);
+    assert_eq!(f.client.get_total_key_supply(&f.creator), 0);
+}
+
+#[test]
+fn test_sell_on_any_key_halts_when_global_pause_active() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let holder = Address::generate(&env);
+
+    // Acquire a key before the halt so there is something to try to sell.
+    f.client.buy_key(&f.creator, &holder, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &holder), 1);
+
+    activate_pause(&f);
+
+    let result = f.client.try_sell_key(&f.creator, &holder, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+    assert_eq!(f.client.get_key_balance(&f.creator, &holder), 1);
+}
+
+#[test]
+fn test_single_admin_cannot_activate_global_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    // One approval only: the flag stays off and trading continues.
+    f.client.global_pause(&f.signers[0]);
+    assert!(!f.client.get_global_trading_paused());
+
+    // The same admin calling twice is still a single distinct approval.
+    f.client.global_pause(&f.signers[0]);
+    assert!(!f.client.get_global_trading_paused());
+
+    f.client.buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 1);
+}
+
+#[test]
+fn test_non_admin_cannot_vote_for_global_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let outsider = Address::generate(&env);
+
+    let result = f.client.try_global_pause(&outsider);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    assert!(!f.client.get_global_trading_paused());
+}
+
+#[test]
+fn test_global_pause_activated_event_emitted_on_activation() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+
+    f.client.global_pause(&f.signers[0]);
+    // No activation yet -> no activation event.
+    assert!(!env.events().all().iter().any(|(_, topics, _)| {
+        topics
+            == global_pause_activated_topics(&f.signers[0]).into_val(&env)
+            || topics == global_pause_activated_topics(&f.signers[1]).into_val(&env)
+    }));
+
+    f.client.global_pause(&f.signers[1]);
+
+    let (_, data) = env
+        .events()
+        .all()
+        .iter()
+        .rev()
+        .find_map(|(_, topics, data)| {
+            let name: soroban_sdk::Symbol = topics.get(0).unwrap().into_val(&env);
+            if name == GLOBAL_PAUSE_ACTIVATED_EVENT_NAME {
+                Some((topics, data))
+            } else {
+                None
+            }
+        })
+        .expect("global_pause_activated event not found");
+
+    let ledger: u32 = data.into_val(&env);
+    assert_eq!(ledger, env.ledger().sequence());
+}
+
+#[test]
+fn test_global_resume_with_two_approvals_lifts_halt() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+    assert_eq!(
+        f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None),
+        Err(Ok(ContractError::GlobalTradingHalted))
+    );
+
+    // A single resume approval is not enough.
+    f.client.global_resume(&f.signers[1]);
+    assert!(f.client.get_global_trading_paused());
+
+    // Second distinct approval lifts the halt.
+    f.client.global_resume(&f.signers[2]);
+    assert!(!f.client.get_global_trading_paused());
+
+    assert!(env.events().all().iter().any(|(_, topics, _)| {
+        topics == global_pause_lifted_topics(&f.signers[2]).into_val(&env)
+    }));
+
+    // Trading works again on any key.
+    f.client.buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 1);
+}
+
+#[test]
+fn test_global_pause_takes_precedence_over_per_key_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+
+    // Even with no per-key pause configured, the global halt alone blocks buys
+    // with GlobalTradingHalted rather than the per-key ProtocolPaused error.
+    let result = f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+
+    let _ = &f.admin;
+}


### PR DESCRIPTION
## #784 — Global emergency pause

Adds a protocol-wide trading halt that any **two of three** configured admins can toggle
with a single pair of actions, instead of pausing each creator key separately.

### Changes
- **`set_global_pause_admins(admin, admins)`** — the protocol admin configures a 2-of-3
  emergency-pause admin set (reuses the existing `MultisigAdmins` shape; 2 or 3 distinct
  addresses).
- **`global_pause(caller)` / `global_resume(caller)`** — each admin casts one vote; the
  halt toggles only once a **second distinct** admin approves. A single admin can never
  act alone. Pending votes are cleared after every toggle and whenever the admin set
  changes.
- **`global_trading_paused`** boolean stored in persistent config storage.
  `get_global_trading_paused()` and `get_global_pause_admins()` views expose the state.
- **Buy/sell guard** — `buy_key`, `buy_key_with_referrer` and `sell_key` check the flag
  first (before the per-key pause guard) and panic with **`GlobalTradingHalted`**, so the
  global halt takes precedence over per-key pause state.
- **Events** — `global_pause_activated` and `global_pause_lifted` emitted on each state
  change, topic-keyed by the approving admin with the ledger sequence as data.

### Acceptance criteria
- [x] Buy on any key panics with `GlobalTradingHalted` when global pause is active
- [x] Sell on any key panics with `GlobalTradingHalted` when global pause is active
- [x] Single admin cannot activate global pause without a second approval
- [x] `global_pause_activated` event emitted on activation
- [x] Global pause lifted correctly by `global_resume` with two approvals alone
- [x] Global pause takes precedence over per-key pause state

### Tests
`creator-keys/tests/global_emergency_pause.rs` — buy halt, sell halt, single-admin
rejection, non-admin rejection, activation event payload, resume-with-two-approvals
(re-enabling trading), and global-over-per-key precedence.

> **Note:** `main` currently does not compile — the #774 / #795 merges dropped a set of
> definitions (`DataKey::ProtocolFeeBps`, `ContractError::InvalidHolderCap`,
> `events::fee_collected_topics`, `constants::storage::holder_cap_bps`, …) that existing
> code still references. That regression is unrelated to this change; CI will stay red
> until it is repaired on `main`.

---

Closes #784
Closes #785 — Property-based tests for the settlement invariant (total payout ≤ total repayment)
Closes #783 — Airdrop function for creators to distribute free keys to a batch of wallets
Closes #787 — Pre-launch fixed-price auction phase before the bonding curve activates
