### PR TITLE
feat: add auction phase configuration

### DIFF
--- a/creator-keys/src/lib.rs
+++ b/creator-keys/src/lib.rs
@@ -849,6 +849,8 @@ pub enum DataKey {
     ReferralEarnings(Address),
     WhitelistMap(Address, Address),
     WhitelistMode(Address),
+    /// Pre-launch auction configuration for a creator's keys.
+    AuctionConfig(Address),
     /// Protocol-wide emergency trading halt flag (#784). When `true`, every
     /// buy and sell is rejected regardless of per-key pause state.
     GlobalTradingPaused,
@@ -858,6 +860,19 @@ pub enum DataKey {
     GlobalPauseVote(Address),
     /// A pending `global_resume` vote cast by the given admin.
     GlobalResumeVote(Address),
+}
+
+/// Fixed-price pre-launch auction configuration for a creator's keys.
+///
+/// While `auction_sold < auction_supply`, buys settle at `auction_price`
+/// instead of the bonding curve price. The contract transitions to the
+/// bonding curve automatically once the auction supply is exhausted.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct AuctionConfig {
+    pub auction_price: i128,
+    pub auction_supply: u32,
+    pub auction_sold: u32,
 }
 
 /// Time-locked key allocation for creator self-vesting.


### PR DESCRIPTION
## Summary

Completes the pre-launch auction configuration feature (#793) by restoring the two core type definitions that were dropped during the merge of PR #796: the `AuctionConfig` struct and the `DataKey::AuctionConfig(Address)` storage variant. With these in place, `configure_auction` (and the buy/quote/cancel/get paths built on it) can compile and satisfy the issue's acceptance criteria.

Closes #793 

## Problem

The `configure_auction` entrypoint, its `buy_key` integration, the auction events, and the integration tests were all present in the tree, but they referenced the `AuctionConfig` type and the `DataKey::AuctionConfig` storage key — neither of which existed. A botched merge conflict resolution dropped both definitions while keeping every call site, leaving the auction feature un-compilable:

- `creator-keys/src/lib.rs:487` — `constants::storage::auction_config` returned a `DataKey::AuctionConfig` variant that the `DataKey` enum did not define
- `creator-keys/src/lib.rs:1823/2433/5784` — code read and wrote an `AuctionConfig` struct that was never declared
- `creator-keys/tests/prelaunch_auction.rs` — imported `creator_keys::AuctionConfig`, which did not exist

## Changes

### `creator-keys/src/lib.rs`

- **Added `DataKey::AuctionConfig(Address)` variant** to the `DataKey` enum, documented as the pre-launch auction configuration for a creator's keys.
- **Added `pub struct AuctionConfig`** as a `#[contracttype]` with the fields used across the feature:

  ```rust
  #[derive(Clone, Debug, PartialEq)]
  #[contracttype]
  pub struct AuctionConfig {
      pub auction_price: i128,
      pub auction_supply: u32,
      pub auction_sold: u32,
  }
  ```

  `AuctionConfig` is the value stored by `configure_auction`, read/written by `buy_key` during the auction phase, returned by `get_auction_config`, and asserted in the integration tests.

No other behavioral changes were made. The `configure_auction`, `cancel_auction`, `get_auction_config`, `buy_key` auction-phase logic, `resolve_buy_quote_price` auction-aware quoting, and the auction events were already in place and are exercised by the existing tests.

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Auction config stored correctly for valid input | ✅ `configure_auction` validates and persists `AuctionConfig { auction_price, auction_supply, auction_sold: 0 }` under `DataKey::AuctionConfig(creator)` |
| Buy within `auction_supply` uses `auction_price` instead of bonding curve price | ✅ `buy_key` settles at the fixed price while `profile.supply < auction_supply`; `get_buy_quote` mirrors it |
| Buy beyond `auction_supply` uses bonding curve price | ✅ automatic fallback to the curve once supply reaches the auction supply |
| `AuctionAlreadyStarted` panics if keys already sold | ✅ returns `FeatureError::AuctionAlreadyStarted` when `profile.supply > 0` |
| Non-creator caller panics with `Unauthorized` | ✅ `caller.require_auth()` + `caller != creator` |
| `auction_configured` event emitted with key id, price, and supply | ✅ publishes `AuctionConfiguredEvent { creator_id, auction_price, auction_supply }` |
| `auction_sold` stored and initialised to `0` | ✅ persisted inside `AuctionConfig`, incremented per auction buy |

Existing integration tests in `creator-keys/tests/prelaunch_auction.rs` and `creator-keys/tests/auction_bonding_curve_transition.rs` cover all of the above.

## Testing

- [x] `cargo check --workspace` — no remaining errors reference any auction symbol (`AuctionConfig`, `DataKey::AuctionConfig`, `configure_auction`, `cancel_auction`, `get_auction_config`)
- [ ] `cargo fmt --all -- --check` — passes for the added code; the workspace has pre-existing formatting diffs in `events.rs` and unrelated lines of `lib.rs`
- [ ] `cargo test --workspace` — blocked by pre-existing, unrelated compile breaks in the tree (see note below)

**Note on pre-existing breakage (not part of this PR):** the workspace does not currently compile due to issues introduced by other merges and unrelated to #793. `ContractError` exceeds the 50-case `#[contracterror]` spec cap (51 variants incl. `GlobalTradingHalted` from the global-emergency-pause work), and several other features' storage/event definitions were dropped in similar bad merges (`RoyaltyConfig`, `CurveExponent`, `ProtocolFeeBps`, `LockupDurationSecs`, staking `DataKey` variants, `FeeCollectedEvent`/`LockupBlockedEvent`, `last_buy_timestamp`/`holder_cap_bps` storage helpers). Because these do not concern the auction implementation, they are intentionally left out of this change; the full test suite will run once those are resolved separately.

## Checklist

- [x] Linked issue or backlog item (#793)
- [x] Restored the type definitions required by the pre-launch auction feature
- [x] Verified every auction symbol resolves and no auction-related compile error remains
- [x] Confirmed event names, topic order, payload field order, and storage keys remain compatible with `docs/contract-event-conventions.md` and `docs/storage-key-invariants.md`
- [ ] Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, or explained exactly why a command was not run (see Testing)
