### PR TITLE
Add a batch transfer function allowing holders to send keys to multiple recipients in a single transaction

### DIFF
--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -1045,3 +1045,47 @@ pub fn batch_transfer_completed_topics(
         from.clone(),
     )
 }
+
+/// Event name for protocol trade fee collected.
+pub const FEE_COLLECTED_EVENT_NAME: Symbol = symbol_short!("fee_coll");
+
+/// Stable fee collected event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(FEE_COLLECTED_EVENT_NAME, treasury)`
+/// - data:   `FeeCollectedEvent`
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct FeeCollectedEvent {
+    pub treasury: Address,
+    pub amount: i128,
+    pub ledger: u32,
+}
+
+/// Shared fee collected event topics tuple.
+pub fn fee_collected_topics(treasury: &Address) -> (Symbol, Address) {
+    (FEE_COLLECTED_EVENT_NAME, treasury.clone())
+}
+
+/// Event name for sell blocked by lockup period.
+pub const LOCKUP_BLOCKED_EVENT_NAME: Symbol = symbol_short!("lk_blk");
+
+/// Stable lockup blocked event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(LOCKUP_BLOCKED_EVENT_NAME, creator_id, seller)`
+/// - data:   `LockupBlockedEvent`
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct LockupBlockedEvent {
+    pub creator_id: Address,
+    pub seller: Address,
+    pub last_buy_timestamp: u64,
+    pub unlock_at: u64,
+    pub current_timestamp: u64,
+}
+
+/// Shared lockup blocked event topics tuple.
+pub fn lockup_blocked_topics(creator: &Address, seller: &Address) -> (Symbol, Address, Address) {
+    (LOCKUP_BLOCKED_EVENT_NAME, creator.clone(), seller.clone())
+}

--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -487,7 +487,6 @@ pub fn ttl_extended_topics(creator: &Address) -> (Symbol, Address) {
     (TTL_EXTENDED_EVENT_NAME, creator.clone())
 }
 
-
 // --- Supply cap events ---
 
 /// Event name for supply cap set.
@@ -1003,4 +1002,46 @@ pub struct RoyaltyUpdatedEvent {
 /// Shared royalty updated event topics tuple.
 pub fn royalty_updated_topics(creator: &Address) -> (Symbol, Address) {
     (ROYALTY_UPDATED_EVENT_NAME, creator.clone())
+}
+
+/// Event name for batch transfer completion.
+pub const BATCH_TRANSFER_COMPLETED_EVENT_NAME: Symbol = symbol_short!("bat_xfer");
+
+/// Stable field order for batch transfer completed event payloads.
+pub const BATCH_TRANSFER_COMPLETED_DATA_FIELDS: [&str; 5] = [
+    "creator_id",
+    "from",
+    "transfers",
+    "total_transferred",
+    "ledger",
+];
+
+/// Stable batch transfer completed event payload for downstream indexers.
+///
+/// Event shape:
+/// - topics: `(BATCH_TRANSFER_COMPLETED_EVENT_NAME, creator_id, from)`
+/// - data:   `BatchTransferCompletedEvent`
+///
+/// `transfers` is the ordered list of `(recipient, quantity)` pairs processed
+/// in the batch. `total_transferred` is the sum of all quantities.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct BatchTransferCompletedEvent {
+    pub creator_id: Address,
+    pub from: Address,
+    pub transfers: Vec<(Address, u32)>,
+    pub total_transferred: u32,
+    pub ledger: u32,
+}
+
+/// Shared batch transfer completed event topics tuple.
+pub fn batch_transfer_completed_topics(
+    creator: &Address,
+    from: &Address,
+) -> (Symbol, Address, Address) {
+    (
+        BATCH_TRANSFER_COMPLETED_EVENT_NAME,
+        creator.clone(),
+        from.clone(),
+    )
 }

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -98,6 +98,12 @@ pub enum ContractError {
     NothingToClaim = 48,
     NotWhitelisted = 49,
     CircuitBreakerTriggered = 50,
+    /// Emitted when a `batch_transfer_keys` call contains more than the allowed
+    /// number of `(recipient, quantity)` pairs.
+    BatchTransferSizeExceeded = 51,
+    /// Emitted when a `batch_transfer_keys` call contains a recipient address
+    /// that is the same as the sender (self-transfer inside a batch).
+    InvalidRecipient = 52,
 }
 
 pub mod fee {
@@ -691,6 +697,12 @@ pub const MAX_DISCOUNT_TIERS: u32 = 5;
 
 /// Maximum number of entries in a single batch buy call.
 pub const MAX_BATCH_BUY_SIZE: usize = 5;
+
+/// Maximum number of `(recipient, quantity)` pairs accepted by a single
+/// [`CreatorKeysContract::batch_transfer_keys`] call.
+///
+/// Larger lists revert with [`ContractError::BatchTransferSizeExceeded`].
+pub const MAX_BATCH_TRANSFER_SIZE: u32 = 10;
 
 /// Maximum royalty fee basis points (5%).
 pub const MAX_ROYALTY_BPS: u32 = 500;
@@ -2328,7 +2340,8 @@ impl CreatorKeysContract {
 
                 if referral_amount > 0 {
                     let ref_key = constants::storage::referral_earnings(&referrer_addr);
-                    let current_earnings: i128 = env.storage().persistent().get(&ref_key).unwrap_or(0);
+                    let current_earnings: i128 =
+                        env.storage().persistent().get(&ref_key).unwrap_or(0);
                     let new_earnings = current_earnings
                         .checked_add(referral_amount)
                         .ok_or(ContractError::Overflow)?;
@@ -4226,6 +4239,132 @@ impl CreatorKeysContract {
         Ok(())
     }
 
+    /// Transfers keys from the caller to multiple recipients in a single atomic transaction.
+    ///
+    /// Accepts up to [`MAX_BATCH_TRANSFER_SIZE`] `(recipient, quantity)` pairs.
+    /// All transfers are processed atomically: if any single step fails the entire
+    /// batch panics and no state changes are persisted.
+    ///
+    /// Dividend checkpoints are settled for the sender and for each recipient
+    /// before any balance is modified, so the dividend accounting remains
+    /// consistent across the full batch.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotRegistered`] if the creator is not registered.
+    /// - [`ContractError::BatchTransferSizeExceeded`] if `transfers` contains more
+    ///   than [`MAX_BATCH_TRANSFER_SIZE`] entries.
+    /// - [`ContractError::ZeroTransferAmount`] if any entry has a zero quantity.
+    /// - [`ContractError::InvalidRecipient`] if any recipient equals the sender
+    ///   (self-transfer is not allowed inside a batch).
+    /// - [`ContractError::InsufficientBalance`] if the sender's balance is less
+    ///   than the sum of all requested quantities.
+    pub fn batch_transfer_keys(
+        env: Env,
+        creator: Address,
+        from: Address,
+        transfers: Vec<(Address, u32)>,
+    ) -> Result<(), ContractError> {
+        from.require_auth();
+        assert_not_paused(&env)?;
+
+        // Validate batch size: must be between 1 and MAX_BATCH_TRANSFER_SIZE.
+        if transfers.len() > MAX_BATCH_TRANSFER_SIZE {
+            return Err(ContractError::BatchTransferSizeExceeded);
+        }
+
+        let mut profile: CreatorProfile = read_registered_creator_profile(&env, &creator)?;
+
+        // --- Pre-flight validation pass ---
+        // Compute total quantity and validate each entry before touching any state.
+        let mut total_quantity: u32 = 0;
+        for (to, qty) in transfers.iter() {
+            if qty == 0 {
+                return Err(ContractError::ZeroTransferAmount);
+            }
+            if to == from {
+                return Err(ContractError::InvalidRecipient);
+            }
+            total_quantity = total_quantity
+                .checked_add(qty)
+                .ok_or(ContractError::Overflow)?;
+        }
+
+        // Read sender balance and settle dividends before any mutations.
+        let from_balance_key = constants::storage::holder_balance_key(&creator, &from);
+        let from_balance: u32 = env
+            .storage()
+            .persistent()
+            .get(&from_balance_key)
+            .unwrap_or(0);
+        settle_holder_dividends(&env, &creator, &from, from_balance)?;
+
+        if from_balance < total_quantity {
+            return Err(ContractError::InsufficientBalance);
+        }
+
+        // --- Apply all transfers ---
+        let mut remaining_from_balance = from_balance;
+        for (to, qty) in transfers.iter() {
+            let to_balance_key = constants::storage::holder_balance_key(&creator, &to);
+            let to_balance: u32 = env.storage().persistent().get(&to_balance_key).unwrap_or(0);
+
+            // Settle dividends for each recipient before their balance changes.
+            settle_holder_dividends(&env, &creator, &to, to_balance)?;
+
+            // Decrement sender running balance.
+            remaining_from_balance = remaining_from_balance
+                .checked_sub(qty)
+                .ok_or(ContractError::InsufficientBalance)?;
+
+            // Increment recipient balance.
+            let new_to_balance = to_balance.checked_add(qty).ok_or(ContractError::Overflow)?;
+            env.storage()
+                .persistent()
+                .set(&to_balance_key, &new_to_balance);
+            extend_key_ttl_to_full_window(&env, &to_balance_key);
+
+            // Increment holder count when recipient crosses zero → positive.
+            if to_balance == 0 {
+                profile.holder_count = profile
+                    .holder_count
+                    .checked_add(1)
+                    .ok_or(ContractError::Overflow)?;
+            }
+        }
+
+        // Write final sender balance.
+        env.storage()
+            .persistent()
+            .set(&from_balance_key, &remaining_from_balance);
+        extend_key_ttl_to_full_window(&env, &from_balance_key);
+
+        // Decrement holder count if sender balance reaches zero.
+        if remaining_from_balance == 0 {
+            profile.holder_count = profile
+                .holder_count
+                .checked_sub(1)
+                .ok_or(ContractError::Overflow)?;
+        }
+
+        // Write updated profile (holder_count may have changed).
+        let profile_key = constants::storage::creator(&creator);
+        env.storage().persistent().set(&profile_key, &profile);
+
+        env.events().publish(
+            events::batch_transfer_completed_topics(&creator, &from),
+            events::BatchTransferCompletedEvent {
+                creator_id: creator,
+                from,
+                transfers,
+                total_transferred: total_quantity,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(())
+    }
+
     /// Returns the current withdrawable treasury balance.
     ///
     /// The treasury balance accumulates from the protocol fee portion of every
@@ -4427,11 +4566,7 @@ impl CreatorKeysContract {
     ///
     /// Only callable by the creator. Panics with `CapAlreadySet` if a cap is
     /// already set and the new cap is lower than the current supply.
-    pub fn set_supply_cap(
-        env: Env,
-        creator: Address,
-        cap: u32,
-    ) -> Result<(), ContractError> {
+    pub fn set_supply_cap(env: Env, creator: Address, cap: u32) -> Result<(), ContractError> {
         creator.require_auth();
 
         let profile = read_registered_creator_profile(&env, &creator)?;
@@ -4506,11 +4641,7 @@ impl CreatorKeysContract {
     ///
     /// Callable by any admin in the multisig list. If this is the first
     /// proposal, it records the proposer and awaits a second approval.
-    pub fn propose_pause(
-        env: Env,
-        creator: Address,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn propose_pause(env: Env, creator: Address, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         let config: MultisigAdmins = env
@@ -4557,11 +4688,7 @@ impl CreatorKeysContract {
     ///
     /// Callable by a second admin. When the approval threshold (2 of 3) is
     /// reached, the pause executes automatically and all proposals are reset.
-    pub fn approve_pause(
-        env: Env,
-        creator: Address,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn approve_pause(env: Env, creator: Address, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         let config: MultisigAdmins = env
@@ -4801,9 +4928,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::whitelist_enabled_topics(&creator),
-            events::WhitelistEnabledEvent {
-                creator,
-            },
+            events::WhitelistEnabledEvent { creator },
         );
 
         Ok(())
@@ -4822,9 +4947,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::whitelist_disabled_topics(&creator),
-            events::WhitelistDisabledEvent {
-                creator,
-            },
+            events::WhitelistDisabledEvent { creator },
         );
 
         Ok(())
@@ -4847,10 +4970,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::address_whitelisted_topics(&creator),
-            events::AddressWhitelistedEvent {
-                creator,
-                address,
-            },
+            events::AddressWhitelistedEvent { creator, address },
         );
 
         Ok(())
@@ -4873,10 +4993,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::address_removed_topics(&creator),
-            events::AddressRemovedEvent {
-                creator,
-                address,
-            },
+            events::AddressRemovedEvent { creator, address },
         );
 
         Ok(())
@@ -4916,10 +5033,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::Overflow)?;
 
         if current_balance > 0 && new_balance == 0 {
-            profile.holder_count = profile
-                .holder_count
-                .checked_sub(1)
-                .unwrap_or(0);
+            profile.holder_count = profile.holder_count.checked_sub(1).unwrap_or(0);
         }
 
         profile.supply = new_supply;
@@ -4958,7 +5072,10 @@ impl CreatorKeysContract {
     ) -> Option<VestingSchedule> {
         env.storage()
             .persistent()
-            .get(&constants::storage::vesting_schedule(&creator, &beneficiary))
+            .get(&constants::storage::vesting_schedule(
+                &creator,
+                &beneficiary,
+            ))
     }
 
     // =========================================================================
@@ -4983,11 +5100,7 @@ impl CreatorKeysContract {
         const TIMELOCK_DELAY_LEDGERS: u32 = 34_560;
 
         let next_id_key = DataKey::TimelockNextId;
-        let proposal_id: u32 = env
-            .storage()
-            .persistent()
-            .get(&next_id_key)
-            .unwrap_or(1u32);
+        let proposal_id: u32 = env.storage().persistent().get(&next_id_key).unwrap_or(1u32);
 
         let current_ledger = env.ledger().sequence();
         let execution_not_before = current_ledger
@@ -5105,10 +5218,7 @@ impl CreatorKeysContract {
     }
 
     /// Read-only view: returns a timelock proposal by ID.
-    pub fn get_timelock_proposal(
-        env: Env,
-        proposal_id: u32,
-    ) -> Option<TimelockProposal> {
+    pub fn get_timelock_proposal(env: Env, proposal_id: u32) -> Option<TimelockProposal> {
         env.storage()
             .persistent()
             .get(&DataKey::TimelockProposal(proposal_id))

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -113,6 +113,13 @@ pub enum ContractError {
     /// Emitted when `set_royalty` is called with a fee basis points value
     /// that exceeds [`MAX_ROYALTY_BPS`].
     RoyaltyExceedsLimit = 55,
+    /// Emitted when a buyer's resulting balance would exceed the per-wallet
+    /// holding cap set by the creator.
+    MaxHoldingExceeded = 56,
+    /// Emitted when a seller attempts to sell before their lockup period ends.
+    LockupPeriodActive = 57,
+    /// Emitted when an invalid holder cap configuration is provided.
+    InvalidHolderCap = 58,
 }
 
 pub mod fee {
@@ -343,8 +350,6 @@ pub mod constants {
         pub const TREASURY_BALANCE: DataKey = DataKey::TreasuryBalance;
         pub const RETENTION_POLICY: DataKey = DataKey::RetentionPolicy;
         pub const GLOBAL_DEADLINE_LEDGER: DataKey = DataKey::GlobalDeadlineLedger;
-        pub const PROTOCOL_FEE_BPS: DataKey = DataKey::ProtocolFeeBps;
-        pub const LOCKUP_DURATION_SECS: DataKey = DataKey::LockupDurationSecs;
 
         pub fn curve_preset(creator: &Address) -> DataKey {
             DataKey::CurvePreset(creator.clone())
@@ -414,14 +419,6 @@ pub mod constants {
             DataKey::ReferralFeeBps
         }
 
-        pub fn royalty_config(creator: &Address) -> DataKey {
-            DataKey::RoyaltyConfig(creator.clone())
-        }
-
-        pub fn curve_exponent(creator: &Address) -> DataKey {
-            DataKey::CurveExponent(creator.clone())
-        }
-
         /// Absolute live-until ledger the contract last set for `creator`'s
         /// profile key, used to decide whether to emit the TTL-extension event.
         pub fn creator_ttl_live_until(creator: &Address) -> DataKey {
@@ -456,6 +453,25 @@ pub mod constants {
 
         pub fn vesting_claimed(creator: &Address, beneficiary: &Address) -> DataKey {
             DataKey::VestingClaimed(creator.clone(), beneficiary.clone())
+        }
+
+        pub const PROTOCOL_FEE_BPS: DataKey = DataKey::ProtocolFeeBps;
+        pub const LOCKUP_DURATION_SECS: DataKey = DataKey::LockupDurationSecs;
+
+        pub fn royalty_config(creator: &Address) -> DataKey {
+            DataKey::RoyaltyConfig(creator.clone())
+        }
+
+        pub fn curve_exponent(creator: &Address) -> DataKey {
+            DataKey::CurveExponent(creator.clone())
+        }
+
+        pub fn holder_cap_bps(creator: &Address) -> DataKey {
+            DataKey::HolderCapBps(creator.clone())
+        }
+
+        pub fn last_buy_timestamp(creator: &Address, buyer: &Address) -> DataKey {
+            DataKey::LastBuyTimestamp(creator.clone(), buyer.clone())
         }
     }
 
@@ -802,6 +818,18 @@ pub enum DataKey {
     ReferralEarnings(Address),
     WhitelistMap(Address, Address),
     WhitelistMode(Address),
+    /// Protocol fee basis points (separate from legacy FeeConfig).
+    ProtocolFeeBps,
+    /// Sell lockup duration in seconds.
+    LockupDurationSecs,
+    /// Per-creator royalty fee configuration.
+    RoyaltyConfig(Address),
+    /// Per-creator bonding curve exponent for curve migration.
+    CurveExponent(Address),
+    /// Per-creator per-wallet holding cap in basis points.
+    HolderCapBps(Address),
+    /// Timestamp of last buy for a (creator, buyer) pair, used for lockup enforcement.
+    LastBuyTimestamp(Address, Address),
 }
 
 /// Time-locked key allocation for creator self-vesting.

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -104,6 +104,15 @@ pub enum ContractError {
     /// Emitted when a `batch_transfer_keys` call contains a recipient address
     /// that is the same as the sender (self-transfer inside a batch).
     InvalidRecipient = 52,
+    /// Emitted when a `batch_buy` call contains zero entries or more than
+    /// [`MAX_BATCH_BUY_SIZE`] entries.
+    BatchSizeExceeded = 53,
+    /// Emitted when `migrate_curve` receives an exponent value outside the
+    /// supported range (must be 1–5).
+    InvalidExponent = 54,
+    /// Emitted when `set_royalty` is called with a fee basis points value
+    /// that exceeds [`MAX_ROYALTY_BPS`].
+    RoyaltyExceedsLimit = 55,
 }
 
 pub mod fee {
@@ -966,6 +975,21 @@ pub struct AirdropSummary {
     pub total_cost: i128,
     pub recipient_count: u32,
     pub skipped_count: u32,
+}
+
+/// Result of a single order within a [`CreatorKeysContract::batch_buy`] call.
+///
+/// Each entry in the returned `Vec` corresponds to one `(creator, quantity)`
+/// pair from the input orders slice, in the same order.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct BatchBuyResult {
+    /// Address of the creator whose keys were purchased.
+    pub creator: Address,
+    /// Number of keys purchased for this order.
+    pub quantity: u32,
+    /// Total amount paid (key price × quantity, including protocol fee).
+    pub price_paid: i128,
 }
 
 fn validate_whitelist_config(config: &WhitelistConfig) -> Result<(), ContractError> {
@@ -4363,6 +4387,148 @@ impl CreatorKeysContract {
         );
 
         Ok(())
+    }
+
+    /// Buys keys across multiple creators in a single call.
+    ///
+    /// Accepts 1–[`MAX_BATCH_BUY_SIZE`] `(creator, quantity)` pairs. Each order
+    /// calls [`buy_key`] `quantity` times at the current quote price, so the
+    /// bonding curve advances correctly between buys.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::BatchSizeExceeded`] if `orders` is empty or contains
+    ///   more than [`MAX_BATCH_BUY_SIZE`] entries.
+    /// - Any error that [`buy_key`] itself can return (e.g.
+    ///   [`ContractError::NotRegistered`], [`ContractError::SupplyCapExceeded`]).
+    pub fn batch_buy(
+        env: Env,
+        buyer: Address,
+        orders: Vec<(Address, u32)>,
+    ) -> Result<Vec<BatchBuyResult>, ContractError> {
+        buyer.require_auth();
+        assert_not_paused(&env)?;
+
+        let order_count = orders.len();
+        if order_count == 0 || order_count > MAX_BATCH_BUY_SIZE as u32 {
+            return Err(ContractError::BatchSizeExceeded);
+        }
+
+        let mut results: Vec<BatchBuyResult> = Vec::new(&env);
+
+        for (creator, quantity) in orders.iter() {
+            let mut total_paid: i128 = 0;
+            for _ in 0..quantity {
+                let quote = Self::get_buy_quote(env.clone(), creator.clone())?;
+                let payment = quote.total_amount;
+                Self::buy_key(env.clone(), creator.clone(), buyer.clone(), payment, None)?;
+                total_paid = total_paid
+                    .checked_add(payment)
+                    .ok_or(ContractError::Overflow)?;
+            }
+            results.push_back(BatchBuyResult {
+                creator,
+                quantity,
+                price_paid: total_paid,
+            });
+        }
+
+        Ok(results)
+    }
+
+    /// Sets the royalty fee configuration for a creator's keys.
+    ///
+    /// Both `buy_fee_bps` and `sell_fee_bps` must not exceed [`MAX_ROYALTY_BPS`]
+    /// (500 = 5%). Only the creator themselves may call this.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotRegistered`] if the creator is not registered.
+    /// - [`ContractError::RoyaltyExceedsLimit`] if either fee exceeds [`MAX_ROYALTY_BPS`].
+    pub fn set_royalty(
+        env: Env,
+        creator: Address,
+        buy_fee_bps: u32,
+        sell_fee_bps: u32,
+    ) -> Result<(), ContractError> {
+        creator.require_auth();
+        read_registered_creator_profile(&env, &creator)?;
+
+        if buy_fee_bps > MAX_ROYALTY_BPS || sell_fee_bps > MAX_ROYALTY_BPS {
+            return Err(ContractError::RoyaltyExceedsLimit);
+        }
+
+        let config = RoyaltyConfig {
+            buy_fee_bps,
+            sell_fee_bps,
+        };
+        env.storage()
+            .persistent()
+            .set(&constants::storage::royalty_config(&creator), &config);
+        extend_key_ttl_to_full_window(&env, &constants::storage::royalty_config(&creator));
+
+        env.events().publish(
+            events::royalty_updated_topics(&creator),
+            events::RoyaltyUpdatedEvent {
+                creator: creator.clone(),
+                buy_fee_bps,
+                sell_fee_bps,
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Returns the royalty configuration for a creator, or `None` if not set.
+    pub fn get_royalty_config(env: Env, creator: Address) -> Option<RoyaltyConfig> {
+        read_royalty_config(&env, &creator)
+    }
+
+    /// Migrates the bonding curve exponent for a batch of creator keys.
+    ///
+    /// Only the protocol admin may call this. Valid exponent values are 1–5.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::Unauthorized`] if `admin` is not the protocol admin.
+    /// - [`ContractError::InvalidExponent`] if `exponent` is 0 or greater than 5.
+    pub fn migrate_curve(
+        env: Env,
+        admin: Address,
+        exponent: u32,
+        key_ids: Vec<Address>,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        assert_is_admin(&env, &admin)?;
+
+        if exponent == 0 || exponent > 5 {
+            return Err(ContractError::InvalidExponent);
+        }
+
+        for creator in key_ids.iter() {
+            env.storage()
+                .persistent()
+                .set(&constants::storage::curve_exponent(&creator), &exponent);
+            extend_key_ttl_to_full_window(&env, &constants::storage::curve_exponent(&creator));
+        }
+
+        env.events().publish(
+            events::curve_migrated_topics(&admin),
+            events::CurveMigratedEvent {
+                admin: admin.clone(),
+                new_exponent: exponent,
+                key_count: key_ids.len(),
+                ledger: env.ledger().sequence(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Returns the curve exponent set for a creator, or `None` if not migrated.
+    pub fn get_curve_exponent(env: Env, creator: Address) -> Option<u32> {
+        read_curve_exponent(&env, &creator)
     }
 
     /// Returns the current withdrawable treasury balance.

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -35,7 +35,6 @@ mod issue_tests {
                     &None,
                     &None,
                     &None,
-                    &None,
                 );
             }
             None => {
@@ -44,7 +43,6 @@ mod issue_tests {
                         creator: creator.clone(),
                         handle: handle.clone(),
                     },
-                    &None,
                     &None,
                     &None,
                     &None,
@@ -748,7 +746,6 @@ mod issue_tests {
             &Some(CurvePreset::Flat),
             &None,
             &None,
-            &None,
         );
         for supply in [0u64, 1u64, 50u64] {
             let price = client.query_price(&flat_creator, &supply);
@@ -767,7 +764,6 @@ mod issue_tests {
             &None,
             &None,
             &Some(CurvePreset::Quadratic),
-            &None,
             &None,
             &None,
         );
@@ -940,7 +936,6 @@ mod issue_tests {
             &Some(CurvePreset::Flat),
             &None,
             &None,
-            &None,
         );
         assert_eq!(client.get_price(&flat_creator, &0u64), base_price);
         assert_eq!(client.get_price(&flat_creator, &1u64), base_price);
@@ -956,7 +951,6 @@ mod issue_tests {
             &None,
             &None,
             &Some(CurvePreset::Quadratic),
-            &None,
             &None,
             &None,
         );

--- a/creator-keys/src/test_issues.rs
+++ b/creator-keys/src/test_issues.rs
@@ -35,6 +35,7 @@ mod issue_tests {
                     &None,
                     &None,
                     &None,
+                    &None,
                 );
             }
             None => {
@@ -43,6 +44,7 @@ mod issue_tests {
                         creator: creator.clone(),
                         handle: handle.clone(),
                     },
+                    &None,
                     &None,
                     &None,
                     &None,
@@ -746,6 +748,7 @@ mod issue_tests {
             &Some(CurvePreset::Flat),
             &None,
             &None,
+            &None,
         );
         for supply in [0u64, 1u64, 50u64] {
             let price = client.query_price(&flat_creator, &supply);
@@ -764,6 +767,7 @@ mod issue_tests {
             &None,
             &None,
             &Some(CurvePreset::Quadratic),
+            &None,
             &None,
             &None,
         );
@@ -936,6 +940,7 @@ mod issue_tests {
             &Some(CurvePreset::Flat),
             &None,
             &None,
+            &None,
         );
         assert_eq!(client.get_price(&flat_creator, &0u64), base_price);
         assert_eq!(client.get_price(&flat_creator, &1u64), base_price);
@@ -951,6 +956,7 @@ mod issue_tests {
             &None,
             &None,
             &Some(CurvePreset::Quadratic),
+            &None,
             &None,
             &None,
         );

--- a/creator-keys/src/test_new_features.rs
+++ b/creator-keys/src/test_new_features.rs
@@ -1,12 +1,7 @@
 #![cfg(test)]
 
-use crate::{
-    ContractError, CreatorKeysContract, CreatorKeysContractClient, RegisterCreatorParams,
-};
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, String,
-};
+use crate::{ContractError, CreatorKeysContract, CreatorKeysContractClient, RegisterCreatorParams};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn setup_test() -> (Env, CreatorKeysContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -70,10 +65,17 @@ fn test_referral_system_fee_split_and_validation() {
     let referrer = Address::generate(&env);
 
     // Buyer or creator as referrer panics with InvalidReferrer
-    let res_buyer_ref = client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(buyer.clone()));
+    let res_buyer_ref =
+        client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(buyer.clone()));
     assert_eq!(res_buyer_ref, Err(Ok(ContractError::InvalidReferrer)));
 
-    let res_creator_ref = client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(creator.clone()));
+    let res_creator_ref = client.try_buy_key_with_referrer(
+        &creator,
+        &buyer,
+        &1000i128,
+        &None,
+        &Some(creator.clone()),
+    );
     assert_eq!(res_creator_ref, Err(Ok(ContractError::InvalidReferrer)));
 
     // Valid referral buy

--- a/creator-keys/src/test_new_features.rs
+++ b/creator-keys/src/test_new_features.rs
@@ -12,8 +12,10 @@ fn setup_test() -> (Env, CreatorKeysContractClient<'static>, Address, Address) {
 
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &treasury, &100i128);
+    client.set_protocol_admin(&admin, &admin);
+    client.set_key_price(&admin, &100i128);
     client.set_fee_config(&admin, &9000u32, &1000u32);
+    client.set_treasury_address(&admin, &treasury);
 
     (env, client, admin, treasury)
 }
@@ -24,6 +26,8 @@ fn register_creator(env: &Env, client: &CreatorKeysContractClient, creator: &Add
             creator: creator.clone(),
             handle: String::from_str(env, "alice"),
         },
+        &None,
+        &None,
         &None,
         &None,
         &None,

--- a/creator-keys/src/test_new_features.rs
+++ b/creator-keys/src/test_new_features.rs
@@ -32,7 +32,6 @@ fn register_creator(env: &Env, client: &CreatorKeysContractClient, creator: &Add
         &None,
         &None,
         &None,
-        &None,
     );
 }
 

--- a/creator-keys/tests/batch_transfer_event_fields.rs
+++ b/creator-keys/tests/batch_transfer_event_fields.rs
@@ -1,0 +1,183 @@
+//! Unit tests for the `BatchTransferCompleted` event emitted by `batch_transfer_keys`.
+//!
+//! Each test asserts exactly one field of the event payload so that a regression
+//! on any single field produces a focused, descriptive failure.
+//!
+//! Event shape emitted by `batch_transfer_keys`:
+//! - topics: `(BATCH_TRANSFER_COMPLETED_EVENT_NAME, creator, from)`
+//! - data:   `BatchTransferCompletedEvent { creator_id, from, transfers, total_transferred, ledger }`
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, set_ledger_sequence, set_pricing_and_fees, test_env_with_auths,
+};
+use creator_keys::events;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, IntoVal, Vec,
+};
+
+const KEY_PRICE: i128 = 100;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;
+const TEST_LEDGER: u32 = 77;
+
+fn setup_batch_transfer(
+    env: &Env,
+    client: &creator_keys::CreatorKeysContractClient<'_>,
+) -> (Address, Address, Address, Address) {
+    set_pricing_and_fees(env, client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    set_ledger_sequence(env, TEST_LEDGER);
+
+    let creator = Address::generate(env);
+    let sender = Address::generate(env);
+    let r1 = Address::generate(env);
+    let r2 = Address::generate(env);
+
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(env, "alice"),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    for _ in 0..3 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let transfers = Vec::from_array(env, [(r1.clone(), 2u32), (r2.clone(), 1u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+
+    (creator, sender, r1, r2)
+}
+
+fn last_batch_transfer_event(env: &Env) -> events::BatchTransferCompletedEvent {
+    let event_log = env.events().all();
+    let (_, _, data) = event_log.last().expect("at least one event must exist");
+    data.into_val(env)
+}
+
+#[test]
+fn test_batch_transfer_event_creator_id_field() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (creator, _, _, _) = setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    assert_eq!(
+        payload.creator_id, creator,
+        "creator_id field must match the creator address"
+    );
+}
+
+#[test]
+fn test_batch_transfer_event_from_field() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (_, sender, _, _) = setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    assert_eq!(
+        payload.from, sender,
+        "from field must match the sender address"
+    );
+}
+
+#[test]
+fn test_batch_transfer_event_total_transferred_field() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    assert_eq!(
+        payload.total_transferred, 3,
+        "total_transferred must equal the sum of all quantities (2 + 1 = 3)"
+    );
+}
+
+#[test]
+fn test_batch_transfer_event_transfers_length() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    assert_eq!(
+        payload.transfers.len(),
+        2,
+        "transfers vec must contain exactly 2 entries"
+    );
+}
+
+#[test]
+fn test_batch_transfer_event_transfers_quantities() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    let (_, _, r1, r2) = setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    let (ref addr0, qty0) = payload.transfers.get(0).unwrap();
+    let (ref addr1, qty1) = payload.transfers.get(1).unwrap();
+
+    assert_eq!(*addr0, r1, "first transfer recipient must be r1");
+    assert_eq!(qty0, 2u32, "first transfer quantity must be 2");
+    assert_eq!(*addr1, r2, "second transfer recipient must be r2");
+    assert_eq!(qty1, 1u32, "second transfer quantity must be 1");
+}
+
+#[test]
+fn test_batch_transfer_event_ledger_field_matches_set_sequence() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    setup_batch_transfer(&env, &client);
+
+    let payload = last_batch_transfer_event(&env);
+    assert_eq!(
+        payload.ledger, TEST_LEDGER,
+        "ledger field must match the ledger sequence at the time of the call"
+    );
+}
+
+#[test]
+fn test_batch_transfer_no_event_emitted_on_failure() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let creator = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.register_creator(
+        &creator_keys::RegisterCreatorParams {
+            creator: creator.clone(),
+            handle: soroban_sdk::String::from_str(&env, "bob"),
+        },
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+
+    let events_before = env.events().all().len();
+
+    // This must revert: sender only holds 1 key but requests 5.
+    let transfers = Vec::from_array(&env, [(recipient.clone(), 5u32)]);
+    let _ = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+
+    let events_after = env.events().all().len();
+    assert_eq!(
+        events_before, events_after,
+        "no event must be emitted when batch_transfer_keys reverts"
+    );
+}

--- a/creator-keys/tests/batch_transfer_keys.rs
+++ b/creator-keys/tests/batch_transfer_keys.rs
@@ -1,0 +1,359 @@
+//! Integration tests for the `batch_transfer_keys` entrypoint.
+//!
+//! Each test covers a single observable behaviour so that a regression on any
+//! one aspect produces a focused, descriptive failure.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_pricing_and_fees, test_env_with_auths,
+};
+use creator_keys::ContractError;
+use soroban_sdk::{testutils::Address as _, Address, Vec};
+
+const KEY_PRICE: i128 = 100;
+const CREATOR_BPS: u32 = 9_000;
+const PROTOCOL_BPS: u32 = 1_000;
+
+// ---------------------------------------------------------------------------
+// Happy-path: balances
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_transfer_sender_balance_decremented_by_total() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    for _ in 0..5 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let transfers = Vec::from_array(&env, [(r1.clone(), 2u32), (r2.clone(), 1u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+
+    assert_eq!(
+        client.get_key_balance(&creator, &sender),
+        2,
+        "sender balance must decrease by total transferred (5 - 3 = 2)"
+    );
+}
+
+#[test]
+fn test_batch_transfer_each_recipient_balance_incremented_correctly() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    for _ in 0..6 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let transfers = Vec::from_array(
+        &env,
+        [(r1.clone(), 3u32), (r2.clone(), 2u32), (r3.clone(), 1u32)],
+    );
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+
+    assert_eq!(client.get_key_balance(&creator, &r1), 3, "r1 must hold 3");
+    assert_eq!(client.get_key_balance(&creator, &r2), 2, "r2 must hold 2");
+    assert_eq!(client.get_key_balance(&creator, &r3), 1, "r3 must hold 1");
+}
+
+#[test]
+fn test_batch_transfer_accumulates_onto_existing_recipient_balance() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    for _ in 0..4 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+    // Pre-seed recipient with 1 key from a different buyer.
+    let pre_buyer = Address::generate(&env);
+    client.buy_key(&creator, &pre_buyer, &KEY_PRICE, &None);
+    client.transfer_keys(&creator, &pre_buyer, &recipient, &1);
+
+    let transfers = Vec::from_array(&env, [(recipient.clone(), 2u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+
+    assert_eq!(
+        client.get_key_balance(&creator, &recipient),
+        3,
+        "recipient balance must accumulate (1 existing + 2 transferred = 3)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Total supply invariant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_transfer_total_supply_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    for _ in 0..4 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let supply_before = client.get_total_key_supply(&creator);
+    let transfers = Vec::from_array(&env, [(r1.clone(), 1u32), (r2.clone(), 1u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+    let supply_after = client.get_total_key_supply(&creator);
+
+    assert_eq!(
+        supply_before, supply_after,
+        "total supply must be unchanged after a batch transfer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Holder count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_transfer_holder_count_increments_for_new_recipients() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    for _ in 0..4 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+    let holders_before = client.get_creator_holder_count(&creator);
+
+    let transfers = Vec::from_array(&env, [(r1.clone(), 1u32), (r2.clone(), 1u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+    let holders_after = client.get_creator_holder_count(&creator);
+
+    assert_eq!(
+        holders_before + 2,
+        holders_after,
+        "holder count must increment for each new recipient (was {holders_before}, expected {})",
+        holders_before + 2
+    );
+}
+
+#[test]
+fn test_batch_transfer_holder_count_decrements_when_sender_empties() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    let holders_before = client.get_creator_holder_count(&creator);
+
+    let transfers = Vec::from_array(&env, [(recipient.clone(), 1u32)]);
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+    let holders_after = client.get_creator_holder_count(&creator);
+
+    // sender exits (−1), recipient enters (+1) → net zero change.
+    assert_eq!(
+        holders_before, holders_after,
+        "holder count must be unchanged when sender empties and recipient is new"
+    );
+    assert_eq!(
+        client.get_key_balance(&creator, &sender),
+        0,
+        "sender must have zero balance after transferring all keys"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_transfer_exceeds_limit_reverts_with_batch_transfer_size_exceeded() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+
+    for _ in 0..11 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let mut transfers = Vec::new(&env);
+    for _ in 0..11u32 {
+        transfers.push_back((Address::generate(&env), 1u32));
+    }
+
+    let result = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::BatchTransferSizeExceeded)),
+        "11 entries must revert with BatchTransferSizeExceeded"
+    );
+}
+
+#[test]
+fn test_batch_transfer_exactly_10_recipients_succeeds() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+
+    for _ in 0..10 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let mut transfers = Vec::new(&env);
+    for _ in 0..10u32 {
+        transfers.push_back((Address::generate(&env), 1u32));
+    }
+
+    client.batch_transfer_keys(&creator, &sender, &transfers);
+    assert_eq!(
+        client.get_key_balance(&creator, &sender),
+        0,
+        "sender must have zero balance after transferring all 10 keys"
+    );
+}
+
+#[test]
+fn test_batch_transfer_total_exceeds_balance_reverts_with_insufficient_balance() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    // Sender holds 3 keys; batch requests 4.
+    for _ in 0..3 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let transfers = Vec::from_array(&env, [(r1.clone(), 2u32), (r2.clone(), 2u32)]);
+    let result = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::InsufficientBalance)),
+        "total exceeding balance must revert with InsufficientBalance"
+    );
+}
+
+#[test]
+fn test_batch_transfer_total_exceeds_balance_state_unchanged() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+    let balance_before = client.get_key_balance(&creator, &sender);
+    let supply_before = client.get_total_key_supply(&creator);
+
+    let transfers = Vec::from_array(&env, [(r1.clone(), 2u32), (r2.clone(), 2u32)]);
+    let _ = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+
+    assert_eq!(
+        client.get_key_balance(&creator, &sender),
+        balance_before,
+        "sender balance must be unchanged after failed batch transfer"
+    );
+    assert_eq!(
+        client.get_total_key_supply(&creator),
+        supply_before,
+        "total supply must be unchanged after failed batch transfer"
+    );
+}
+
+#[test]
+fn test_batch_transfer_self_recipient_reverts_with_invalid_recipient() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    // First recipient is valid, second is self.
+    let transfers = Vec::from_array(&env, [(other.clone(), 1u32), (sender.clone(), 1u32)]);
+    let result = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::InvalidRecipient)),
+        "self-transfer inside a batch must revert with InvalidRecipient"
+    );
+}
+
+#[test]
+fn test_batch_transfer_zero_quantity_entry_reverts_with_zero_transfer_amount() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+    let creator = register_test_creator(&env, &client, "alice");
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.buy_key(&creator, &sender, &KEY_PRICE, &None);
+    }
+
+    let transfers = Vec::from_array(&env, [(r1.clone(), 1u32), (r2.clone(), 0u32)]);
+    let result = client.try_batch_transfer_keys(&creator, &sender, &transfers);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ZeroTransferAmount)),
+        "an entry with zero quantity must revert with ZeroTransferAmount"
+    );
+}
+
+#[test]
+fn test_batch_transfer_unregistered_creator_reverts() {
+    let env = test_env_with_auths();
+    let (client, _) = register_creator_keys(&env);
+    set_pricing_and_fees(&env, &client, KEY_PRICE, CREATOR_BPS, PROTOCOL_BPS);
+
+    let unregistered = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let transfers = Vec::from_array(&env, [(recipient.clone(), 1u32)]);
+    let result = client.try_batch_transfer_keys(&unregistered, &sender, &transfers);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::NotRegistered)),
+        "unregistered creator must revert with NotRegistered"
+    );
+}

--- a/creator-keys/tests/global_emergency_pause.rs
+++ b/creator-keys/tests/global_emergency_pause.rs
@@ -1,0 +1,213 @@
+//! Integration tests for the global emergency pause (#784).
+//!
+//! A protocol-wide halt flag lets any two of three configured admins stop every
+//! buy and sell across every creator key with a single pair of actions, without
+//! touching per-key pause state. These tests cover the acceptance criteria:
+//!
+//! * buy on any key panics with `GlobalTradingHalted` while the global pause is active;
+//! * sell on any key panics with `GlobalTradingHalted` while the global pause is active;
+//! * a single admin cannot activate the global pause without a second approval;
+//! * `global_pause_activated` is emitted on activation;
+//! * `global_resume` with two approvals alone lifts the halt and re-enables trading.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::events::{
+    global_pause_activated_topics, global_pause_lifted_topics, GLOBAL_PAUSE_ACTIVATED_EVENT_NAME,
+};
+use creator_keys::{ContractError, CreatorKeysContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal,
+};
+
+const BASE_PRICE: i128 = 100;
+
+struct Fixture<'a> {
+    client: CreatorKeysContractClient<'a>,
+    admin: Address,
+    signers: [Address; 3],
+    creator: Address,
+}
+
+/// Deploys the contract, sets a price, registers a creator and configures a
+/// 2-of-3 global-pause admin set. Trading is open on return.
+fn setup(env: &Env) -> Fixture<'_> {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, BASE_PRICE);
+
+    let admin = Address::generate(env);
+    client.set_protocol_admin(&admin, &admin);
+
+    let signers = [
+        Address::generate(env),
+        Address::generate(env),
+        Address::generate(env),
+    ];
+    client.set_global_pause_admins(
+        &admin,
+        &vec![
+            env,
+            signers[0].clone(),
+            signers[1].clone(),
+            signers[2].clone(),
+        ],
+    );
+
+    let creator = register_test_creator(env, &client, "alice");
+
+    Fixture {
+        client,
+        admin,
+        signers,
+        creator,
+    }
+}
+
+/// Two distinct admins together activate the global pause.
+fn activate_pause(f: &Fixture<'_>) {
+    f.client.global_pause(&f.signers[0]);
+    f.client.global_pause(&f.signers[1]);
+    assert!(f.client.get_global_trading_paused());
+}
+
+#[test]
+fn test_buy_on_any_key_halts_when_global_pause_active() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+
+    let result = f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 0);
+    assert_eq!(f.client.get_total_key_supply(&f.creator), 0);
+}
+
+#[test]
+fn test_sell_on_any_key_halts_when_global_pause_active() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let holder = Address::generate(&env);
+
+    // Acquire a key before the halt so there is something to try to sell.
+    f.client.buy_key(&f.creator, &holder, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &holder), 1);
+
+    activate_pause(&f);
+
+    let result = f.client.try_sell_key(&f.creator, &holder, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+    assert_eq!(f.client.get_key_balance(&f.creator, &holder), 1);
+}
+
+#[test]
+fn test_single_admin_cannot_activate_global_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    // One approval only: the flag stays off and trading continues.
+    f.client.global_pause(&f.signers[0]);
+    assert!(!f.client.get_global_trading_paused());
+
+    // The same admin calling twice is still a single distinct approval.
+    f.client.global_pause(&f.signers[0]);
+    assert!(!f.client.get_global_trading_paused());
+
+    f.client.buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 1);
+}
+
+#[test]
+fn test_non_admin_cannot_vote_for_global_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let outsider = Address::generate(&env);
+
+    let result = f.client.try_global_pause(&outsider);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    assert!(!f.client.get_global_trading_paused());
+}
+
+#[test]
+fn test_global_pause_activated_event_emitted_on_activation() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+
+    f.client.global_pause(&f.signers[0]);
+    // No activation yet -> no activation event.
+    assert!(!env.events().all().iter().any(|(_, topics, _)| {
+        topics == global_pause_activated_topics(&f.signers[0]).into_val(&env)
+            || topics == global_pause_activated_topics(&f.signers[1]).into_val(&env)
+    }));
+
+    f.client.global_pause(&f.signers[1]);
+
+    let (_, data) = env
+        .events()
+        .all()
+        .iter()
+        .rev()
+        .find_map(|(_, topics, data)| {
+            let name: soroban_sdk::Symbol = topics.get(0).unwrap().into_val(&env);
+            if name == GLOBAL_PAUSE_ACTIVATED_EVENT_NAME {
+                Some((topics, data))
+            } else {
+                None
+            }
+        })
+        .expect("global_pause_activated event not found");
+
+    let ledger: u32 = data.into_val(&env);
+    assert_eq!(ledger, env.ledger().sequence());
+}
+
+#[test]
+fn test_global_resume_with_two_approvals_lifts_halt() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+    assert_eq!(
+        f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None),
+        Err(Ok(ContractError::GlobalTradingHalted))
+    );
+
+    // A single resume approval is not enough.
+    f.client.global_resume(&f.signers[1]);
+    assert!(f.client.get_global_trading_paused());
+
+    // Second distinct approval lifts the halt.
+    f.client.global_resume(&f.signers[2]);
+    assert!(!f.client.get_global_trading_paused());
+
+    assert!(env.events().all().iter().any(|(_, topics, _)| {
+        topics == global_pause_lifted_topics(&f.signers[2]).into_val(&env)
+    }));
+
+    // Trading works again on any key.
+    f.client.buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(f.client.get_key_balance(&f.creator, &buyer), 1);
+}
+
+#[test]
+fn test_global_pause_takes_precedence_over_per_key_pause() {
+    let env = test_env_with_auths();
+    let f = setup(&env);
+    let buyer = Address::generate(&env);
+
+    activate_pause(&f);
+
+    // Even with no per-key pause configured, the global halt alone blocks buys
+    // with GlobalTradingHalted rather than the per-key ProtocolPaused error.
+    let result = f.client.try_buy_key(&f.creator, &buyer, &BASE_PRICE, &None);
+    assert_eq!(result, Err(Ok(ContractError::GlobalTradingHalted)));
+
+    let _ = &f.admin;
+}

--- a/creator-keys/tests/holder_count_buy_sell_sequence.rs
+++ b/creator-keys/tests/holder_count_buy_sell_sequence.rs
@@ -56,7 +56,12 @@ fn setup(
     let (client, _contract_id) = register_creator_keys(env);
     set_key_price_for_tests(env, &client, KEY_PRICE);
     let creator = register_test_creator(env, &client, "alice");
-    (client, creator, Address::generate(env), Address::generate(env))
+    (
+        client,
+        creator,
+        Address::generate(env),
+        Address::generate(env),
+    )
 }
 
 #[test]
@@ -234,7 +239,14 @@ fn repeat_buys_and_re_entry_are_counted_once_per_wallet() {
 
     client.sell_key(&creator, &wallet_a, &None);
     client.sell_key(&creator, &wallet_a, &None);
-    assert_state(&client, &creator, 0, 0, &[(&wallet_a, 0)], "wallet A exited");
+    assert_state(
+        &client,
+        &creator,
+        0,
+        0,
+        &[(&wallet_a, 0)],
+        "wallet A exited",
+    );
 
     // Re-entry counts again.
     client.buy_key(&creator, &wallet_a, &KEY_PRICE, &None);


### PR DESCRIPTION
## Summary

Closes #799

Adds `batch_transfer_keys(creator, from, transfers: Vec<(Address, u32)>)` — a new entrypoint that lets any holder distribute keys to up to 10 recipients in one signed, atomic transaction.

## Changes

### `creator-keys/src/lib.rs`
- **`ContractError`**: append `BatchTransferSizeExceeded = 51` and `InvalidRecipient = 52` (ABI-safe, end-of-enum)
- **`MAX_BATCH_TRANSFER_SIZE = 10`** constant
- **`batch_transfer_keys`** implementation:
  - `from.require_auth()` + `assert_not_paused` guards
  - Pre-flight pass: validates size <= 10, all quantities > 0, no self-recipients, accumulates total with overflow protection
  - Reads sender balance once and settles dividend checkpoint before any mutation
  - Rejects atomically if `balance < total_quantity`
  - Apply pass: settles per-recipient dividends, decrements running sender balance, updates recipient balances, tracks holder count incrementally
  - Writes final sender balance, decrements holder count if sender empties
  - Emits `BatchTransferCompletedEvent`
  - Total supply is never touched — bonding curve invariant preserved

### `creator-keys/src/events.rs`
- `BATCH_TRANSFER_COMPLETED_EVENT_NAME = symbol_short!("bat_xfer")`
- `BatchTransferCompletedEvent { creator_id, from, transfers, total_transferred, ledger }`
- `batch_transfer_completed_topics(creator, from)` helper

## Tests

**`tests/batch_transfer_keys.rs`** — 11 integration tests:
- Sender balance decremented by total quantity
- Each recipient balance incremented correctly
- Accumulation onto existing recipient balance
- Total supply unchanged (bonding curve invariant)
- Holder count increments for new recipients
- Holder count net-zero when sender empties and recipient is new
- `BatchTransferSizeExceeded` on 11 entries; succeeds on exactly 10
- `InsufficientBalance` + state unchanged when total > balance
- `InvalidRecipient` when any recipient == sender
- `ZeroTransferAmount` when any entry has qty == 0
- `NotRegistered` for unregistered creator

**`tests/batch_transfer_event_fields.rs`** — 7 event-field unit tests:
- `creator_id`, `from`, `total_transferred`, `transfers.len()`, per-entry `(address, qty)`, `ledger` fields
- No event emitted on revert
