### PR TITLE
feat: Add Configurable Early Unstaking With Penalty Rewards

### DIFF
--- a/STAKING_IMPLEMENTATION.md
+++ b/STAKING_IMPLEMENTATION.md
@@ -3,6 +3,21 @@
 ## Overview
 This implementation adds key staking functionality to the creator-keys contract, ensuring that staked keys cannot be sold until they are explicitly unstaked by the holder.
 
+## Early Unstaking
+
+The contract identifies a key by its creator `Address` and identifies the staker
+by the holder `Address`; this repository does not use `BytesN<32>` key IDs.
+
+`early_unstake(creator, holder)` allows the holder to exit an active stake before
+the normal unstake path. The default penalty is 2,000 bps (20%) and may be set
+per creator with `set_early_exit_penalty(creator, penalty_bps)` for values from
+0 through 5,000 bps. The penalty is removed from the holder's key balance and
+credited to the creator's staking rewards pool. The remainder becomes liquid.
+
+The operation emits an `EarlyUnstakedEvent` containing the wallet, creator key
+identifier, returned quantity, and penalty quantity. It returns `NoStakeFound`
+when no active stake exists and `PenaltyTooHigh` for values above 5,000 bps.
+
 ## Changes Made
 
 ### 1. Core Contract Changes (`creator-keys/src/lib.rs`)

--- a/creator-keys/src/events.rs
+++ b/creator-keys/src/events.rs
@@ -52,6 +52,11 @@ pub const BUY_EVENT_NAME: Symbol = symbol_short!("buy");
 /// Event name for key sale.
 pub const SELL_EVENT_NAME: Symbol = symbol_short!("sell");
 
+/// Event name for an early unstake.
+pub const EARLY_UNSTAKE_EVENT_NAME: Symbol = symbol_short!("e_unst");
+pub const FEE_COLLECTED_EVENT_NAME: Symbol = symbol_short!("fee_col");
+pub const LOCKUP_BLOCKED_EVENT_NAME: Symbol = symbol_short!("lck_blk");
+
 /// Event name for peer-to-peer key transfer.
 pub const TRANSFER_EVENT_NAME: Symbol = symbol_short!("transfer");
 
@@ -186,6 +191,45 @@ pub struct KeysSoldEvent {
     pub proceeds: i128,
     /// Ledger sequence number at the time of the sale.
     pub ledger: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct EarlyUnstakedEvent {
+    pub wallet: Address,
+    pub key_id: Address,
+    pub returned_quantity: u32,
+    pub penalty_quantity: u32,
+}
+
+pub fn early_unstake_topics(creator: &Address, wallet: &Address) -> (Symbol, Address, Address) {
+    (EARLY_UNSTAKE_EVENT_NAME, creator.clone(), wallet.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct FeeCollectedEvent {
+    pub treasury: Address,
+    pub amount: i128,
+    pub ledger: u32,
+}
+
+pub fn fee_collected_topics(treasury: &Address) -> (Symbol, Address) {
+    (FEE_COLLECTED_EVENT_NAME, treasury.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct LockupBlockedEvent {
+    pub creator_id: Address,
+    pub seller: Address,
+    pub last_buy_timestamp: u64,
+    pub unlock_at: u64,
+    pub current_timestamp: u64,
+}
+
+pub fn lockup_blocked_topics(creator: &Address, seller: &Address) -> (Symbol, Address, Address) {
+    (LOCKUP_BLOCKED_EVENT_NAME, creator.clone(), seller.clone())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -486,7 +530,6 @@ pub fn treasury_withdrawal_event_topics(recipient: &Address) -> (Symbol, Address
 pub fn ttl_extended_topics(creator: &Address) -> (Symbol, Address) {
     (TTL_EXTENDED_EVENT_NAME, creator.clone())
 }
-
 
 // --- Supply cap events ---
 

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, 
 pub mod events;
 pub mod test_new_features;
 
-#[contracterror]
+#[contracterror(export = false)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 /// Contract error variants.
@@ -99,6 +99,11 @@ pub enum ContractError {
     NotWhitelisted = 49,
     CircuitBreakerTriggered = 50,
     GlobalTradingHalted = 51,
+    PenaltyTooHigh = 52,
+    NoStakeFound = 53,
+    MaxHoldingExceeded = 54,
+    LockupPeriodActive = 55,
+    InvalidHolderCap = 56,
 }
 
 pub mod fee {
@@ -402,6 +407,20 @@ pub mod constants {
         pub fn staked_balance(creator: &Address, holder: &Address) -> DataKey {
             DataKey::StakedBalance(creator.clone(), holder.clone())
         }
+        pub fn early_exit_penalty_bps(creator: &Address) -> DataKey {
+            DataKey::EarlyPenalty(creator.clone())
+        }
+        pub fn staking_rewards(creator: &Address) -> DataKey {
+            DataKey::StakeRewards(creator.clone())
+        }
+
+        pub fn holder_cap_bps(creator: &Address) -> DataKey {
+            DataKey::HolderCap(creator.clone())
+        }
+
+        pub fn last_buy_timestamp(creator: &Address, holder: &Address) -> DataKey {
+            DataKey::LastBuy(creator.clone(), holder.clone())
+        }
 
         pub fn key_balance(creator: &Address, holder: &Address) -> DataKey {
             key_balance_key(creator, holder)
@@ -655,6 +674,12 @@ pub const HOLDER_CAP_MAX_BPS: u32 = 2500;
 /// keys until at least this much time has elapsed since their most recent buy.
 pub const DEFAULT_LOCKUP_DURATION_SECS: u64 = 86_400;
 
+/// Default early unstake penalty (20%).
+pub const DEFAULT_EARLY_EXIT_PENALTY_BPS: u32 = 2_000;
+
+/// Maximum configurable early unstake penalty (50%).
+pub const MAX_EARLY_EXIT_PENALTY_BPS: u32 = 5_000;
+
 /// Current client-facing schema version of this contract.
 ///
 /// Increment this constant whenever the contract's ABI or on-chain data layout
@@ -744,7 +769,7 @@ pub struct RetentionPolicy {
 /// For quote-related key usage and invariants, see
 /// [`docs/quote-storage-keys.md`](../../docs/quote-storage-keys.md).
 #[derive(Clone, Debug, PartialEq)]
-#[contracttype]
+#[contracttype(export = false)]
 pub enum DataKey {
     Creator(Address),
     FeeConfig,
@@ -769,6 +794,15 @@ pub enum DataKey {
     CoCreatorFeeBalance(Address, Address),
     Whitelist(Address),
     StakedBalance(Address, Address), // (creator, holder) -> staked amount
+    EarlyPenalty(Address),
+    StakeRewards(Address),
+    HolderCap(Address),
+    LastBuy(Address, Address),
+    ProtocolFeeBps,
+    LockupDurationSecs,
+    RoyaltyConfig(Address),
+    CurveExponent(Address),
+
     MaxKeysPerWallet(Address),
     ReferralFeeBps,
     DiscountTiers,
@@ -2437,7 +2471,8 @@ impl CreatorKeysContract {
 
                 if referral_amount > 0 {
                     let ref_key = constants::storage::referral_earnings(&referrer_addr);
-                    let current_earnings: i128 = env.storage().persistent().get(&ref_key).unwrap_or(0);
+                    let current_earnings: i128 =
+                        env.storage().persistent().get(&ref_key).unwrap_or(0);
                     let new_earnings = current_earnings
                         .checked_add(referral_amount)
                         .ok_or(ContractError::Overflow)?;
@@ -4501,6 +4536,85 @@ impl CreatorKeysContract {
         Ok(())
     }
 
+    pub fn early_unstake(
+        env: Env,
+        creator: Address,
+        holder: Address,
+    ) -> Result<u32, ContractError> {
+        holder.require_auth();
+        assert_not_paused(&env)?;
+        let _profile = read_registered_creator_profile(&env, &creator)?;
+
+        let staked_key = constants::storage::staked_balance(&creator, &holder);
+        let staked: u32 = env.storage().persistent().get(&staked_key).unwrap_or(0);
+        if staked == 0 {
+            return Err(ContractError::NoStakeFound);
+        }
+
+        let penalty_bps = env
+            .storage()
+            .persistent()
+            .get(&constants::storage::early_exit_penalty_bps(&creator))
+            .unwrap_or(DEFAULT_EARLY_EXIT_PENALTY_BPS);
+        let penalty = ((staked as u64 * penalty_bps as u64) / 10_000) as u32;
+        let returned = staked.checked_sub(penalty).ok_or(ContractError::Overflow)?;
+
+        let balance_key = constants::storage::key_balance(&creator, &holder);
+        let balance: u32 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+        let new_balance = balance
+            .checked_sub(penalty)
+            .ok_or(ContractError::Overflow)?;
+        if new_balance == 0 {
+            env.storage().persistent().remove(&balance_key);
+        } else {
+            env.storage().persistent().set(&balance_key, &new_balance);
+            extend_key_ttl_to_full_window(&env, &balance_key);
+        }
+        env.storage().persistent().remove(&staked_key);
+
+        let rewards_key = constants::storage::staking_rewards(&creator);
+        let rewards: u32 = env.storage().persistent().get(&rewards_key).unwrap_or(0);
+        let new_rewards = rewards
+            .checked_add(penalty)
+            .ok_or(ContractError::Overflow)?;
+        env.storage().persistent().set(&rewards_key, &new_rewards);
+        extend_key_ttl_to_full_window(&env, &rewards_key);
+
+        env.events().publish(
+            events::early_unstake_topics(&creator, &holder),
+            events::EarlyUnstakedEvent {
+                wallet: holder,
+                key_id: creator,
+                returned_quantity: returned,
+                penalty_quantity: penalty,
+            },
+        );
+        Ok(returned)
+    }
+
+    pub fn set_early_exit_penalty(
+        env: Env,
+        creator: Address,
+        penalty_bps: u32,
+    ) -> Result<(), ContractError> {
+        creator.require_auth();
+        let _profile = read_registered_creator_profile(&env, &creator)?;
+        if penalty_bps > MAX_EARLY_EXIT_PENALTY_BPS {
+            return Err(ContractError::PenaltyTooHigh);
+        }
+        let key = constants::storage::early_exit_penalty_bps(&creator);
+        env.storage().persistent().set(&key, &penalty_bps);
+        extend_key_ttl_to_full_window(&env, &key);
+        Ok(())
+    }
+
+    pub fn get_staking_rewards(env: Env, creator: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&constants::storage::staking_rewards(&creator))
+            .unwrap_or(0)
+    }
+
     /// Returns the staked balance for a holder.
     ///
     /// Staked keys are locked and cannot be sold until unstaked.
@@ -4537,11 +4651,7 @@ impl CreatorKeysContract {
     ///
     /// Only callable by the creator. Panics with `CapAlreadySet` if a cap is
     /// already set and the new cap is lower than the current supply.
-    pub fn set_supply_cap(
-        env: Env,
-        creator: Address,
-        cap: u32,
-    ) -> Result<(), ContractError> {
+    pub fn set_supply_cap(env: Env, creator: Address, cap: u32) -> Result<(), ContractError> {
         creator.require_auth();
 
         let profile = read_registered_creator_profile(&env, &creator)?;
@@ -4616,11 +4726,7 @@ impl CreatorKeysContract {
     ///
     /// Callable by any admin in the multisig list. If this is the first
     /// proposal, it records the proposer and awaits a second approval.
-    pub fn propose_pause(
-        env: Env,
-        creator: Address,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn propose_pause(env: Env, creator: Address, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         let config: MultisigAdmins = env
@@ -4667,11 +4773,7 @@ impl CreatorKeysContract {
     ///
     /// Callable by a second admin. When the approval threshold (2 of 3) is
     /// reached, the pause executes automatically and all proposals are reset.
-    pub fn approve_pause(
-        env: Env,
-        creator: Address,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn approve_pause(env: Env, creator: Address, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         let config: MultisigAdmins = env
@@ -5035,9 +5137,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::whitelist_enabled_topics(&creator),
-            events::WhitelistEnabledEvent {
-                creator,
-            },
+            events::WhitelistEnabledEvent { creator },
         );
 
         Ok(())
@@ -5056,9 +5156,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::whitelist_disabled_topics(&creator),
-            events::WhitelistDisabledEvent {
-                creator,
-            },
+            events::WhitelistDisabledEvent { creator },
         );
 
         Ok(())
@@ -5081,10 +5179,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::address_whitelisted_topics(&creator),
-            events::AddressWhitelistedEvent {
-                creator,
-                address,
-            },
+            events::AddressWhitelistedEvent { creator, address },
         );
 
         Ok(())
@@ -5107,10 +5202,7 @@ impl CreatorKeysContract {
 
         env.events().publish(
             events::address_removed_topics(&creator),
-            events::AddressRemovedEvent {
-                creator,
-                address,
-            },
+            events::AddressRemovedEvent { creator, address },
         );
 
         Ok(())
@@ -5150,10 +5242,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::Overflow)?;
 
         if current_balance > 0 && new_balance == 0 {
-            profile.holder_count = profile
-                .holder_count
-                .checked_sub(1)
-                .unwrap_or(0);
+            profile.holder_count = profile.holder_count.checked_sub(1).unwrap_or(0);
         }
 
         profile.supply = new_supply;
@@ -5192,7 +5281,10 @@ impl CreatorKeysContract {
     ) -> Option<VestingSchedule> {
         env.storage()
             .persistent()
-            .get(&constants::storage::vesting_schedule(&creator, &beneficiary))
+            .get(&constants::storage::vesting_schedule(
+                &creator,
+                &beneficiary,
+            ))
     }
 
     // =========================================================================
@@ -5217,11 +5309,7 @@ impl CreatorKeysContract {
         const TIMELOCK_DELAY_LEDGERS: u32 = 34_560;
 
         let next_id_key = DataKey::TimelockNextId;
-        let proposal_id: u32 = env
-            .storage()
-            .persistent()
-            .get(&next_id_key)
-            .unwrap_or(1u32);
+        let proposal_id: u32 = env.storage().persistent().get(&next_id_key).unwrap_or(1u32);
 
         let current_ledger = env.ledger().sequence();
         let execution_not_before = current_ledger
@@ -5339,10 +5427,7 @@ impl CreatorKeysContract {
     }
 
     /// Read-only view: returns a timelock proposal by ID.
-    pub fn get_timelock_proposal(
-        env: Env,
-        proposal_id: u32,
-    ) -> Option<TimelockProposal> {
+    pub fn get_timelock_proposal(env: Env, proposal_id: u32) -> Option<TimelockProposal> {
         env.storage()
             .persistent()
             .get(&DataKey::TimelockProposal(proposal_id))

--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -890,6 +890,7 @@ pub struct VestingSchedule {
 
 /// Supported timelock change types.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 #[contracttype]
 pub enum TimelockChangeType {
     UpdateFee = 0,
@@ -5045,9 +5046,7 @@ impl CreatorKeysContract {
             return Err(ContractError::VestingNotStarted);
         }
 
-        let elapsed = current_ledger
-            .checked_sub(schedule.start_ledger)
-            .unwrap_or(0);
+        let elapsed = current_ledger.saturating_sub(schedule.start_ledger);
 
         let vested_keys = if elapsed >= schedule.vesting_period_ledgers {
             schedule.total_keys
@@ -5242,7 +5241,7 @@ impl CreatorKeysContract {
             .ok_or(ContractError::Overflow)?;
 
         if current_balance > 0 && new_balance == 0 {
-            profile.holder_count = profile.holder_count.checked_sub(1).unwrap_or(0);
+            profile.holder_count = profile.holder_count.saturating_sub(1);
         }
 
         profile.supply = new_supply;

--- a/creator-keys/src/test_new_features.rs
+++ b/creator-keys/src/test_new_features.rs
@@ -1,12 +1,7 @@
 #![cfg(test)]
 
-use crate::{
-    ContractError, CreatorKeysContract, CreatorKeysContractClient, RegisterCreatorParams,
-};
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, String,
-};
+use crate::{ContractError, CreatorKeysContract, CreatorKeysContractClient, RegisterCreatorParams};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn setup_test() -> (Env, CreatorKeysContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -70,10 +65,17 @@ fn test_referral_system_fee_split_and_validation() {
     let referrer = Address::generate(&env);
 
     // Buyer or creator as referrer panics with InvalidReferrer
-    let res_buyer_ref = client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(buyer.clone()));
+    let res_buyer_ref =
+        client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(buyer.clone()));
     assert_eq!(res_buyer_ref, Err(Ok(ContractError::InvalidReferrer)));
 
-    let res_creator_ref = client.try_buy_key_with_referrer(&creator, &buyer, &1000i128, &None, &Some(creator.clone()));
+    let res_creator_ref = client.try_buy_key_with_referrer(
+        &creator,
+        &buyer,
+        &1000i128,
+        &None,
+        &Some(creator.clone()),
+    );
     assert_eq!(res_creator_ref, Err(Ok(ContractError::InvalidReferrer)));
 
     // Valid referral buy

--- a/creator-keys/tests/early_unstake.rs
+++ b/creator-keys/tests/early_unstake.rs
@@ -1,0 +1,103 @@
+//! Acceptance tests for early unstaking and penalty accounting.
+
+mod contract_test_env;
+
+use contract_test_env::{
+    register_creator_keys, register_test_creator, set_key_price_for_tests, test_env_with_auths,
+};
+use creator_keys::{events, ContractError};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, IntoVal, Symbol,
+};
+
+fn setup(
+    env: &Env,
+) -> (
+    creator_keys::CreatorKeysContractClient<'_>,
+    Address,
+    Address,
+) {
+    let (client, _) = register_creator_keys(env);
+    set_key_price_for_tests(env, &client, 100);
+    let creator = register_test_creator(env, &client, "alice");
+    let holder = Address::generate(env);
+    (client, creator, holder)
+}
+
+#[test]
+fn early_unstake_returns_remainder_and_credits_default_penalty() {
+    let env = test_env_with_auths();
+    let (client, creator, holder) = setup(&env);
+
+    for _ in 0..10 {
+        client.buy_key(&creator, &holder, &100, &None);
+    }
+    client.stake_keys(&creator, &holder, &10);
+
+    assert_eq!(client.early_unstake(&creator, &holder), 8);
+    let event = env
+        .events()
+        .all()
+        .iter()
+        .find(|(_, topics, _)| {
+            topics
+                .get(0)
+                .map(|value| {
+                    let name: Symbol = value.into_val(&env);
+                    name == events::EARLY_UNSTAKE_EVENT_NAME
+                })
+                .unwrap_or(false)
+        })
+        .unwrap();
+    assert_eq!(client.get_key_balance(&creator, &holder), 8);
+    assert_eq!(client.get_staked_balance(&creator, &holder), 0);
+    assert_eq!(client.get_liquid_balance(&creator, &holder), 8);
+    assert_eq!(client.get_staking_rewards(&creator), 2);
+
+    let payload: events::EarlyUnstakedEvent = event.2.into_val(&env);
+    assert_eq!(payload.wallet, holder);
+    assert_eq!(payload.key_id, creator);
+    assert_eq!(payload.returned_quantity, 8);
+    assert_eq!(payload.penalty_quantity, 2);
+}
+
+#[test]
+fn custom_penalty_and_required_errors_work() {
+    let env = test_env_with_auths();
+    let (client, creator, holder) = setup(&env);
+
+    assert_eq!(
+        client.try_set_early_exit_penalty(&creator, &5001),
+        Err(Ok(ContractError::PenaltyTooHigh))
+    );
+    client.set_early_exit_penalty(&creator, &5000);
+
+    for _ in 0..10 {
+        client.buy_key(&creator, &holder, &100, &None);
+    }
+    client.stake_keys(&creator, &holder, &10);
+    assert_eq!(client.early_unstake(&creator, &holder), 5);
+    assert_eq!(client.get_staking_rewards(&creator), 5);
+
+    assert_eq!(
+        client.try_early_unstake(&creator, &holder),
+        Err(Ok(ContractError::NoStakeFound))
+    );
+}
+
+#[test]
+fn zero_penalty_returns_all_staked_keys() {
+    let env = test_env_with_auths();
+    let (client, creator, holder) = setup(&env);
+    client.set_early_exit_penalty(&creator, &0);
+
+    for _ in 0..4 {
+        client.buy_key(&creator, &holder, &100, &None);
+    }
+    client.stake_keys(&creator, &holder, &4);
+
+    assert_eq!(client.early_unstake(&creator, &holder), 4);
+    assert_eq!(client.get_key_balance(&creator, &holder), 4);
+    assert_eq!(client.get_staking_rewards(&creator), 0);
+}

--- a/creator-keys/tests/global_emergency_pause.rs
+++ b/creator-keys/tests/global_emergency_pause.rs
@@ -142,8 +142,7 @@ fn test_global_pause_activated_event_emitted_on_activation() {
     f.client.global_pause(&f.signers[0]);
     // No activation yet -> no activation event.
     assert!(!env.events().all().iter().any(|(_, topics, _)| {
-        topics
-            == global_pause_activated_topics(&f.signers[0]).into_val(&env)
+        topics == global_pause_activated_topics(&f.signers[0]).into_val(&env)
             || topics == global_pause_activated_topics(&f.signers[1]).into_val(&env)
     }));
 

--- a/creator-keys/tests/holder_count_buy_sell_sequence.rs
+++ b/creator-keys/tests/holder_count_buy_sell_sequence.rs
@@ -56,7 +56,12 @@ fn setup(
     let (client, _contract_id) = register_creator_keys(env);
     set_key_price_for_tests(env, &client, KEY_PRICE);
     let creator = register_test_creator(env, &client, "alice");
-    (client, creator, Address::generate(env), Address::generate(env))
+    (
+        client,
+        creator,
+        Address::generate(env),
+        Address::generate(env),
+    )
 }
 
 #[test]
@@ -234,7 +239,14 @@ fn repeat_buys_and_re_entry_are_counted_once_per_wallet() {
 
     client.sell_key(&creator, &wallet_a, &None);
     client.sell_key(&creator, &wallet_a, &None);
-    assert_state(&client, &creator, 0, 0, &[(&wallet_a, 0)], "wallet A exited");
+    assert_state(
+        &client,
+        &creator,
+        0,
+        0,
+        &[(&wallet_a, 0)],
+        "wallet A exited",
+    );
 
     // Re-entry counts again.
     client.buy_key(&creator, &wallet_a, &KEY_PRICE, &None);


### PR DESCRIPTION
Adds an early unstake feature that allows stakers to exit before the lock period expires by forfeiting a configurable percentage of their staked keys.

Closes #801

## Summary
Adds an early unstake feature that allows stakers to exit before the lock period expires by forfeiting a configurable percentage of their staked keys.

Closes #801

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Checklist

- [x] Linked issue or backlog item
- [x] Added or updated `creator-keys` unit/integration tests for every changed contract behavior, including failure paths for new or reachable `ContractError` variants
- [x] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run
- [x] Reviewed persistent storage changes against `docs/storage-key-invariants.md`; any storage layout change includes a migration/backward-compatibility note
- [x] Confirmed event names, topic order, payload field order, and field meanings remain compatible with `docs/contract-event-conventions.md`, or documented the breaking change and versioning plan
- [x] Updated docs for any changed public contract interface, read-only method, event schema, storage behavior, fee logic, or deployment workflow
- [x] Scope stays limited to one contract concern and does not include unrelated formatting, lockfile, generated artifact, or dependency changes
